### PR TITLE
Sort imports and remove wildcard imports

### DIFF
--- a/src/error.py
+++ b/src/error.py
@@ -1,5 +1,6 @@
 import attr
 
+
 @attr.s
 class DecompFailure(Exception):
     message: str = attr.ib()

--- a/src/flow_graph.py
+++ b/src/flow_graph.py
@@ -1,12 +1,15 @@
-import attr
 import copy
-
 import typing
-from typing import List, Union, Iterator, Optional, Dict, Set, Tuple, Callable, Any
+from typing import (Any, Callable, Dict, Iterator, List, Optional, Set, Tuple,
+                    Union)
 
-from parse_instruction import *
-from parse_file import Function, Label
+import attr
+
 from error import DecompFailure
+from parse_file import Function, Label
+from parse_instruction import (AsmLiteral, Instruction, JumpTarget, Register,
+                               parse_instruction)
+
 
 @attr.s(cmp=False)
 class Block:

--- a/src/if_statements.py
+++ b/src/if_statements.py
@@ -1,9 +1,11 @@
-# from contextlib import contextmanager
 import queue
 import typing
 from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Union
 
-from flow_graph import *
+import attr
+
+from flow_graph import (BasicNode, Block, ConditionalNode, FlowGraph, Node,
+                        ReturnNode)
 from options import Options
 from translate import (BinaryOp, BlockInfo, Condition, FunctionInfo, Type,
                        as_type, simplify_condition)

--- a/src/if_statements.py
+++ b/src/if_statements.py
@@ -1,12 +1,13 @@
 # from contextlib import contextmanager
 import queue
-
 import typing
-from typing import List, Union, Iterator, Optional, Dict, Callable, Any, Set
+from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Union
 
-from options import Options
 from flow_graph import *
-from translate import FunctionInfo, BlockInfo, BinaryOp, Condition, Type, simplify_condition, as_type
+from options import Options
+from translate import (BinaryOp, BlockInfo, Condition, FunctionInfo, Type,
+                       as_type, simplify_condition)
+
 
 @attr.s
 class Context:

--- a/src/main.py
+++ b/src/main.py
@@ -1,12 +1,12 @@
-import sys
 import argparse
+import sys
 
+from error import DecompFailure
 from flow_graph import build_flowgraph, visualize_flowgraph
-from parse_file import parse_file, Function
-from translate import translate_to_ast
 from if_statements import write_function
 from options import Options
-from error import DecompFailure
+from parse_file import Function, parse_file
+from translate import translate_to_ast
 
 
 def decompile_function(options: Options, function: Function) -> None:

--- a/src/options.py
+++ b/src/options.py
@@ -1,5 +1,7 @@
-import attr
 from typing import Dict
+
+import attr
+
 
 @attr.s
 class Options:

--- a/src/parse_file.py
+++ b/src/parse_file.py
@@ -1,11 +1,12 @@
-import attr
 import re
-
 import typing
-from typing import List, Union, Iterator, Optional, Dict, Callable, Any
+from typing import Any, Callable, Dict, Iterator, List, Optional, Union
+
+import attr
 
 from options import Options
 from parse_instruction import *
+
 
 @attr.s(frozen=True)
 class Label:

--- a/src/parse_file.py
+++ b/src/parse_file.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Union
 import attr
 
 from options import Options
-from parse_instruction import *
+from parse_instruction import Instruction, Register, parse_instruction
 
 
 @attr.s(frozen=True)

--- a/src/parse_instruction.py
+++ b/src/parse_instruction.py
@@ -1,13 +1,13 @@
 """Functions and classes useful for parsing an arbitrary MIPS instruction.
 """
 import ast
-import attr
 import re
 import string
 import sys
-
 import typing
-from typing import List, Union, Iterator, Optional, Dict, Callable, Any
+from typing import Any, Callable, Dict, Iterator, List, Optional, Union
+
+import attr
 
 
 @attr.s(frozen=True)
@@ -228,4 +228,3 @@ def parse_instruction(line: str) -> Instruction:
     args: List[Argument] = list(filter(None,
         [parse_arg(arg_str.strip()) for arg_str in args_str.split(',')]))
     return Instruction(mnemonic, args)
-

--- a/src/translate.py
+++ b/src/translate.py
@@ -1,12 +1,12 @@
-import attr
 import traceback
-
 import typing
-from typing import List, Union, Iterator, Optional, Dict, Callable, Tuple, Any
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
+import attr
+
+from flow_graph import *
 from options import Options
 from parse_instruction import *
-from flow_graph import *
 
 ARGUMENT_REGS = list(map(Register, [
     'a0', 'a1', 'a2', 'a3',

--- a/src/translate.py
+++ b/src/translate.py
@@ -1,12 +1,16 @@
+import sys
 import traceback
 import typing
-from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
+from typing import (Any, Callable, Dict, Iterator, List, Optional, Set, Tuple,
+                    Union)
 
 import attr
 
-from flow_graph import *
+from flow_graph import (Block, FlowGraph, Function, Node, ReturnNode,
+                        build_flowgraph)
 from options import Options
-from parse_instruction import *
+from parse_instruction import (Argument, AsmAddressMode, AsmGlobalSymbol,
+                               AsmLiteral, BinOp, Instruction, Macro, Register)
 
 ARGUMENT_REGS = list(map(Register, [
     'a0', 'a1', 'a2', 'a3',


### PR DESCRIPTION
I started using pylint/black/isort and this seems like a good first step for cleanup. Just gonna merge this because it doesn't change anything.