### PR TITLE
Add compatibility with n64split's func_XXXXXXXX: notation

### DIFF
--- a/src/parse_file.py
+++ b/src/parse_file.py
@@ -156,6 +156,13 @@ def parse_file(f: typing.TextIO, options: Options) -> MIPSFile:
                         mips_file.new_jumptable_label(function_name)
                     else:
                         mips_file.new_function(function_name)
+                elif line.startswith('func'):
+                    # Other kind of function label.
+                    function_name: str = line[:-1]
+                    if re.match('L(_U_)?[0-9A-F]{8}', function_name):
+                        mips_file.new_jumptable_label(function_name)
+                    else:
+                        mips_file.new_function(function_name)
                 else:
                     # Instruction.
                     instr: Instruction = parse_instruction(line, emit_goto)

--- a/src/parse_file.py
+++ b/src/parse_file.py
@@ -159,10 +159,7 @@ def parse_file(f: typing.TextIO, options: Options) -> MIPSFile:
                 elif line.startswith('func'):
                     # Other kind of function label.
                     function_name: str = line.rstrip(":")
-                    if re.match('L(_U_)?[0-9A-F]{8}', function_name):
-                        mips_file.new_jumptable_label(function_name)
-                    else:
-                        mips_file.new_function(function_name)
+                    mips_file.new_function(function_name)
                 else:
                     # Instruction.
                     instr: Instruction = parse_instruction(line, emit_goto)

--- a/src/parse_file.py
+++ b/src/parse_file.py
@@ -158,7 +158,7 @@ def parse_file(f: typing.TextIO, options: Options) -> MIPSFile:
                         mips_file.new_function(function_name)
                 elif line.startswith('func'):
                     # Other kind of function label.
-                    function_name: str = line[:-1]
+                    function_name: str = line.rstrip(":")
                     if re.match('L(_U_)?[0-9A-F]{8}', function_name):
                         mips_file.new_jumptable_label(function_name)
                     else:


### PR DESCRIPTION
So you can use mips_to_c on functions in files obtained from n64split.