### PR TITLE
Separate logging from printing output

### DIFF
--- a/src/flow_graph.py
+++ b/src/flow_graph.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 import typing
 from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Union
 
@@ -16,6 +17,8 @@ from .parse_instruction import (
     Register,
     parse_instruction,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @attr.s(eq=False)
@@ -913,5 +916,7 @@ def visualize_flowgraph(flow_graph: FlowGraph) -> None:
         else:
             pass
     dot.render("graphviz_render.gv")
-    print("Rendered to graphviz_render.gv.pdf")
-    print("Key: green = successor, red = conditional edge, blue = fallthrough edge")
+    logger.info("Rendered to graphviz_render.gv.pdf")
+    logger.info(
+        "Key: green = successor, red = conditional edge, blue = fallthrough edge"
+    )

--- a/src/if_statements.py
+++ b/src/if_statements.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 import attr
@@ -24,6 +25,8 @@ from .translate import (
     simplify_condition,
     stringify_expr,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @attr.s
@@ -371,7 +374,7 @@ def count_non_postdominated_parents(
     # output of && and || may not be correct.
     if count not in [0, len(child.parents)] and not context.has_warned:
         context.has_warned = True
-        print(
+        logger.warning(
             "Warning: confusing control flow, output may have incorrect && "
             "and || detection. Run with --no-andor to disable detection and "
             "print gotos instead.\n"
@@ -695,8 +698,7 @@ def write_function(function_info: FunctionInfo, options: Options) -> None:
         elif isinstance(node, BasicNode) and node.is_loop():
             context.loop_nodes.add(node.successor)
 
-    if options.debug:
-        print("Here's the whole function!\n")
+    logger.debug("Here's the whole function!")
     body: Body
     if options.ifs:
         body = build_flowgraph_between(context, start_node, return_node, 4)

--- a/src/parse_file.py
+++ b/src/parse_file.py
@@ -1,3 +1,4 @@
+import logging
 import re
 import struct
 import typing
@@ -8,6 +9,8 @@ import attr
 from .error import DecompFailure
 from .options import Options
 from .parse_instruction import Instruction, parse_instruction
+
+logger = logging.getLogger(__name__)
 
 
 @attr.s(frozen=True)
@@ -200,7 +203,7 @@ def parse_file(f: typing.TextIO, options: Options) -> MIPSFile:
                 macro_name = line.split()[1]
                 if macro_name not in defines:
                     defines[macro_name] = 0
-                    print(
+                    logger.info(
                         f"Note: assuming {macro_name} is unset for .ifdef, "
                         f"pass -D{macro_name}/-U{macro_name} to set/unset explicitly."
                     )

--- a/src/parse_instruction.py
+++ b/src/parse_instruction.py
@@ -1,5 +1,6 @@
 """Functions and classes useful for parsing an arbitrary MIPS instruction.
 """
+import logging
 import re
 import string
 import sys
@@ -8,6 +9,8 @@ from typing import List, Optional, Set, Union
 import attr
 
 from .error import DecompFailure
+
+logger = logging.getLogger(__name__)
 
 LENGTH_TWO: Set[str] = {
     "negu",
@@ -430,5 +433,5 @@ def parse_instruction(line: str, emit_goto: bool) -> Instruction:
         instr = Instruction(mnemonic, args, emit_goto)
         return normalize_instruction(instr)
     except Exception as e:
-        print(f"Failed to parse instruction: {line}\n", file=sys.stderr)
+        logger.error(f"Failed to parse instruction: {line}")
         raise e

--- a/src/translate.py
+++ b/src/translate.py
@@ -1,3 +1,4 @@
+import logging
 import struct
 import sys
 import traceback
@@ -43,6 +44,8 @@ from .types import (
     ptr_type_from_ctype,
     type_from_ctype,
 )
+
+logger = logging.getLogger(__name__)
 
 ARGUMENT_REGS = list(map(Register, ["a0", "a1", "a2", "a3", "f12", "f14"]))
 
@@ -2486,14 +2489,12 @@ def translate_graph_from_block(
     its appropriate BlockInfo (which contains the AST of its code).
     """
 
-    if options.debug:
-        print(f"\nNode in question: {node.block}")
+    logger.debug(f"Node in question: {node.block}")
 
     # Translate the given node and discover final register states.
     try:
         block_info = translate_node_body(node, regs, stack_info)
-        if options.debug:
-            print(block_info)
+        logger.debug(block_info)
     except Exception as e:  # TODO: handle issues better
         if options.stop_on_error:
             raise e
@@ -2505,7 +2506,7 @@ def translate_graph_from_block(
 
         if isinstance(e, DecompFailure):
             emsg = str(e)
-            print(emsg)
+            logger.error(emsg)
         else:
             tb = e.__traceback__
             traceback.print_exception(None, e, tb)
@@ -2514,11 +2515,9 @@ def translate_graph_from_block(
 
         error_stmts: List[Statement] = [CommentStmt(f"Error: {emsg}")]
         if instr is not None:
-            print(
-                f"Error occurred while processing instruction: {instr}", file=sys.stderr
-            )
+            logger.error(f"Error occurred while processing instruction: {instr}")
             error_stmts.append(CommentStmt(f"At instruction: {instr}"))
-        print(file=sys.stderr)
+
         block_info = BlockInfo(
             error_stmts,
             None,
@@ -2613,9 +2612,8 @@ def translate_to_ast(
             }
         )
 
-    if options.debug:
-        print(stack_info)
-        print("\nNow, we attempt to translate:")
+    logger.debug(stack_info)
+    logger.debug("\nNow, we attempt to translate:")
 
     start_reg: RegInfo = RegInfo(contents=initial_regs, stack_info=stack_info)
     used_phis: List[PhiExpr] = []


### PR DESCRIPTION
We use `print()` throughout the codebase to do two different things: log information for the reader, and print the actual desired output. This PR uses the python `logging` module to separate the former from the latter.