### PR TITLE
Refactor the main function of if_statements to return a string

### DIFF
--- a/src/if_statements.py
+++ b/src/if_statements.py
@@ -177,7 +177,7 @@ def emit_goto_or_early_return(
     """Emit a goto to a node, *unless* that node is an early return, which we
     can't goto to since it's not a real node and won't ever be emitted."""
     if isinstance(target, ReturnNode) and not target.is_real():
-        write_return(context, body, target, indent, last=False)
+        add_return_statement(context, body, target, indent, last=False)
     else:
         emit_goto(context, target, body, indent)
 
@@ -497,7 +497,7 @@ def get_full_if_condition(
         )
 
 
-def write_return(
+def add_return_statement(
     context: Context, body: Body, node: ReturnNode, indent: int, last: bool
 ) -> None:
     emit_node(context, node, body, indent)
@@ -574,7 +574,7 @@ def build_flowgraph_between(
                 assert block_info.switch_value is not None
                 emit_switch_jump(context, block_info.switch_value, body, indent)
             else:  # ReturnNode
-                write_return(context, body, curr_start, indent, last=False)
+                add_return_statement(context, body, curr_start, indent, last=False)
 
             # Advance to the next node in block order. This may skip over
             # unreachable blocks -- hopefully none too important.
@@ -608,7 +608,7 @@ def build_flowgraph_between(
         else:  # ReturnNode
             # Write the return node, and break, because there is nothing more
             # to process.
-            write_return(context, body, curr_start, indent, last=False)
+            add_return_statement(context, body, curr_start, indent, last=False)
             break
 
     return body
@@ -705,7 +705,7 @@ def build_body(
         body = build_naive(context, context.flow_graph.nodes)
 
     if return_node.index != -1:
-        write_return(context, body, return_node, 4, last=True)
+        add_return_statement(context, body, return_node, 4, last=True)
 
     return body
 

--- a/src/main.py
+++ b/src/main.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 from .error import DecompFailure
 from .flow_graph import build_flowgraph, visualize_flowgraph
-from .if_statements import write_function
+from .if_statements import get_function_text
 from .options import Options, CodingStyle
 from .parse_file import Function, MIPSFile, Rodata, parse_file
 from .translate import translate_to_ast
@@ -23,7 +23,8 @@ def decompile_function(
         return
 
     function_info = translate_to_ast(function, options, rodata, typemap)
-    write_function(function_info, options)
+    function_text = get_function_text(function_info, options)
+    print(function_text)
 
 
 def run(options: Options) -> int:


### PR DESCRIPTION
A very simple PR to make the logic at the bottom of `if_statements.py` return a string instead of printing it out piece by piece. 

Things I considered also doing:
 - Putting `get_function_text()` in its own file. It is not the "proper" entry point of if_statements; `get_body()` is. But this file would be pretty sparse - I'm not sure what else would fit there. So I decided against it for now.
 - Renaming `if_statements.py` to something like `flatten_flow_graph.py` or `flatten_ast.py` or `ast_to_statements`, since that more accurately represents what it's doing - it's taking a whole bunch of info and outputting a list of statements.