### PR TITLE
Attach TypeMap to CType-related Types

### DIFF
--- a/src/translate.py
+++ b/src/translate.py
@@ -1916,7 +1916,7 @@ def handle_addi_real(
         var = stack_info.get_stack_var(imm.value, store=False)
         if isinstance(var, LocalVar):
             stack_info.add_local_var(var)
-        return AddressOf(var, type=Type.ptr(var.type))
+        return AddressOf(var, type=Type.ptr(var.type, stack_info.typemap))
     else:
         return add_imm(source, imm, stack_info)
 
@@ -2279,7 +2279,7 @@ def array_access_from_add(
             target_size=None,
             field_name=sub_field_name,
             stack_info=stack_info,
-            type=Type.ptr(elem_type),
+            type=Type.ptr(elem_type, typemap),
         )
         offset -= sub_offset
         target_type = type_from_ctype(elem_type, typemap)

--- a/src/translate.py
+++ b/src/translate.py
@@ -1916,7 +1916,7 @@ def handle_addi_real(
         var = stack_info.get_stack_var(imm.value, store=False)
         if isinstance(var, LocalVar):
             stack_info.add_local_var(var)
-        return AddressOf(var, type=Type.ptr(var.type, stack_info.typemap))
+        return AddressOf(var, type=Type.ptr(var.type))
     else:
         return add_imm(source, imm, stack_info)
 
@@ -2279,7 +2279,7 @@ def array_access_from_add(
             target_size=None,
             field_name=sub_field_name,
             stack_info=stack_info,
-            type=Type.ptr(elem_type, typemap),
+            type=Type.cptr(elem_type, typemap),
         )
         offset -= sub_offset
         target_type = type_from_ctype(elem_type, typemap)


### PR DESCRIPTION
I was interested in improving some of the type detection stuff, and it seemed like a prereq for that was having the `TypeMap` available to the `Type.unify()` function.

There are two calls on the `format` codepath that called `unify`, and it was really hard to get the typemap there. My understanding of the code is that the types should already be resolved at that point -- the `unify` function is mostly a check if the two types are the same. I added a `Type.is_unified()` (`is_equivalent`?) method to start to try to refactor it even though it's a bit ugly.

As mentioned on the Discord, this won't handle all cases: the typemap still isn't available everywhere. I'll need to take another pass at this.