### PR TITLE
Add `--project` flag to run tests against all mm/oot asm

### DIFF
--- a/code_coverage.py
+++ b/code_coverage.py
@@ -28,11 +28,22 @@ parser.add_argument(
     dest="project_dirs",
     action="append",
     default=[],
-    type=Path,
+    type=lambda p: (Path(p), False),
     help=(
         "Run tests on the asm files from a decompilation project. "
         "The zeldaret/oot and zeldaret/mm projects are supported. "
-        "If ctx.c exists in this directory, it will be used as context. "
+        "Can be specified multiple times."
+    ),
+)
+parser.add_argument(
+    "--project-with-context",
+    dest="project_dirs",
+    action="append",
+    default=[],
+    type=lambda p: (Path(p), True),
+    help=(
+        "Same as --project, but use the C context file `ctx.c` "
+        "from the base directory. "
         "Can be specified multiple times."
     ),
 )

--- a/code_coverage.py
+++ b/code_coverage.py
@@ -3,6 +3,7 @@ from coverage import Coverage  # type: ignore
 import sys
 import argparse
 import os
+from pathlib import Path
 
 parser = argparse.ArgumentParser(description="Compute code coverage for tests.")
 parser.add_argument(
@@ -17,6 +18,19 @@ parser.add_argument(
     help="emit a .coverage file",
     action="store_true",
 )
+parser.add_argument(
+    "--project",
+    dest="project_dirs",
+    action="append",
+    default=[],
+    type=Path,
+    help=(
+        "Run tests on the asm files from a decompilation project. "
+        "The zeldaret/oot and zeldaret/mm projects are supported. "
+        "If ctx.c exists in this directory, it will be used as context. "
+        "Can be specified multiple times."
+    ),
+)
 args = parser.parse_args()
 
 cov = Coverage(
@@ -27,7 +41,7 @@ cov.start()
 import run_tests
 
 run_tests.set_up_logging(debug=False)
-ret = run_tests.main(should_overwrite=False, coverage=cov)
+ret = run_tests.main(args.project_dirs, should_overwrite=False, coverage=cov)
 
 cov.stop()
 

--- a/code_coverage.py
+++ b/code_coverage.py
@@ -19,6 +19,11 @@ parser.add_argument(
     action="store_true",
 )
 parser.add_argument(
+    "--filter",
+    dest="filter",
+    help=("Only run tests matching this regular expression."),
+)
+parser.add_argument(
     "--project",
     dest="project_dirs",
     action="append",
@@ -41,7 +46,9 @@ cov.start()
 import run_tests
 
 run_tests.set_up_logging(debug=False)
-ret = run_tests.main(args.project_dirs, should_overwrite=False, coverage=cov)
+ret = run_tests.main(
+    args.project_dirs, should_overwrite=False, filter_regex=args.filter, coverage=cov
+)
 
 cov.stop()
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -7,7 +7,7 @@ import logging
 import shlex
 import sys
 from pathlib import Path
-from typing import Any, List
+from typing import Any, List, Optional
 
 from src.main import parse_flags
 from src.main import run as decompile
@@ -43,7 +43,12 @@ def get_test_flags(flags_path: Path) -> List[str]:
 
 
 def decompile_and_compare(
-    asm_file_path: Path, output_path: Path, flags_path: Path, should_overwrite: bool
+    asm_file_path: Path,
+    output_path: Path,
+    should_overwrite: bool = False,
+    brief_crashes: bool = True,
+    flags_path: Optional[Path] = None,
+    flags: Optional[List[str]] = None,
 ) -> bool:
     logging.debug(
         f"Decompiling {asm_file_path}"
@@ -55,12 +60,14 @@ def decompile_and_compare(
         logging.info(f"{output_path} does not exist. Creating...")
         original_contents = "(file did not exist)"
 
-    flags = [str(asm_file_path), "test", "--stop-on-error"]
-    flags_list = get_test_flags(flags_path)
-    flags.extend(flags_list)
+    test_flags = ["--stop-on-error", str(asm_file_path)]
+    if flags is not None:
+        test_flags.extend(flags)
+    if flags_path is not None:
+        test_flags.extend(get_test_flags(flags_path))
+    options = parse_flags(test_flags)
 
-    options = parse_flags(flags)
-    final_contents = decompile_and_capture_output(options)
+    final_contents = decompile_and_capture_output(options, brief_crashes)
 
     if should_overwrite:
         output_path.write_text(final_contents)
@@ -80,14 +87,20 @@ def decompile_and_compare(
     return should_overwrite or not changed
 
 
-def decompile_and_capture_output(options: Options) -> str:
+def decompile_and_capture_output(options: Options, brief_crashes: bool) -> str:
     out_string = io.StringIO()
     with contextlib.redirect_stdout(out_string):
         returncode = decompile(options)
+    out_text = out_string.getvalue()
+    # Rewrite paths in the output to be relative (e.g. in tracebacks)
+    out_text = out_text.replace(str(Path(__file__).parent), ".")
     if returncode == 0:
-        return out_string.getvalue()
+        return out_text
     else:
-        return CRASH_STRING
+        if brief_crashes:
+            return CRASH_STRING
+        else:
+            return f"{CRASH_STRING}\n{out_text}"
 
 
 def run_e2e_test(
@@ -100,19 +113,100 @@ def run_e2e_test(
         old_output_path = asm_file_path.parent.joinpath(asm_file_path.stem + "-out.c")
         flags_path = asm_file_path.parent.joinpath(asm_file_path.stem + "-flags.txt")
         if coverage:
-            coverage.switch_context(str(asm_file_path.relative_to(e2e_top_dir)))
+            coverage.switch_context(f"e2e:{asm_file_path.relative_to(e2e_top_dir)}")
         if not decompile_and_compare(
-            asm_file_path, old_output_path, flags_path, should_overwrite
+            asm_file_path,
+            old_output_path,
+            brief_crashes=True,
+            should_overwrite=should_overwrite,
+            flags_path=flags_path,
+            flags=["test"],
         ):
             ret = False
     return ret
 
 
-def main(should_overwrite: bool, coverage: Any) -> int:
+def run_project_tests(
+    base_dir: Path,
+    output_dir: Path,
+    should_overwrite: bool,
+    coverage: Any,
+    cov_prefix: str,
+) -> bool:
+    ret = True
+    asm_dir = base_dir / "asm"
+    context_file = base_dir / "ctx.c"
+    for asm_file in asm_dir.rglob("*"):
+        if asm_file.suffix not in (".asm", ".s"):
+            continue
+        if "non_matching" in str(asm_file):
+            continue
+
+        asm_name = asm_file.name
+        if (
+            asm_name.startswith("code_data")
+            or asm_name.startswith("code_rodata")
+            or asm_name.startswith("boot_data")
+            or asm_name.startswith("boot_rodata")
+            or asm_name.endswith("_data.asm")
+            or asm_name.endswith("_rodata.asm")
+        ):
+            continue
+
+        flags = []
+        if context_file.exists():
+            flags.extend(["--context", str(context_file)])
+            cov_prefix = f"{cov_prefix}_ctx"
+
+        # Guess the name of .rodata file(s) for the MM decomp project
+        for candidate in [
+            # code/*.asm
+            "code_rodata_" + asm_name,
+            asm_name.replace("code_", "code_rodata_"),
+            # boot/*.asm
+            "boot_rodata_" + asm_name,
+            asm_name.replace("boot_", "boot_rodata_"),
+            # overlays/*.asm
+            asm_name.rpartition("_0x")[0] + "_rodata.asm",
+            asm_name.rpartition("_0x")[0] + "_late_rodata.asm",
+        ]:
+            if candidate == asm_name:
+                continue
+            f = asm_file.parent / candidate
+            if f.exists():
+                flags.extend(["--rodata", str(f)])
+
+        test_path = asm_file.relative_to(asm_dir)
+        logging.info(f"Running test: {test_path}")
+        if coverage:
+            coverage.switch_context(f"{cov_prefix}:{test_path}")
+
+        output_file = (output_dir / test_path).with_suffix(".c")
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        if not decompile_and_compare(
+            asm_file,
+            output_file,
+            brief_crashes=False,
+            flags=flags,
+            should_overwrite=should_overwrite,
+        ):
+            ret = False
+    return ret
+
+
+def main(project_dirs: List[Path], should_overwrite: bool, coverage: Any) -> int:
     ret = 0
     e2e_top_dir = Path(__file__).parent / "tests" / "end_to_end"
     for e2e_test_path in e2e_top_dir.iterdir():
         if not run_e2e_test(e2e_top_dir, e2e_test_path, should_overwrite, coverage):
+            ret = 1
+
+    for project_dir in project_dirs:
+        name = project_dir.name
+        output_dir = Path(__file__).parent / "tests" / "project" / name
+        if not run_project_tests(
+            project_dir, output_dir, should_overwrite, coverage, name
+        ):
             ret = 1
 
     return ret
@@ -134,10 +228,23 @@ if __name__ == "__main__":
             "Do this once before committing."
         ),
     )
+    parser.add_argument(
+        "--project",
+        dest="project_dirs",
+        action="append",
+        default=[],
+        type=Path,
+        help=(
+            "Run tests on the asm files from a decompilation project. "
+            "The zeldaret/oot and zeldaret/mm projects are supported. "
+            "If ctx.c exists in this directory, it will be used as context. "
+            "Can be specified multiple times."
+        ),
+    )
     args = parser.parse_args()
     set_up_logging(args.debug)
 
     if args.should_overwrite:
         logging.info("Overwriting test output files.")
-    ret = main(args.should_overwrite, coverage=None)
+    ret = main(args.project_dirs, args.should_overwrite, coverage=None)
     sys.exit(ret)

--- a/run_tests.py
+++ b/run_tests.py
@@ -164,10 +164,10 @@ def run_project_tests(
         ):
             continue
 
+        has_context = context_file.exists()
         flags = []
-        if context_file.exists():
+        if has_context:
             flags.extend(["--context", str(context_file)])
-            name_prefix = f"{name_prefix}_ctx"
 
         # Guess the name of .rodata file(s) for the MM decomp project
         for candidate in [
@@ -188,7 +188,7 @@ def run_project_tests(
                 flags.extend(["--rodata", str(f)])
 
         test_path = asm_file.relative_to(asm_dir)
-        name = f"{name_prefix}:{test_path}"
+        name = f"{name_prefix}{'_ctx' if has_context else ''}:{test_path}"
         if filter_regex is not None and not re.search(filter_regex, name):
             continue
         if coverage:

--- a/src/c_types.py
+++ b/src/c_types.py
@@ -3,6 +3,7 @@ based on a C AST. Based on the pycparser library."""
 
 from collections import defaultdict
 import copy
+import functools
 from typing import Any, Dict, Iterator, Match, Set, List, Tuple, Optional, Union
 import re
 
@@ -584,6 +585,7 @@ def parse_c(source: str) -> ca.FileAST:
         raise DecompFailure(f"Syntax error when parsing C context.\n{msg}{posstr}")
 
 
+@functools.lru_cache(maxsize=4)
 def build_typemap(source: str) -> TypeMap:
     source = add_builtin_typedefs(source)
     source = strip_comments(source)

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 import argparse
 import sys
 import traceback
+from pathlib import Path
 from typing import List, Optional
 
 from .error import DecompFailure
@@ -47,7 +48,7 @@ def run(options: Options) -> int:
         if options.c_context is not None:
             with open(options.c_context, "r", encoding="utf-8-sig") as f:
                 typemap = build_typemap(f.read())
-    except (OSError, DecompFailure) as e:
+    except (AssertionError, OSError, DecompFailure) as e:
         print(e)
         return 1
 
@@ -68,7 +69,7 @@ def run(options: Options) -> int:
                 has_error = True
             except Exception:
                 print(f"Internal error while decompiling function {fn.name}:\n")
-                traceback.print_exc()
+                traceback.print_exc(file=sys.stdout)
                 has_error = True
         if has_error:
             return 1

--- a/src/main.py
+++ b/src/main.py
@@ -48,8 +48,11 @@ def run(options: Options) -> int:
         if options.c_context is not None:
             with open(options.c_context, "r", encoding="utf-8-sig") as f:
                 typemap = build_typemap(f.read())
-    except (AssertionError, OSError, DecompFailure) as e:
+    except (OSError, DecompFailure) as e:
         print(e)
+        return 1
+    except Exception as e:
+        traceback.print_exc(file=sys.stdout)
         return 1
 
     if options.dump_typemap:

--- a/src/parse_file.py
+++ b/src/parse_file.py
@@ -25,7 +25,11 @@ class Function:
     body: List[Union[Instruction, Label]] = attr.ib(factory=list)
 
     def new_label(self, name: str) -> None:
-        self.body.append(Label(name))
+        label = Label(name)
+        if self.body and self.body[-1] == label:
+            # Skip repeated labels
+            return
+        self.body.append(label)
 
     def new_instruction(self, instruction: Instruction) -> None:
         self.body.append(instruction)

--- a/src/parse_file.py
+++ b/src/parse_file.py
@@ -76,8 +76,12 @@ class MIPSFile:
         if self.current_function is None:
             # Allow (and ignore) nop instructions in the .text
             # section before any function labels
-            assert instruction.mnemonic == "nop"
-            return
+            if instruction.mnemonic == "nop":
+                return
+            else:
+                raise DecompFailure(
+                    "unsupported non-nop instruction outside of function"
+                )
         self.current_function.new_instruction(instruction)
 
     def new_label(self, label_name: str) -> None:


### PR DESCRIPTION
This was discussed briefly on the Discord yesterday. Here are some notes about this PR:

- I'm calling them "project tests" -- not super happy with that name, but had trouble thinking of a better one.
- This PR doesn't commit the results of the tests. There was some brief discussion on the discord about how best to design this so that we can keep this repo isolated from the decomp project repos. 
    - I'm personally excited enough to get this code in as-is, even if it's a bit trickier to work with. Even though the "baseline" output `.c` files are not checked in, I can run the tests locally before making changes to populate the `tests/` directory with the baseline files.
- The project tests use `ctx.c` if it exists in the project base directory. This also makes the tests *a lot* slower.
    - I think a huge speedup could come from building the `typemap` once (from parsing the context), then re-using it between tests. I believe it isn't modified once the parsing is done. Unfortunately this would require some slightly weird plumbing: right now arguments are passed through argparse to the decompiler API.
- For the project tests, if there's an error for one function, it includes the error message in the output `.c` and then continues to try to decompile the other functions.
- I made 2 bugfixes. I think they're pretty benign but I put them in a separate PR if that's preferred. Now all MM `.asm` files can be processed without error! (except `boot/exceptasm.asm`, which seems hand-written)
    - I added ignoring `nop`s at the start of `.text` sections, which was needed for a few OOT files.
    - Skip duplicate consecutive labels. There are some parts of the asm that have `glabel X; .X:`.
- All `.py` files formatted with `black` 21.5b0 and checked with `mypy` 0.812.