### PR TITLE
Remove is_trivial_expression check in fold_mul_chains

### DIFF
--- a/src/translate.py
+++ b/src/translate.py
@@ -731,6 +731,14 @@ class BinaryOp(Condition):
                 expr = BinaryOp(op=self.op, left=self.left, right=right, type=self.type)
                 return expr.format(fmt)
 
+        if (
+            isinstance(self.right, Literal)
+            and self.right.value == -1
+            and self.op == "*"
+        ):
+            unary_expr = UnaryOp(op="-", expr=self.left, type=self.type)
+            return unary_expr.format(fmt)
+
         # For commutative, left-associative operations, strip unnecessary parentheses.
         left_expr = late_unwrap(self.left)
         lhs = left_expr.format(fmt)
@@ -2212,7 +2220,7 @@ def fold_mul_chains(expr: Expression) -> Expression:
             and not expr.forced_emit
         ):
             base, num = fold(expr.wrapped_expr, False, allow_sll)
-            if num != 1 and is_trivial_expression(base):
+            if num != 1:
                 return (base, num)
         return (expr, 1)
 


### PR DESCRIPTION
I'm opening this up as a draft, because I'm not sure if this change is sound. 

Using #95, the output looks reasonable -- I think the `not expr.emit_exactly_once and not expr.forced_emit` conditions in ` fold_mul_chains` are sufficient to prevent bugs?

[Here's the big diff](https://gist.github.com/zbanks/ac185e6047e7c5318eb2bc93c61a051b) from running this patch on top of #95 against OOT & MM.

Some key examples from that file:

```diff
-        temp_v0 = (((phi_t0 * 4) - phi_t0) * 4) + &D_80B3FE08;
+        temp_v0 = (phi_t0 * 0xC) + &D_80B3FE08;
```

```diff
-                    temp_v1_32->unk4 = (s32) ((((((((phi_t3 * 0x10) - phi_t3) * 4) + phi_t3) * 4) - phi_t3) * 8) + 0xC000000);
+                    temp_v1_32->unk4 = (s32) ((phi_t3 * 0x798) + 0xC000000);
```

```diff
-        phi_a2 = -(s32) temp_v1 << 0x10;
+        phi_a2 = (s32) temp_v1 * -0x10000;
```

I think the potential downsides to this PR is that it now causes `-x << N` to be re-written as `x * -(1 << N)`. To be honest, both forms feel unnatural to me.
