### PR TITLE
Simplify `x = x op y` into `x op= y`

### DIFF
--- a/tests/end_to_end/andor_assignment/irix-g-out.c
+++ b/tests/end_to_end/andor_assignment/irix-g-out.c
@@ -15,7 +15,7 @@ s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
     } else {
         sp1C = -2;
     }
-    sp1C = sp1C + arg2;
+    sp1C += arg2;
     if ((sp24 != 0) && (sp20 != 0)) {
         temp_t6 = sp24 + sp20;
         sp24 = temp_t6;
@@ -23,27 +23,27 @@ s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
         if ((sp20 != 0) && (arg3 != 0)) {
             if (sp1C < 5) {
 loop_13:
-                sp1C = sp1C + 1;
-                sp1C = sp1C * 2;
+                sp1C += 1;
+                sp1C *= 2;
                 if (sp1C < 5) {
                     goto loop_13;
                 }
             }
-            sp1C = sp1C + 5;
+            sp1C += 5;
         }
     }
     if ((sp24 != 0) && (sp20 != 0) && (temp_t9 = sp24 + sp20, sp24 = temp_t9, sp20 = func_00400090(temp_t9), (sp20 != 0)) && (arg3 != 0)) {
         if (sp1C < 5) {
 loop_20:
-            sp1C = sp1C + 1;
-            sp1C = sp1C * 2;
+            sp1C += 1;
+            sp1C *= 2;
             if (sp1C < 5) {
                 goto loop_20;
             }
         }
-        sp1C = sp1C + 5;
+        sp1C += 5;
     } else {
-        sp1C = sp1C + 6;
+        sp1C += 6;
     }
     return sp1C;
 }

--- a/tests/end_to_end/doubles/irix-g-mips1-out.c
+++ b/tests/end_to_end/doubles/irix-g-mips1-out.c
@@ -4,7 +4,7 @@ f64 test(f32 arg0, s32 arg2, f64 arg4) {
     f64 sp0;
 
     sp8 = ((f64) arg2 * (f64) arg0) + ((f64) arg0 / arg4);
-    sp8 = sp8 - 7.0;
+    sp8 -= 7.0;
     if ((sp8 < arg4) || (sp8 == arg4) || (sp8 > 9.0)) {
         sp0 = 2.3125f;
         sp4 = 0.0f;

--- a/tests/end_to_end/doubles/irix-g-out.c
+++ b/tests/end_to_end/doubles/irix-g-out.c
@@ -3,7 +3,7 @@ f64 test(f32 arg0, s32 arg2, f64 arg4) {
     f64 sp0;
 
     sp8 = ((f64) arg2 * (f64) arg0) + ((f64) arg0 / arg4);
-    sp8 = sp8 - 7.0;
+    sp8 -= 7.0;
     if ((sp8 < arg4) || (sp8 == arg4) || (sp8 > 9.0)) {
         sp0 = 0.0;
     } else {

--- a/tests/end_to_end/int-float-doublelit/irix-g-out.c
+++ b/tests/end_to_end/int-float-doublelit/irix-g-out.c
@@ -3,7 +3,7 @@ f32 test(f32 arg0, s32 arg1, f32 arg2, s32 arg3) {
     D_410194 = (f32) arg1;
     arg2 = (f32) ((f64) arg2 + 5.0);
     arg2 = (f32) ((f64) arg2 + 0.0);
-    arg2 = arg2 + 0.0f;
+    arg2 += 0.0f;
     arg2 = (f32) ((f64) arg2 + D_400180);
     return (f32) (u32) (arg3 + 3) + arg2;
 }

--- a/tests/end_to_end/int-float/irix-g-out.c
+++ b/tests/end_to_end/int-float/irix-g-out.c
@@ -1,6 +1,6 @@
 f32 test(f32 arg0, s32 arg1, f32 arg2, s32 arg3) {
     D_410130 = (s32) arg0;
     D_410134 = (f32) arg1;
-    arg2 = arg2 + 5.0f;
+    arg2 += 5.0f;
     return (f32) (u32) (arg3 + 3) + arg2;
 }

--- a/tests/end_to_end/jump-into-loop/irix-g-out.c
+++ b/tests/end_to_end/jump-into-loop/irix-g-out.c
@@ -2,10 +2,10 @@ s32 test(s32 arg0) {
     goto block_3;
 loop_2:
     func_0040010C(arg0);
-    arg0 = arg0 + 1;
+    arg0 += 1;
 block_3:
     func_0040010C(arg0);
-    arg0 = arg0 * 2;
+    arg0 *= 2;
     if (arg0 < 4) {
         goto loop_2;
     }

--- a/tests/end_to_end/loop_nested/irix-g-out.c
+++ b/tests/end_to_end/loop_nested/irix-g-out.c
@@ -10,13 +10,13 @@ loop_1:
         sp4 = 0;
         if (sp4 < arg0) {
 loop_2:
-            sp8 = sp8 + (spC * sp4);
-            sp4 = sp4 + 1;
+            sp8 += spC * sp4;
+            sp4 += 1;
             if (sp4 < arg0) {
                 goto loop_2;
             }
         }
-        spC = spC + 1;
+        spC += 1;
         if (spC < arg0) {
             goto loop_1;
         }

--- a/tests/end_to_end/loop_with_if/irix-g-out.c
+++ b/tests/end_to_end/loop_with_if/irix-g-out.c
@@ -5,9 +5,9 @@ s32 test(s32 arg0) {
     if (sp4 < arg0) {
 loop_1:
         if (sp4 == 5) {
-            sp4 = sp4 * 2;
+            sp4 *= 2;
         } else {
-            sp4 = sp4 + 4;
+            sp4 += 4;
         }
         if (sp4 < arg0) {
             goto loop_1;

--- a/tests/end_to_end/sqrt/irix-g-out.c
+++ b/tests/end_to_end/sqrt/irix-g-out.c
@@ -10,6 +10,6 @@ f32 test(f32 arg0) {
     spC = (bitwise s32) sp4;
     spC = 0x5F3759DF - (spC >> 1);
     sp4 = (bitwise f32) spC;
-    sp4 = (sp0 - (sp8 * sp4 * sp4)) * sp4;
+    sp4 *= sp0 - (sp8 * sp4 * sp4);
     return sp4;
 }


### PR DESCRIPTION
Some notes:

- There are two other places that can emit `lhs = rhs;` statements that I didn't change: `EvalOnceStmt` & `SetPhiStmt`. In these two cases, I don't think it's possible to have `lhs` be in the `rhs` expression. 
- I didn't simplify `x += 1;` into `x++;` to avoid having to deal with precedence rules. (`*x += 1;` is not equivalent to `*x++`).
    - IMO refactoring `x += 1;` by hand is still easier to than `x = x + 1;`
- It looks like `late_unwrap(...)` is completely safe to use inside `format(...)` functions. I think `late_unwrap(expr).format(fmt) == expr.format(fmt)` is an invariant. 