### PR TITLE
Fix test nondeterminism

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -148,6 +148,7 @@ def create_e2e_tests(
                 flags=["test"],  # Decompile the function 'test'
             )
         )
+    cases.sort()
     return cases
 
 
@@ -215,6 +216,7 @@ def create_project_tests(
                 flags=flags,
             )
         )
+    cases.sort()
     return cases
 
 

--- a/src/c_types.py
+++ b/src/c_types.py
@@ -660,7 +660,7 @@ def type_to_string(type: CType, name: str = "") -> str:
             return f"{su} {type.type.name}"
         else:
             return f"anon {su}"
-    decl = ca.Decl(name, [], [], [], type, None, None)
+    decl = ca.Decl(name, [], [], [], copy.deepcopy(type), None, None)
     set_decl_name(decl)
     return to_c(decl)
 

--- a/tests/end_to_end/complicated_context/irix-o2-typemap-out.c
+++ b/tests/end_to_end/complicated_context/irix-o2-typemap-out.c
@@ -7,7 +7,7 @@ short test(struct SomeStruct *, unsigned char, union SomeUnion, ...);
 
 Functions:
 void func_decl(void);
-short test(struct SomeStruct *, unsigned char should, union SomeUnion union_arg, ...);
+short test(struct SomeStruct *arg, unsigned char should, union SomeUnion union_arg, ...);
 
 Structs:
 SomeUnion: size 8, align 8
@@ -82,7 +82,7 @@ SomeStruct: size 640, align 8
   0x250: sub_array[1] (anon struct) sub_array[1].a (int)
   0x254: sub_array[1].b (struct 
 {
-  int;
+  int c;
 } [3]) sub_array[1].b[0] (anon struct) sub_array[1].b[0].c (int)
   0x258: sub_array[1].b[1] (anon struct) sub_array[1].b[1].c (int)
   0x25c: sub_array[1].b[2] (anon struct) sub_array[1].b[2].c (int)


### PR DESCRIPTION
~~Is it related to this `deepcopy` call?~~

The issue was that ` type_to_string` was calling `set_decl_name` without deepcopy'ing `type`. This mutated the `typemap` state, which is cached & re-used between tests. This appears to be the only place where `typemap` is mutated, so it should be sufficient.
The new test output looks more correct - it consistently has the arg/field names.

I also sorted the tests as an independent change, to make the output more consistent across machines.