### PR TITLE
Add GlobalInfo class for managing top-level declarations

### DIFF
--- a/src/options.py
+++ b/src/options.py
@@ -32,6 +32,7 @@ class Options:
     coding_style: CodingStyle = attr.ib()
     sanitize_tracebacks: bool = attr.ib()
     valid_syntax: bool = attr.ib()
+    emit_globals: bool = attr.ib()
 
     def formatter(self) -> "Formatter":
         return Formatter(

--- a/tests/end_to_end/array-access/irix-g-flags.txt
+++ b/tests/end_to_end/array-access/irix-g-flags.txt
@@ -1,1 +1,1 @@
---context orig.c
+--context orig.c --emit-globals

--- a/tests/end_to_end/array-access/irix-g-out.c
+++ b/tests/end_to_end/array-access/irix-g-out.c
@@ -1,3 +1,5 @@
+extern s32 *D_410140;
+
 void test(struct A *a, s32 b) {
     D_410140 = (s32 *) a->array[b];
     D_410140 = (s32 *) &a->array[b];

--- a/tests/end_to_end/array-access/irix-o2-flags.txt
+++ b/tests/end_to_end/array-access/irix-o2-flags.txt
@@ -1,1 +1,1 @@
---context orig.c
+--context orig.c --emit-globals

--- a/tests/end_to_end/array-access/irix-o2-out.c
+++ b/tests/end_to_end/array-access/irix-o2-out.c
@@ -1,3 +1,5 @@
+extern s32 *D_410110;
+
 void test(struct A *a, s32 b) {
     D_410110 = (s32 *) a->array[b];
     D_410110 = (s32 *) &a->array[b];

--- a/tests/end_to_end/complicated_context/irix-g-flags.txt
+++ b/tests/end_to_end/complicated_context/irix-g-flags.txt
@@ -1,1 +1,1 @@
---context orig.c
+--context orig.c --emit-globals

--- a/tests/end_to_end/complicated_context/irix-o2-flags.txt
+++ b/tests/end_to_end/complicated_context/irix-o2-flags.txt
@@ -1,1 +1,1 @@
---context orig.c
+--context orig.c --emit-globals

--- a/tests/end_to_end/function-pointer2/irix-o2-flags.txt
+++ b/tests/end_to_end/function-pointer2/irix-o2-flags.txt
@@ -1,1 +1,1 @@
---context context.c --void
+--context context.c --void --emit-globals

--- a/tests/end_to_end/function-pointer2/irix-o2-out.c
+++ b/tests/end_to_end/function-pointer2/irix-o2-out.c
@@ -1,3 +1,6 @@
+extern int (float) bar;
+extern int (*)(float) glob2;
+
 void test(void) {
     glob = foo;
     glob = &bar;

--- a/tests/end_to_end/misc1/irix-o2-validsyntax-flags.txt
+++ b/tests/end_to_end/misc1/irix-o2-validsyntax-flags.txt
@@ -1,1 +1,1 @@
---valid-syntax
+--valid-syntax --emit-globals

--- a/tests/end_to_end/misc1/irix-o2-validsyntax-out.c
+++ b/tests/end_to_end/misc1/irix-o2-validsyntax-out.c
@@ -1,3 +1,8 @@
+extern s32 D_410170;
+extern MIPS2C_UNK D_410178;
+extern MIPS2C_UNK func_00400140;
+extern MIPS2C_UNK func_00400158;
+
 s32 test(s32 arg0, MIPS2C_UNK arg1) {
     s32 sp2C;
     s32 sp28;


### PR DESCRIPTION
- Created a `GlobalInfo` class for managing any (potentially mutable) cross-function state.
    - Right now this is the TypeMap, Rodata, and types of global symbols
    - Happy to have a better name, it felt like a good complement to `FunctionInfo`?
- Added `--emit-globals` flag, making the default behavior to *not* print these detected globals.
    - I think it'd be nice to make this on by default once there's a chance for it to "burn in" for a bit, and #106 is merged which will fix global function decls which currently show up as `void *` or `? *`.
    - Added `--emit-globals` to a smattering of existing tests
- Without modifying the test flags, there is no change in test output. 