### PR TITLE
Improve function type unification

### DIFF
--- a/src/types.py
+++ b/src/types.py
@@ -417,28 +417,30 @@ class FunctionSignature:
         can_unify = self.return_type.unify(other.return_type)
         for x, y in zip(self.params, other.params):
             can_unify &= x.type.unify(y.type)
+        if not can_unify:
+            return False
 
-        if can_unify:
-            # If one side has fewer params (and params_known is not True), then
-            # extend its param list to match the other side
-            if not self.params_known:
-                self.is_variadic |= other.is_variadic
-                self.params_known |= other.params_known
-                while len(other.params) > len(self.params):
-                    self.params.append(other.params[len(self.params)])
-            if not other.params_known:
-                other.is_variadic |= self.is_variadic
-                other.params_known |= self.params_known
-                while len(self.params) > len(other.params):
-                    other.params.append(self.params[len(other.params)])
+        # If one side has fewer params (and params_known is not True), then
+        # extend its param list to match the other side
+        if not self.params_known:
+            self.is_variadic |= other.is_variadic
+            self.params_known |= other.params_known
+            while len(other.params) > len(self.params):
+                self.params.append(other.params[len(self.params)])
+        if not other.params_known:
+            other.is_variadic |= self.is_variadic
+            other.params_known |= self.params_known
+            while len(self.params) > len(other.params):
+                other.params.append(self.params[len(other.params)])
 
-            # If any parameter names are missing, try to fill them in
-            for x, y in zip(self.params, other.params):
-                if not x.name and y.name:
-                    x.name = y.name
-                elif not y.name and x.name:
-                    y.name = x.name
-        return can_unify
+        # If any parameter names are missing, try to fill them in
+        for x, y in zip(self.params, other.params):
+            if not x.name and y.name:
+                x.name = y.name
+            elif not y.name and x.name:
+                y.name = x.name
+
+        return True
 
     def unify_with_args(self, concrete: "FunctionSignature") -> bool:
         """


### PR DESCRIPTION
This PR mostly resolves that TODO I had left open from my previous PR.
```
# TODO: If neither params_known is true, can we try to unify up
# to the min of the two param lengths, and set both params equal
# to the longer one?
```
- Now `FunctionSignature.unify()` does that ^
- Added an explicit note about how a function type without `params_known` can have its *number* of parameters change over time: this can result in early calls having fewer arguments than the eventually determined type. I added a warning about this to `FuncCall.format()`
   - An interesting idea is to try to patch these calls up at a later time: either remove args, or add args from the `possible_regs` candidates that were previously discarded. I think this is tricky to do right; doing it at format-time would make `FuncCall.dependencies()` unreliable.
   - On the plus side, this seems pretty rare and the errors aren't too bad for a human to patch. (It is also fixable by re-running mips2c with the derived function prototype in the context)
- Use casts to make sure that function arguments will have the right types, so that `FunctionSignature.unify_with_args()` is more likely to succeed. 
- Overall, the changes to the MM/OOT tests are small & explainable.