### PR TITLE
Support loading in .data & .bss in addition to .rodata

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -182,15 +182,20 @@ def create_project_tests(
         if context_file is not None:
             flags.extend(["--context", str(context_file)])
 
-        # Guess the name of .rodata file(s) for the MM decomp project
+        # Guess the name of .data/.rodata file(s) for the OOT/MM decomp projects
         for candidate in [
             # mm code/*.asm
+            "code_data_" + asm_name,
             "code_rodata_" + asm_name,
+            asm_name.replace("code_", "code_data_"),
             asm_name.replace("code_", "code_rodata_"),
             # mm boot/*.asm
+            "boot_data_" + asm_name,
             "boot_rodata_" + asm_name,
+            asm_name.replace("boot_", "boot_data_"),
             asm_name.replace("boot_", "boot_rodata_"),
             # mm overlays/*.asm
+            asm_name.rpartition("_0x")[0] + "_data.asm",
             asm_name.rpartition("_0x")[0] + "_rodata.asm",
             asm_name.rpartition("_0x")[0] + "_late_rodata.asm",
             # oot *.s
@@ -201,7 +206,7 @@ def create_project_tests(
                 continue
             f = asm_file.parent / candidate
             if f.exists():
-                flags.extend(["--rodata", str(f)])
+                flags.extend(["--data", str(f)])
 
         test_path = asm_file.relative_to(asm_dir)
         name = f"{name_prefix}:{test_path}"

--- a/run_tests.py
+++ b/run_tests.py
@@ -206,7 +206,7 @@ def create_project_tests(
                 continue
             f = asm_file.parent / candidate
             if f.exists():
-                flags.extend(["--data", str(f)])
+                flags.extend(["--rodata", str(f)])
 
         test_path = asm_file.relative_to(asm_dir)
         name = f"{name_prefix}:{test_path}"

--- a/src/flow_graph.py
+++ b/src/flow_graph.py
@@ -934,14 +934,7 @@ def build_graph_from_block(
                     "to get correct control flow for non-jtbl switch jumps.)"
                 )
 
-            jtbl_data_entry = data_section.values[jtbl_name]
-            if not jtbl_data_entry.is_readonly:
-                raise DecompFailure(
-                    f"Found jr instruction {jump.meta.loc_str()}, but the "
-                    "corresponding jump table was not in the .rodata section."
-                )
-
-            jtbl_entries = jtbl_data_entry.data
+            jtbl_entries = data_section.values[jtbl_name].data
             for entry in jtbl_entries:
                 if isinstance(entry, bytes):
                     # We have entered padding, stop reading.

--- a/src/main.py
+++ b/src/main.py
@@ -8,7 +8,7 @@ from .error import DecompFailure
 from .flow_graph import build_flowgraph, visualize_flowgraph
 from .if_statements import get_function_text
 from .options import Options, CodingStyle
-from .parse_file import Function, MIPSFile, Rodata, parse_file
+from .parse_file import Function, MIPSFile, parse_file
 from .translate import (
     FunctionInfo,
     GlobalInfo,
@@ -48,11 +48,11 @@ def run(options: Options) -> int:
             with open(options.filename, "r", encoding="utf-8-sig") as f:
                 mips_file = parse_file(f, options)
 
-        # Move over jtbl rodata from files given by --rodata
-        for rodata_file in options.rodata_files:
-            with open(rodata_file, "r", encoding="utf-8-sig") as f:
+        # Move over jtbl rodata from files given by --rodata & --data
+        for data_file in options.data_files:
+            with open(data_file, "r", encoding="utf-8-sig") as f:
                 sub_file = parse_file(f, options)
-                sub_file.rodata.merge_into(mips_file.rodata)
+                sub_file.data_section.merge_into(mips_file.data_section)
 
         if options.c_context is not None:
             with open(options.c_context, "r", encoding="utf-8-sig") as f:
@@ -91,12 +91,12 @@ def run(options: Options) -> int:
                 return 1
 
     return_code = 0
-    global_info = GlobalInfo(mips_file.rodata, typemap)
+    global_info = GlobalInfo(mips_file.data_section, typemap)
     function_infos: List[Union[FunctionInfo, Exception]] = []
     for function in functions:
         try:
             if options.visualize_flowgraph:
-                visualize_flowgraph(build_flowgraph(function, mips_file.rodata))
+                visualize_flowgraph(build_flowgraph(function, mips_file.data_section))
                 continue
 
             info = translate_to_ast(function, options, global_info)
@@ -193,12 +193,21 @@ def parse_flags(flags: List[str]) -> Options:
         "patterns are allowed.",
     )
     parser.add_argument(
+        # Deprecated, provided for backwards compatability. Use --data instead
         "--rodata",
         metavar="ASM_FILE",
-        dest="rodata_files",
+        dest="data_files",
         action="append",
         default=[],
-        help="read jump table data from this file",
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--data",
+        metavar="ASM_FILE",
+        dest="data_files",
+        action="append",
+        default=[],
+        help="read jump table, constant, and global variable information from this file",
     )
     parser.add_argument(
         "--stop-on-error",
@@ -302,7 +311,7 @@ def parse_flags(flags: List[str]) -> Options:
         skip_casts=args.skip_casts,
         reg_vars=reg_vars,
         goto_patterns=args.goto_patterns,
-        rodata_files=args.rodata_files,
+        data_files=args.data_files,
         stop_on_error=args.stop_on_error,
         print_assembly=args.print_assembly,
         visualize_flowgraph=args.visualize,

--- a/src/options.py
+++ b/src/options.py
@@ -21,7 +21,7 @@ class Options:
     skip_casts: bool = attr.ib()
     reg_vars: List[str] = attr.ib()
     goto_patterns: List[str] = attr.ib()
-    data_files: List[str] = attr.ib()
+    asm_data_files: List[str] = attr.ib()
     stop_on_error: bool = attr.ib()
     print_assembly: bool = attr.ib()
     visualize_flowgraph: bool = attr.ib()

--- a/src/options.py
+++ b/src/options.py
@@ -21,7 +21,7 @@ class Options:
     skip_casts: bool = attr.ib()
     reg_vars: List[str] = attr.ib()
     goto_patterns: List[str] = attr.ib()
-    rodata_files: List[str] = attr.ib()
+    data_files: List[str] = attr.ib()
     stop_on_error: bool = attr.ib()
     print_assembly: bool = attr.ib()
     visualize_flowgraph: bool = attr.ib()

--- a/src/parse_file.py
+++ b/src/parse_file.py
@@ -300,7 +300,6 @@ def parse_file(f: typing.TextIO, options: Options) -> MIPSFile:
                 elif (
                     line.startswith(".rdata")
                     or line.startswith(".rodata")
-                    or line.startswith(".rdata")
                     or line.startswith(".late_rodata")
                 ):
                     curr_section = ".rodata"

--- a/src/translate.py
+++ b/src/translate.py
@@ -20,7 +20,7 @@ from .flow_graph import (
     build_flowgraph,
 )
 from .options import CodingStyle, Options, Formatter, DEFAULT_CODING_STYLE
-from .parse_file import DataSection, DataSectionEntry
+from .parse_file import AsmData, AsmDataEntry
 from .parse_instruction import (
     Argument,
     AsmAddressMode,
@@ -3702,12 +3702,12 @@ def resolve_types_late(stack_info: StackInfo) -> None:
 
 @attr.s
 class GlobalInfo:
-    data_section: DataSection = attr.ib()
+    asm_data: AsmData = attr.ib()
     typemap: Optional[TypeMap] = attr.ib()
     symbol_type_map: Dict[str, "Type"] = attr.ib(factory=dict)
 
-    def rodata_value(self, sym_name: str) -> Optional[DataSectionEntry]:
-        entry = self.data_section.values.get(sym_name)
+    def rodata_value(self, sym_name: str) -> Optional[AsmDataEntry]:
+        entry = self.asm_data.values.get(sym_name)
         if entry and entry.is_readonly:
             return entry
         return None
@@ -3722,7 +3722,7 @@ class GlobalInfo:
         for name, type in self.symbol_type_map.items():
             if self.typemap and name in self.typemap.var_types:
                 continue
-            is_static = name in self.data_section.values
+            is_static = name in self.asm_data.values
             order = (is_static, name)
             prefix = ""
             if is_static:
@@ -3753,7 +3753,7 @@ def translate_to_ast(
     branch condition.
     """
     # Initialize info about the function.
-    flow_graph: FlowGraph = build_flowgraph(function, global_info.data_section)
+    flow_graph: FlowGraph = build_flowgraph(function, global_info.asm_data)
     stack_info = get_stack_info(function, global_info, flow_graph)
     typemap = global_info.typemap
 

--- a/src/translate.py
+++ b/src/translate.py
@@ -2144,7 +2144,6 @@ def handle_load(args: InstrArgs, type: Type) -> Expression:
             if (
                 ent
                 and ent.data
-                and ent.is_readonly
                 and isinstance(ent.data[0], bytes)
                 and len(ent.data[0]) >= size
             ):


### PR DESCRIPTION
This PR has a lot of lines changed, but it's mostly renaming. The technical aspects are pretty small, I wanted to check that the renaming I did makes sense.

- `Rodata` --> `DataSection`, which now holds `.rodata`, `.data`, and `.bss`. (although `.bss` is untested)
- `RodataEntry` --> `DataSectionEntry`, which has a `is_readonly` attr for distinguishing rodata from data/bss.
- Changed the command line arg `--rodata` to `--data` & updated help/error messages. Left in support for `--rodata` as a hidden option to preserve compatibility.