### PR TITLE
Improve global_decls() for C-like output

### DIFF
--- a/mips2c_macros.h
+++ b/mips2c_macros.h
@@ -16,11 +16,16 @@
 #define MIPS2C_UNK32 s32
 #define MIPS2C_UNK64 s64
 
+/* Unknown field access, like `*(type_ptr) &expr->unk_offset` */
+#define MIPS2C_FIELD(expr, type_ptr, offset) (*(type_ptr)((s8 *)(expr) + (offset)))
+
 /* Bitwise (reinterpret) cast */
 #define MIPS2C_BITWISE(type, expr) ((type)(expr))
 
-/* Unknown field access, like `*(type_ptr) &expr->unk_offset` */
-#define MIPS2C_FIELD(expr, type_ptr, offset) (*(type_ptr)((s8 *)(expr) + (offset)))
+/* Unaligned reads */
+#define MIPS2C_LWL(expr) (expr)
+#define MIPS2C_FIRST3BYTES(expr) (expr)
+#define MIPS2C_UNALIGNED32(expr) (expr)
 
 /* Unhandled instructions */
 #define MIPS2C_ERROR(desc) (0)

--- a/src/translate.py
+++ b/src/translate.py
@@ -296,12 +296,6 @@ class StackInfo:
             self.unique_type_map[key] = default
         return self.unique_type_map[key]
 
-    def global_symbol(self, sym: AsmGlobalSymbol) -> "GlobalSymbol":
-        return GlobalSymbol(
-            symbol_name=sym.symbol_name,
-            type=self.global_info.symbol_type(sym.symbol_name),
-        )
-
     def saved_reg_symbol(self, reg_name: str) -> "GlobalSymbol":
         sym_name = "saved_reg_" + reg_name
         type = self.unique_type_for("saved_reg", sym_name, Type.any_reg())
@@ -353,23 +347,6 @@ class StackInfo:
         if reg.register_name == "fp":
             return self.uses_framepointer
         return False
-
-    def address_of_gsym(self, sym: "GlobalSymbol") -> "Expression":
-        ent = self.global_info.rodata_value(sym.symbol_name)
-        if ent and ent.is_string and ent.data and isinstance(ent.data[0], bytes):
-            return StringLiteral(ent.data[0], type=Type.ptr(Type.s8()))
-        type = Type.ptr(sym.type)
-        typemap = self.global_info.typemap
-        if typemap:
-            ctype = typemap.var_types.get(sym.symbol_name)
-            if ctype:
-                ctype_type, is_ptr = ptr_type_from_ctype(ctype, typemap)
-                if is_ptr:
-                    return as_type(sym, ctype_type, True)
-                else:
-                    type.unify(ctype_type)
-                    type = ctype_type
-        return AddressOf(sym, type=type)
 
     def get_struct_type_map(self) -> Dict["Expression", Dict[int, Type]]:
         """Reorganize struct information in unique_type_map by var & offset"""
@@ -1200,7 +1177,7 @@ class Lwl(Expression):
         return [self.load_expr]
 
     def format(self, fmt: Formatter) -> str:
-        return f"LWL({self.load_expr.format(fmt)})"
+        return f"MIPS2C_LWL({self.load_expr.format(fmt)})"
 
 
 @attr.s(frozen=True)
@@ -1212,6 +1189,8 @@ class Load3Bytes(Expression):
         return [self.load_expr]
 
     def format(self, fmt: Formatter) -> str:
+        if fmt.valid_syntax:
+            return f"MIPS2C_FIRST3BYTES({self.load_expr.format(fmt)})"
         return f"(first 3 bytes) {self.load_expr.format(fmt)}"
 
 
@@ -1224,6 +1203,8 @@ class UnalignedLoad(Expression):
         return [self.load_expr]
 
     def format(self, fmt: Formatter) -> str:
+        if fmt.valid_syntax:
+            return f"MIPS2C_UNALIGNED32({self.load_expr.format(fmt)})"
         return f"(unaligned s32) {self.load_expr.format(fmt)}"
 
 
@@ -1423,7 +1404,7 @@ class CommentStmt(Statement):
         return True
 
     def format(self, fmt: Formatter) -> str:
-        return f"// {self.contents}"
+        return f"/* {self.contents} */"
 
 
 @attr.s(frozen=True)
@@ -1582,7 +1563,7 @@ class InstrArgs:
         arg = strip_macros(self.raw_arg(index))
         ret = literal_expr(arg, self.stack_info)
         if isinstance(ret, GlobalSymbol):
-            return self.stack_info.address_of_gsym(ret)
+            return self.stack_info.global_info.address_of_gsym(ret.symbol_name)
         return ret
 
     def imm(self, index: int) -> Expression:
@@ -1651,7 +1632,7 @@ def deref(
             return stack_info.get_stack_var(offset, store=store)
         var = regs[arg.rhs]
     else:
-        var = stack_info.address_of_gsym(stack_info.global_symbol(arg.sym))
+        var = stack_info.global_info.address_of_gsym(arg.sym.symbol_name)
 
     # Struct member is being dereferenced.
 
@@ -1913,7 +1894,7 @@ def unwrap_deep(expr: Expression) -> Expression:
 
 def literal_expr(arg: Argument, stack_info: StackInfo) -> Expression:
     if isinstance(arg, AsmGlobalSymbol):
-        return stack_info.global_symbol(arg)
+        return stack_info.global_info.global_symbol(arg.symbol_name)
     if isinstance(arg, AsmLiteral):
         return Literal(arg.value)
     if isinstance(arg, BinOp):
@@ -1972,7 +1953,7 @@ def load_upper(args: InstrArgs) -> Expression:
         raise DecompFailure(f"Invalid %hi argument {hi_arg}")
 
     stack_info = args.stack_info
-    source = stack_info.address_of_gsym(stack_info.global_symbol(sym))
+    source = stack_info.global_info.address_of_gsym(sym.symbol_name)
     imm = Literal(offset)
     return handle_addi_real(args.reg_ref(0), None, source, imm, stack_info)
 
@@ -1995,7 +1976,7 @@ def handle_la(args: InstrArgs) -> Expression:
                 stack_info=args.stack_info,
             )
         )
-    var = stack_info.address_of_gsym(stack_info.global_symbol(target.sym))
+    var = stack_info.global_info.address_of_gsym(target.sym.symbol_name)
     return add_imm(var, Literal(target.offset), stack_info)
 
 
@@ -2143,12 +2124,14 @@ def handle_load(args: InstrArgs, type: Type) -> Expression:
             and type.is_float()
         ):
             sym_name = target.expr.symbol_name
-            ent = args.stack_info.global_info.rodata_value(sym_name)
+            ent = args.stack_info.global_info.asm_data_value(sym_name)
             if (
                 ent
                 and ent.data
                 and isinstance(ent.data[0], bytes)
                 and len(ent.data[0]) >= size
+                and ent.is_readonly
+                and type.unify(target.expr.type)
             ):
                 data = ent.data[0][:size]
                 val: int
@@ -3703,10 +3686,11 @@ def resolve_types_late(stack_info: StackInfo) -> None:
 @attr.s
 class GlobalInfo:
     asm_data: AsmData = attr.ib()
+    local_functions: Set[str] = attr.ib()
     typemap: Optional[TypeMap] = attr.ib()
     symbol_type_map: Dict[str, "Type"] = attr.ib(factory=dict)
 
-    def rodata_value(self, sym_name: str) -> Optional[AsmDataEntry]:
+    def asm_data_value(self, sym_name: str) -> Optional[AsmDataEntry]:
         entry = self.asm_data.values.get(sym_name)
         if entry and entry.is_readonly:
             return entry
@@ -3717,20 +3701,147 @@ class GlobalInfo:
             self.symbol_type_map[sym_name] = Type.any()
         return self.symbol_type_map[sym_name]
 
-    def global_decls(self, fmt: Formatter) -> str:
-        lines = []
-        for name, type in self.symbol_type_map.items():
-            if self.typemap and name in self.typemap.var_types:
-                continue
-            is_static = name in self.asm_data.values
-            order = (is_static, name)
-            prefix = ""
-            if is_static:
-                prefix = "static "
-            elif not type.is_function():
-                prefix = "extern "
+    def global_symbol(self, sym_name: str) -> "GlobalSymbol":
+        return GlobalSymbol(
+            symbol_name=sym_name,
+            type=self.symbol_type(sym_name),
+        )
 
-            lines.append((order, f"{prefix}{type.to_decl(name, fmt)};\n"))
+    def address_of_gsym(self, sym_name: str) -> Expression:
+        ent = self.asm_data_value(sym_name)
+        if ent and ent.is_string and ent.data and isinstance(ent.data[0], bytes):
+            return StringLiteral(ent.data[0], type=Type.ptr(Type.s8()))
+        sym = self.global_symbol(sym_name)
+        type = Type.ptr(sym.type)
+        if self.typemap:
+            ctype = self.typemap.var_types.get(sym_name)
+            if ctype:
+                ctype_type, is_ptr = ptr_type_from_ctype(ctype, self.typemap)
+                if is_ptr:
+                    return as_type(sym, ctype_type, True)
+                else:
+                    type.unify(ctype_type)
+                    type = ctype_type
+        return AddressOf(sym, type=type)
+
+    def data_to_initializer(
+        self, type: Type, data: List[Union[str, bytes]], fmt: Formatter
+    ) -> Optional[str]:
+        data = data[:]
+
+        def read_bytes(n: int) -> Optional[int]:
+            """Read the next `n` bytes from `data` as an (long) integer"""
+            assert 0 < n <= 8
+            if not data or not isinstance(data[0], bytes):
+                return None
+            if len(data[0]) < n:
+                return None
+            bs = data[0][:n]
+            data[0] = data[0][n:]
+            if not data[0]:
+                del data[0]
+            value = 0
+            for b in bs:
+                value = (value << 8) | b
+            return value
+
+        def read_pointer() -> Optional[Expression]:
+            """Read the next label from `data`"""
+            if not data or not isinstance(data[0], str):
+                return None
+            label = data.pop(0)
+            assert isinstance(label, str)
+            return self.address_of_gsym(label)
+
+        if type.is_int() or type.is_float():
+            size = type.get_size_bits() // 8
+            value = read_bytes(size)
+            if value is not None:
+                return Literal(value, type).format(fmt)
+
+        if type.is_pointer():
+            ptr = read_pointer()
+            if ptr is not None:
+                return as_type(ptr, type, True).format(fmt)
+
+        if type.is_ctype():
+            # TODO: Generate initializers for structs/arrays/etc.
+            return None
+
+        # Type kinds K_FN and K_VOID do not have initializers
+        return None
+
+    def global_decls(self, fmt: Formatter) -> str:
+        # Format labels from symbol_type_map into global declarations.
+        # As the initializers are formatted, this may cause more symbols
+        # to be added to the symbol_type_map.
+        lines = []
+        processed_names: Set[str] = set()
+        while True:
+            names = self.symbol_type_map.keys() - processed_names
+            if not names:
+                break
+            for name in names:
+                processed_names.add(name)
+                type = self.symbol_type_map[name]
+
+                # Is the label defined in this unit (in the active AsmData file(s))
+                is_in_file = (
+                    name in self.asm_data.values or name in self.local_functions
+                )
+                # Is the label externally visible (mentioned in the context file)
+                is_global = self.typemap and name in self.typemap.var_types
+                if not is_in_file and is_global:
+                    # Skip externally-declared symbols that are defined in other files
+                    continue
+                if is_in_file and is_global and type.is_function():
+                    # Skip externally-declared functions that are defined here
+                    continue
+
+                sort_order = (not type.is_function(), is_global, is_in_file, name)
+                qualifier = ""
+                initializer = ""
+                comments = []
+
+                # Determine type qualifier: static, extern, or neither
+                if is_in_file and is_global:
+                    qualifier = ""
+                elif is_in_file:
+                    qualifier = "static"
+                else:
+                    qualifier = "extern"
+
+                if type.is_function():
+                    comments.append(qualifier)
+                    qualifier = ""
+
+                # Try to convert the data from .data/.rodata into an initializer
+                entry = self.asm_data.values.get(name)
+                if entry is not None:
+                    if entry.is_readonly:
+                        comments.append("const")
+                    data_size = entry.size_bytes()
+                    type_size = type.get_size_bits() // 8
+                    if data_size != type_size:
+                        # TODO: Use heuristic to detect padding
+                        if data_size // type_size > 1:
+                            comments.append(f"array: [{data_size // type_size}]")
+                        if data_size % type_size != 0:
+                            comments.append(f"extra bytes: {data_size % type_size}")
+                    elif entry.is_readonly and type.is_float():
+                        # Float constants are almost always inlined and can be skipped
+                        continue
+                    initializer = self.data_to_initializer(type, entry.data, fmt) or ""
+
+                qualifier = f"{qualifier} " if qualifier else ""
+                initializer = f" = {initializer}" if initializer else ""
+                comment = f" /* {'; '.join(comments)} */" if comments else ""
+                lines.append(
+                    (
+                        sort_order,
+                        f"{qualifier}{type.to_decl(name, fmt)}{initializer};{comment}\n",
+                    )
+                )
         lines.sort()
         return "".join(line for _, line in lines)
 
@@ -3772,7 +3883,7 @@ def translate_to_ast(
     else:
         fn_type = Type.function()
         fn_decl_provided = False
-    fn_type.unify(stack_info.global_symbol(AsmGlobalSymbol(function.name)).type)
+    fn_type.unify(global_info.symbol_type(function.name))
 
     fn_sig = Type.ptr(fn_type).get_function_pointer_signature()
     assert fn_sig is not None, "fn_type is known to be a function"

--- a/src/translate.py
+++ b/src/translate.py
@@ -1404,7 +1404,7 @@ class CommentStmt(Statement):
         return True
 
     def format(self, fmt: Formatter) -> str:
-        return f"/* {self.contents} */"
+        return f"// {self.contents}"
 
 
 @attr.s(frozen=True)
@@ -3835,7 +3835,7 @@ class GlobalInfo:
 
                 qualifier = f"{qualifier} " if qualifier else ""
                 initializer = f" = {initializer}" if initializer else ""
-                comment = f" /* {'; '.join(comments)} */" if comments else ""
+                comment = f" // {'; '.join(comments)}" if comments else ""
                 lines.append(
                     (
                         sort_order,

--- a/src/types.py
+++ b/src/types.py
@@ -152,15 +152,15 @@ class Type:
     def is_unsigned(self) -> bool:
         return self.data().sign == TypeData.UNSIGNED
 
-    def get_size_bits(self) -> int:
-        return self.data().size or 32
+    def get_size_bits(self) -> Optional[int]:
+        return self.data().size
 
     def get_size_align_bytes(self) -> Tuple[int, int]:
         data = self.data()
         if data.kind == TypeData.K_CTYPE and data.ctype_ref is not None:
             assert data.typemap is not None
             return var_size_align(data.ctype_ref, data.typemap)
-        size = self.get_size_bits() // 8
+        size = (self.get_size_bits() or 32) // 8
         return size, size
 
     def is_struct_type(self) -> bool:

--- a/tests/end_to_end/function-pointer2/irix-o2-out.c
+++ b/tests/end_to_end/function-pointer2/irix-o2-out.c
@@ -1,5 +1,5 @@
-s32 bar(f32); /* extern */
-void test(); /* static */
+s32 bar(f32); // extern
+void test(); // static
 extern s32 (*glob2)(f32);
 
 void test(void) {

--- a/tests/end_to_end/function-pointer2/irix-o2-out.c
+++ b/tests/end_to_end/function-pointer2/irix-o2-out.c
@@ -1,6 +1,6 @@
-s32 bar(f32);
+s32 bar(f32); /* extern */
+void test(); /* static */
 extern s32 (*glob2)(f32);
-void test();
 
 void test(void) {
     glob = foo;

--- a/tests/end_to_end/global_decls/irix-o2-flags.txt
+++ b/tests/end_to_end/global_decls/irix-o2-flags.txt
@@ -1,0 +1,1 @@
+--context orig.c --valid-syntax --emit-globals

--- a/tests/end_to_end/global_decls/irix-o2-out.c
+++ b/tests/end_to_end/global_decls/irix-o2-out.c
@@ -1,0 +1,14 @@
+MIPS2C_UNK extern_fn(struct A *); // extern
+MIPS2C_UNK static_fn(struct A *); // static
+extern f32 extern_float;
+struct A static_A; // const; extra bytes: 5
+struct A *static_A_ptr = &static_A;
+s32 static_int = 0x1234;
+
+s32 test(void) {
+    static_int *= 0x1C8;
+    extern_float = (f32) (extern_float * 456.0f);
+    static_fn(&static_A);
+    extern_fn(static_A_ptr);
+    return static_int;
+}

--- a/tests/end_to_end/global_decls/irix-o2-out.c
+++ b/tests/end_to_end/global_decls/irix-o2-out.c
@@ -3,7 +3,7 @@ MIPS2C_UNK static_fn(struct A *); // static
 extern f32 extern_float;
 struct A static_A; // const; extra bytes: 5
 struct A *static_A_ptr = &static_A;
-s32 static_int = 0x1234;
+s32 static_int = 0;
 
 s32 test(void) {
     static_int *= 0x1C8;

--- a/tests/end_to_end/global_decls/irix-o2.s
+++ b/tests/end_to_end/global_decls/irix-o2.s
@@ -1,0 +1,53 @@
+.set noat      # allow manual use of $at
+.set noreorder # don't insert nops after branches
+
+.text
+
+glabel static_fn
+
+/* 0000B4 004000B4 AFA40000 */   sw    $a0, ($sp)
+
+glabel test
+/* 0000B8 004000B8 3C030041 */  lui   $v1, %hi(extern_float)
+/* 0000BC 004000BC 24630134 */  addiu $v1, $v1, %lo(extern_float)
+/* 0000C0 004000C0 3C020041 */  lui   $v0, %hi(static_int)
+/* 0000C4 004000C4 3C0143E4 */  lui   $at, 0x43e4
+/* 0000C8 004000C8 44813000 */  mtc1  $at, $f6
+/* 0000CC 004000CC C4640000 */  lwc1  $f4, ($v1)
+/* 0000D0 004000D0 24420130 */  addiu $v0, $v0, %lo(static_int)
+/* 0000D4 004000D4 8C4E0000 */  lw    $t6, ($v0)
+/* 0000D8 004000D8 46062202 */  mul.s $f8, $f4, $f6
+/* 0000DC 004000DC 27BDFFE8 */  addiu $sp, $sp, -0x18
+/* 0000E0 004000E0 000E78C0 */  sll   $t7, $t6, 3
+/* 0000E4 004000E4 01EE7823 */  subu  $t7, $t7, $t6
+/* 0000E8 004000E8 000F78C0 */  sll   $t7, $t7, 3
+/* 0000EC 004000EC 01EE7821 */  addu  $t7, $t7, $t6
+/* 0000F0 004000F0 AFBF0014 */  sw    $ra, 0x14($sp)
+/* 0000F4 004000F4 000F78C0 */  sll   $t7, $t7, 3
+/* 0000F8 004000F8 3C040041 */  lui   $a0, %hi(static_A)
+/* 0000FC 004000FC AC4F0000 */  sw    $t7, ($v0)
+/* 000100 00400100 E4680000 */  swc1  $f8, ($v1)
+/* 000104 00400104 0C10002C */  jal   static_fn
+/* 000108 00400108 24840138 */   addiu $a0, $a0, %lo(static_A)
+/* 00010C 0040010C 3C040041 */  lui   $a0, %hi(static_A_ptr)
+/* 000110 00400110 0C10002C */  jal   extern_fn
+/* 000114 00400114 8C84014C */   lw    $a0, %lo(static_A_ptr)($a0)
+/* 000118 00400118 8FBF0014 */  lw    $ra, 0x14($sp)
+/* 00011C 0040011C 3C020041 */  lui   $v0, %hi(static_int)
+/* 000120 00400120 8C420130 */  lw    $v0, %lo(static_int)($v0)
+/* 000124 00400124 03E00008 */  jr    $ra
+/* 000128 00400128 27BD0018 */   addiu $sp, $sp, 0x18
+
+/* 00012C 0040012C 00000000 */  nop
+
+.rodata
+glabel static_A
+.byte 0x01, 0x02, 0x03, 0x04, 0x05
+
+.data
+glabel static_A_ptr
+.word static_A
+
+.bss
+glabel static_int
+.word 0

--- a/tests/end_to_end/global_decls/orig.c
+++ b/tests/end_to_end/global_decls/orig.c
@@ -1,0 +1,20 @@
+struct A {
+    int x[5];
+};
+
+//void extern_fn(struct A *a);
+//extern float extern_float;
+//void static_fn(struct A *a) { }
+
+static int static_int;
+static struct A static_A = {{1,2,3,4,5}};
+static struct A *static_A_ptr = &static_A;
+
+int test(void) {
+    static_int *= 456;
+    extern_float *= 456.0f;
+    static_fn(&static_A);
+    extern_fn(static_A_ptr);
+    return static_int;
+}
+

--- a/tests/end_to_end/misc1/irix-o2-validsyntax-out.c
+++ b/tests/end_to_end/misc1/irix-o2-validsyntax-out.c
@@ -1,6 +1,6 @@
-s32 func_00400140(MIPS2C_UNK, MIPS2C_UNK, s32, MIPS2C_UNK, s32); /* static */
-MIPS2C_UNK func_00400158(MIPS2C_UNK32, s32, s32); /* static */
-s32 test(s32 arg0, MIPS2C_UNK arg1); /* static */
+s32 func_00400140(MIPS2C_UNK, MIPS2C_UNK, s32, MIPS2C_UNK, s32); // static
+MIPS2C_UNK func_00400158(MIPS2C_UNK32, s32, s32); // static
+s32 test(s32 arg0, MIPS2C_UNK arg1); // static
 extern s32 D_410170;
 extern MIPS2C_UNK D_410178;
 

--- a/tests/end_to_end/misc1/irix-o2-validsyntax-out.c
+++ b/tests/end_to_end/misc1/irix-o2-validsyntax-out.c
@@ -1,8 +1,8 @@
+s32 func_00400140(MIPS2C_UNK, MIPS2C_UNK, s32, MIPS2C_UNK, s32); /* static */
+MIPS2C_UNK func_00400158(MIPS2C_UNK32, s32, s32); /* static */
+s32 test(s32 arg0, MIPS2C_UNK arg1); /* static */
 extern s32 D_410170;
 extern MIPS2C_UNK D_410178;
-s32 func_00400140(MIPS2C_UNK, MIPS2C_UNK, s32, MIPS2C_UNK, s32);
-MIPS2C_UNK func_00400158(MIPS2C_UNK32, s32, s32);
-s32 test(s32 arg0, MIPS2C_UNK arg1);
 
 s32 test(s32 arg0, MIPS2C_UNK arg1) {
     s32 sp2C;


### PR DESCRIPTION
- When a function fails to decompile, wrap the error message/traceback in `/* ... */` so that you can still try to compile the output.
    - I considered only doing this when `--valid-syntax` is enabled, but it seems benign?
- Added new `MIPS2C` macros for unaligned reads. Rearranged existing macros to be in order of "most-to-least common" to be easier to read.
- ~~Use `/* ... */` for comments, because IDO/c89 does not support `//`~~
- `GlobalInfo` now handles `.global_symbol(...)` and `.address_of_gsym()`
- Expose more information in the `global_decls()` section.
    - If a function is marked `/* extern */`, this means it should be defined in a common header file.
    - Indicate when variables in file scope look like arrays.
    - For simple types, generate the initializer. 

---

I tried directly compiling the C output from this branch (with `--valid-syntax`).
I compiled with `mips-linux-gnu-gcc` because it supports `-include`, which made it easier to script this. (I spot checked a few files with IDO too.)

- OOT, per-function asm, with context: **80%** success
- MM, per-object asm, with context: **25%** success
- Paper Mario, per-function asm, no context: **20%** success

The 10 most common remaining errors, across all 3 projects:
```
  count  error message
   8491  case label not within a switch statement
   1152  conflicting types for ‘get_variable’
    782  assignment to expression with array type
    778  ‘default’ label not within a switch statement
    763  pointer value used where a floating point value was expected
    732  conflicting types for ‘get_npc_unsafe’
    718  too few arguments to function ‘Audio_PlayActorSound2’
    599  cannot convert to a pointer type
    487  expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ at end of input
    439  conflicting types for ‘gPlayerStatus’
```

