### PR TITLE
Detect GlobalSymbol arrays, move initializer logic to a new file

### DIFF
--- a/src/initializers.py
+++ b/src/initializers.py
@@ -1,0 +1,96 @@
+from typing import List, Optional, Union
+
+import attr
+
+from .options import Formatter
+from .types import Type
+from .translate import (
+    as_type,
+    GlobalInfo,
+    GlobalSymbol,
+    Expression,
+    Initializer,
+    Literal,
+)
+
+
+@attr.s
+class GenericInitializer(Initializer):
+    global_info: GlobalInfo = attr.ib()
+    fmt: Formatter = attr.ib()
+    # Data currently being formatted
+    data: List[Union[str, bytes]] = attr.ib(factory=list)
+
+    def for_symbol(self, sym: GlobalSymbol) -> Optional[str]:
+        """Generate the C initializer expression for sym"""
+        if not sym.asm_data_entry:
+            return None
+        self.data = sym.asm_data_entry.data[:]
+
+        if sym.array_dim is None:
+            return self.for_type(sym.type)
+        else:
+            elements: List[str] = []
+            for _ in range(sym.array_dim):
+                el = self.for_type(sym.type)
+                if el is None:
+                    return None
+                elements.append(el)
+            return f"{{{', '.join(elements)}}}"
+
+    def for_type(self, type: Type) -> Optional[str]:
+        if type.is_int() or type.is_float():
+            size_bits = type.get_size_bits()
+            if size_bits == 0:
+                return None
+            elif size_bits is None:
+                # Unknown size; guess 32 bits
+                size_bits = 32
+            value = self.read_uint(size_bits // 8)
+            if value is not None:
+                return Literal(value, type).format(self.fmt)
+
+        if type.is_pointer():
+            ptr = self.read_pointer()
+            if ptr is not None:
+                return as_type(ptr, type, True).format(self.fmt)
+
+        if type.is_ctype():
+            # TODO: Generate initializers for structs/arrays/etc.
+            return None
+
+        # Type kinds K_FN and K_VOID do not have initializers
+        return None
+
+    def read_uint(self, n: int) -> Optional[int]:
+        """Read the next `n` bytes from `data` as an (long) integer"""
+        assert 0 < n <= 8
+        if not self.data or not isinstance(self.data[0], bytes):
+            return None
+        if len(self.data[0]) < n:
+            return None
+        bs = self.data[0][:n]
+        self.data[0] = self.data[0][n:]
+        if not self.data[0]:
+            del self.data[0]
+        value = 0
+        for b in bs:
+            value = (value << 8) | b
+        return value
+
+    def read_pointer(self) -> Optional[Expression]:
+        """Read the next label from `data`"""
+        if not self.data:
+            return None
+
+        if not isinstance(self.data[0], str):
+            # Bare pointer
+            value = self.read_uint(4)
+            if value is None:
+                return None
+            return Literal(value=value)
+
+        # Pointer label
+        label = self.data.pop(0)
+        assert isinstance(label, str)
+        return self.global_info.address_of_gsym(label)

--- a/src/main.py
+++ b/src/main.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Optional, Union
 from .error import DecompFailure
 from .flow_graph import build_flowgraph, visualize_flowgraph
 from .if_statements import get_function_text
+from .initializers import GenericInitializer
 from .options import Options, CodingStyle
 from .parse_file import Function, MIPSFile, parse_file
 from .translate import (
@@ -109,10 +110,10 @@ def run(options: Options) -> int:
         return 0
 
     fmt = options.formatter()
-    if options.emit_globals:
-        global_decls = global_info.global_decls(fmt)
-        if global_decls:
-            print(global_decls)
+    initializer = GenericInitializer(global_info, fmt)
+    global_decls = global_info.global_decls(initializer, fmt)
+    if options.emit_globals and global_decls:
+        print(global_decls)
 
     return_code = 0
     for index, (function, function_info) in enumerate(zip(functions, function_infos)):

--- a/src/parse_file.py
+++ b/src/parse_file.py
@@ -61,10 +61,7 @@ class AsmDataEntry:
 
         padding_size = 0
         if self.data and isinstance(self.data[-1], bytes):
-            if not len(self.data) == 1 and not isinstance(self.data[-2], str):
-                raise DecompFailure(
-                    "Invalid AsmDataEntry created with two `bytes` back-to-back"
-                )
+            assert len(self.data) == 1 or isinstance(self.data[-2], str)
             for b in self.data[-1][::-1]:
                 if b != 0:
                     break

--- a/src/translate.py
+++ b/src/translate.py
@@ -3721,10 +3721,7 @@ class GlobalInfo:
     global_symbol_map: Dict[str, GlobalSymbol] = attr.ib(factory=dict)
 
     def asm_data_value(self, sym_name: str) -> Optional[AsmDataEntry]:
-        entry = self.asm_data.values.get(sym_name)
-        if entry:
-            return entry
-        return None
+        return self.asm_data.values.get(sym_name)
 
     def global_symbol(self, sym_name: str) -> GlobalSymbol:
         if sym_name not in self.global_symbol_map:

--- a/src/types.py
+++ b/src/types.py
@@ -523,7 +523,8 @@ def ptr_type_from_ctype(ctype: CType, typemap: TypeMap) -> Tuple[Type, Optional[
 def get_field(
     type: Type, offset: int, typemap: TypeMap, *, target_size: Optional[int]
 ) -> Tuple[Optional[str], Type, Type, Optional[int]]:
-    """Returns field name, target type, target pointer type, and whether the field is an array."""
+    """Returns field name, target type, target pointer type, and
+    the field's array size (or None if the field is not an array)."""
     if target_size is None and offset == 0:
         # We might as well take a pointer to the whole struct
         target = type.get_pointer_target() or Type.any()

--- a/src/types.py
+++ b/src/types.py
@@ -12,6 +12,7 @@ from .c_types import (
     parse_function,
     primitive_size,
     parse_struct,
+    parse_constant_int,
     resolve_typedefs,
     set_decl_name,
     to_c,
@@ -505,17 +506,23 @@ def type_from_ctype(ctype: CType, typemap: TypeMap) -> Type:
         )
 
 
-def ptr_type_from_ctype(ctype: CType, typemap: TypeMap) -> Tuple[Type, bool]:
+def ptr_type_from_ctype(ctype: CType, typemap: TypeMap) -> Tuple[Type, Optional[int]]:
     real_ctype = resolve_typedefs(ctype, typemap)
     if isinstance(real_ctype, ca.ArrayDecl):
         # Array to pointer decay
-        return Type.ptr(type_from_ctype(real_ctype.type, typemap)), True
-    return Type.ptr(type_from_ctype(ctype, typemap)), False
+        dim = 0
+        try:
+            if real_ctype.dim is not None:
+                dim = parse_constant_int(real_ctype.dim, typemap)
+        except DecompFailure:
+            pass
+        return Type.ptr(type_from_ctype(real_ctype.type, typemap)), dim
+    return Type.ptr(type_from_ctype(ctype, typemap)), None
 
 
 def get_field(
     type: Type, offset: int, typemap: TypeMap, *, target_size: Optional[int]
-) -> Tuple[Optional[str], Type, Type, bool]:
+) -> Tuple[Optional[str], Type, Type, Optional[int]]:
     """Returns field name, target type, target pointer type, and whether the field is an array."""
     if target_size is None and offset == 0:
         # We might as well take a pointer to the whole struct

--- a/tests/end_to_end/global_decls/irix-o2-out.c
+++ b/tests/end_to_end/global_decls/irix-o2-out.c
@@ -1,9 +1,9 @@
 MIPS2C_UNK extern_fn(struct A *); // extern
 MIPS2C_UNK static_fn(struct A *); // static
 extern f32 extern_float;
-struct A static_A; // const; extra bytes: 5
 struct A *static_A_ptr = &static_A;
 s32 static_int = 0;
+struct A static_A; // type too large by 15; const
 
 s32 test(void) {
     static_int *= 0x1C8;


### PR DESCRIPTION
This PR got slightly out of hand - it's really 2-3 changes that are closely related.

- Support for `.short` directive in `parse_file(...)`
- Detect global symbols that are actually arrays.
  - Added the `GlobalSymbol.array_dim` field, which defaults to `None` meaning "not an array." Before formatting, if this field gets populated, it's then assumed that the symbol is an array with the given length. (`0` can be used for arrays with unknown lengths).
      - This worked out pretty well, the only spot that really needed to be changed was the `StructAccess.format`
      - `GlobalSymbol.type` is otherwise unchanged.
  - Use heuristic to guess about zero-padding
      - Really bad at the BSS region, but pretty good otherwise
  - Support writing array initializers.
- Remove StringLiteral, do detection at format time
   - The only downside is that now we have to prune string literals during `GlobalInfo.global_decls()`, like we do with floats. (It's sort of tricky to mark which symbols have been completely elided)
- Move "Initializer" logic to a new file
    - The idea here is to encourage writing project-specific formatters, while keeping them very isolated from the main logic.
    - I want to allow [scripts like this](https://github.com/zeldaret/mm/blob/master/tools/overlayhelpers/colliderinit.py) to *optionally* be part of mips2c directly.
    - I'll bring this up on Discord. There's probably some API ideas to hash out too.

---

I want to try adding a test using the `elfdump` resource, but in the meantime here is a somewhat representative diff from MM's `ovl_Bg_Dblue_Elevator_0x80B91F20`:
```diff
-static s8 D_80B929E0;
+static s8 D_80B929E0[2] = {(u8)0, (u8)2};
 static ? D_80B929E3;
-static s8 D_80B929E4 = (u8)0; // array: [4]
+static s8 D_80B929E4[6] = {(u8)0, (u8)1, (u8)2, (u8)3, (u8)4, (u8)5};
 static ? D_80B929EA;
-static InitChainEntry D_80B929EC; // array: [5]
-static f32 D_80B92A08 = 0.001f; // const; array: [2]
+static InitChainEntry D_80B929EC[5];
```