### PR TITLE
Show code, if available, in `--visualize` flow graph

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -95,10 +95,6 @@ def run(options: Options) -> int:
     function_infos: List[Union[FunctionInfo, Exception]] = []
     for function in functions:
         try:
-            if options.visualize_flowgraph:
-                visualize_flowgraph(build_flowgraph(function, mips_file.asm_data))
-                continue
-
             info = translate_to_ast(function, options, global_info)
             function_infos.append(info)
         except Exception as e:
@@ -106,6 +102,10 @@ def run(options: Options) -> int:
             function_infos.append(e)
 
     if options.visualize_flowgraph:
+        fn_info = function_infos[0]
+        if isinstance(fn_info, Exception):
+            raise fn_info
+        visualize_flowgraph(fn_info.flow_graph)
         return 0
 
     fmt = options.formatter()


### PR DESCRIPTION
Small change!

Not sure if anyone had attachments to the previous flow graph format. If the blocks have not been translated, then it produces very similar output to the old format (except the nodes are rectangles with `// Node N`)

The code in the blocks is not perfect -- it's based solely on the steps from `translate_to_ast()` (before any `if_statements.py`). It still helps to get an approximation of what each branch represents though.

Here's an example from OOT's `ovl_En_Dekubaba/func_809E80D8.s` of what it looks like now - it's a bit easier to follow what's going on.

![graphviz_render gv](https://user-images.githubusercontent.com/113075/121816532-3abc5780-cc4a-11eb-9e25-ce9aba6264e1.png)
