### PR TITLE
3 cleanup tasks (flowgraph/tests)

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -182,7 +182,7 @@ def create_project_tests(
         if context_file is not None:
             flags.extend(["--context", str(context_file)])
 
-        # Guess the name of .data/.rodata file(s) for the OOT/MM decomp projects
+        # Guess the name of .data/.rodata file(s) for various decomp projects
         for candidate in [
             # mm code/*.asm
             "code_data_" + asm_name,
@@ -207,6 +207,14 @@ def create_project_tests(
             f = asm_file.parent / candidate
             if f.exists():
                 flags.extend(["--rodata", str(f)])
+        # papermario
+        papermario_data_path = Path(
+            str(asm_file).replace("/nonmatchings/", "/data/")
+        ).parent.parent
+        for f in papermario_data_path.glob("*.data.s"):
+            flags.extend(["--rodata", str(f)])
+        for f in papermario_data_path.glob("*.rodata.s"):
+            flags.extend(["--rodata", str(f)])
 
         test_path = asm_file.relative_to(asm_dir)
         name = f"{name_prefix}:{test_path}"

--- a/src/if_statements.py
+++ b/src/if_statements.py
@@ -329,7 +329,7 @@ def emit_goto_or_early_return(context: Context, target: Node, body: Body) -> Non
     """
     if isinstance(target, ReturnNode):
         emit_node(context, target, body)
-    else:
+    elif not isinstance(target, TerminalNode):
         emit_goto(context, target, body)
 
 

--- a/tests/end_to_end/andor_assignment/irix-o2-noandor-out.c
+++ b/tests/end_to_end/andor_assignment/irix-o2-noandor-out.c
@@ -29,37 +29,34 @@ s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
     sp2C = temp_t0;
     sp1C = temp_t7;
     phi_t1 = temp_t7;
-    if (temp_t0 == 0) {
-        phi_t1 = temp_t7;
-        if (temp_t7 == 0) {
-            sp20 = temp_t0;
-            temp_v0 = func_00400090(temp_t7);
-            phi_t1 = temp_v0;
-            if (temp_v0 == 0) {
-                phi_t1 = temp_v0;
-                if (arg3 != 0) {
-block_4:
-                    phi_v1 = 1;
-                } else {
-                    phi_t0 = temp_t0;
-                    phi_t1 = temp_v0;
-                    phi_v1 = -2;
-                    phi_a2 = arg2;
-                    if (arg0 != 0) {
-                        phi_t0 = temp_t0;
-                        phi_t1 = temp_v0;
-                        phi_v1 = -1;
-                        phi_a2 = arg2;
-                    }
-                }
-            } else {
-                goto block_4;
-            }
-        } else {
-            goto block_4;
-        }
-    } else {
+    if (temp_t0 != 0) {
         goto block_4;
+    }
+    phi_t1 = temp_t7;
+    if (temp_t7 != 0) {
+        goto block_4;
+    }
+    sp20 = temp_t0;
+    temp_v0 = func_00400090(temp_t7);
+    phi_t1 = temp_v0;
+    if (temp_v0 != 0) {
+        goto block_4;
+    }
+    phi_t1 = temp_v0;
+    if (arg3 != 0) {
+block_4:
+        phi_v1 = 1;
+    } else {
+        phi_t0 = temp_t0;
+        phi_t1 = temp_v0;
+        phi_v1 = -2;
+        phi_a2 = arg2;
+        if (arg0 != 0) {
+            phi_t0 = temp_t0;
+            phi_t1 = temp_v0;
+            phi_v1 = -1;
+            phi_a2 = arg2;
+        }
     }
     temp_v1 = phi_v1 + phi_a2;
     phi_t1_2 = phi_t1;
@@ -95,37 +92,34 @@ loop_12:
             }
         }
     }
-    if (sp2C != 0) {
-        temp_a0_2 = sp2C + phi_t1_2;
-        if (phi_t1_2 != 0) {
-            sp2C = temp_a0_2;
-            sp24 = phi_v1_3;
-            if (func_00400090(temp_a0_2) != 0) {
-                if (arg3 != 0) {
-                    phi_v1_4 = phi_v1_3;
-                    phi_v1_7 = phi_v1_3;
-                    if (phi_v1_3 < 5) {
-loop_19:
-                        temp_t9 = (phi_v1_4 + 1) * 2;
-                        phi_v1_4 = temp_t9;
-                        phi_v1_7 = temp_t9;
-                        if (temp_t9 < 5) {
-                            goto loop_19;
-                        }
-                    }
-                    phi_v1_5 = phi_v1_7 + 5;
-                } else {
-block_21:
-                    phi_v1_5 = phi_v1_3 + 6;
-                }
-            } else {
-                goto block_21;
-            }
-        } else {
-            goto block_21;
-        }
-    } else {
+    if (sp2C == 0) {
         goto block_21;
+    }
+    temp_a0_2 = sp2C + phi_t1_2;
+    if (phi_t1_2 == 0) {
+        goto block_21;
+    }
+    sp2C = temp_a0_2;
+    sp24 = phi_v1_3;
+    if (func_00400090(temp_a0_2) == 0) {
+        goto block_21;
+    }
+    if (arg3 != 0) {
+        phi_v1_4 = phi_v1_3;
+        phi_v1_7 = phi_v1_3;
+        if (phi_v1_3 < 5) {
+loop_19:
+            temp_t9 = (phi_v1_4 + 1) * 2;
+            phi_v1_4 = temp_t9;
+            phi_v1_7 = temp_t9;
+            if (temp_t9 < 5) {
+                goto loop_19;
+            }
+        }
+        phi_v1_5 = phi_v1_7 + 5;
+    } else {
+block_21:
+        phi_v1_5 = phi_v1_3 + 6;
     }
     return phi_v1_5;
 }

--- a/tests/end_to_end/andor_mixed/irix-g-out.c
+++ b/tests/end_to_end/andor_mixed/irix-g-out.c
@@ -6,17 +6,15 @@ s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
     spC = arg0 + arg1;
     sp8 = arg1 + arg2;
     sp4 = 0;
-    if (spC == 0) {
-        if ((sp8 == 0) || ((arg0 * arg1) == 0)) {
-            if ((arg3 != 0) && (arg0 != 0)) {
-block_5:
-                sp4 = arg0 + arg3;
-            }
-        } else {
-            goto block_5;
-        }
-    } else {
+    if (spC != 0) {
         goto block_5;
+    }
+    if (!((sp8 == 0) || ((arg0 * arg1) == 0))) {
+        goto block_5;
+    }
+    if ((arg3 != 0) && (arg0 != 0)) {
+block_5:
+        sp4 = arg0 + arg3;
     }
     return sp4;
 }

--- a/tests/end_to_end/andor_mixed/irix-o2-out.c
+++ b/tests/end_to_end/andor_mixed/irix-o2-out.c
@@ -1,21 +1,19 @@
 s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
     s32 phi_v1;
 
-    if ((arg0 + arg1) == 0) {
-        if (((arg1 + arg2) == 0) || ((arg0 * arg1) == 0)) {
-            phi_v1 = 0;
-            if (arg3 != 0) {
-                phi_v1 = 0;
-                if (arg0 != 0) {
-block_5:
-                    phi_v1 = arg0 + arg3;
-                }
-            }
-        } else {
-            goto block_5;
-        }
-    } else {
+    if ((arg0 + arg1) != 0) {
         goto block_5;
+    }
+    if (!(((arg1 + arg2) == 0) || ((arg0 * arg1) == 0))) {
+        goto block_5;
+    }
+    phi_v1 = 0;
+    if (arg3 != 0) {
+        phi_v1 = 0;
+        if (arg0 != 0) {
+block_5:
+            phi_v1 = arg0 + arg3;
+        }
     }
     return phi_v1;
 }

--- a/tests/end_to_end/andor_return/irix-g-out.c
+++ b/tests/end_to_end/andor_return/irix-g-out.c
@@ -1,10 +1,10 @@
 s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
-    if ((arg0 != 0) || (arg1 != 0)) {
-        if ((arg2 != 0) || (arg3 != 0)) {
-            return arg0 + arg1;
-        }
+    if (!((arg0 != 0) || (arg1 != 0))) {
+        // Duplicate return node #5. Try simplifying control flow for better match
         return arg2 + arg3;
     }
-    // Duplicate return node #5. Try simplifying control flow for better match
+    if ((arg2 != 0) || (arg3 != 0)) {
+        return arg0 + arg1;
+    }
     return arg2 + arg3;
 }

--- a/tests/end_to_end/andor_return/irix-o2-out.c
+++ b/tests/end_to_end/andor_return/irix-o2-out.c
@@ -1,10 +1,10 @@
 s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
-    if ((arg0 != 0) || (arg1 != 0)) {
-        if ((arg2 != 0) || (arg3 != 0)) {
-            return arg0 + arg1;
-        }
+    if (!((arg0 != 0) || (arg1 != 0))) {
+        // Duplicate return node #5. Try simplifying control flow for better match
         return arg2 + arg3;
     }
-    // Duplicate return node #5. Try simplifying control flow for better match
+    if ((arg2 != 0) || (arg3 != 0)) {
+        return arg0 + arg1;
+    }
     return arg2 + arg3;
 }

--- a/tests/end_to_end/doubles/irix-o2-mips1-out.c
+++ b/tests/end_to_end/doubles/irix-o2-mips1-out.c
@@ -2,12 +2,11 @@ f64 test(f64 arg0, s32 arg2, f64 arg4) {
     f64 temp_f0;
 
     temp_f0 = (((f64) arg2 * arg0) + (arg0 / arg4)) - 7.0;
-    if (!(temp_f0 < arg4)) {
-        if ((temp_f0 == arg4) || (temp_f0 > 9.0)) {
-block_4:
-        }
-    } else {
+    if (temp_f0 < arg4) {
         goto block_4;
+    }
+    if ((temp_f0 == arg4) || (temp_f0 > 9.0)) {
+block_4:
     }
     D_410150 = 0.0;
     return 0.0;

--- a/tests/end_to_end/loop/irix-o2-out.c
+++ b/tests/end_to_end/loop/irix-o2-out.c
@@ -14,39 +14,38 @@ s32 test(s8 *arg0, s32 arg1) {
     if (arg1 > 0) {
         temp_a3 = arg1 & 3;
         phi_v0_3 = 0;
-        if (temp_a3 != 0) {
-            phi_v1 = arg0;
-            phi_v0 = 0;
-loop_3:
-            temp_v0 = phi_v0 + 1;
-            *phi_v1 = (u8)0;
-            phi_v1 += 1;
-            phi_v0 = temp_v0;
-            if (temp_a3 != temp_v0) {
-                goto loop_3;
-            }
-            phi_return = temp_v0;
-            phi_v0_3 = temp_v0;
-            if (temp_v0 != arg1) {
-block_5:
-                phi_v1_2 = arg0 + phi_v0_3;
-                phi_v0_2 = phi_v0_3;
-loop_6:
-                temp_v0_2 = phi_v0_2 + 4;
-                phi_v1_2->unk1 = (u8)0;
-                phi_v1_2->unk2 = (u8)0;
-                phi_v1_2->unk3 = (u8)0;
-                temp_v1 = phi_v1_2 + 4;
-                temp_v1->unk-4 = (u8)0;
-                phi_v1_2 = temp_v1;
-                phi_v0_2 = temp_v0_2;
-                phi_return = temp_v0_2;
-                if (temp_v0_2 != arg1) {
-                    goto loop_6;
-                }
-            }
-        } else {
+        if (temp_a3 == 0) {
             goto block_5;
+        }
+        phi_v1 = arg0;
+        phi_v0 = 0;
+loop_3:
+        temp_v0 = phi_v0 + 1;
+        *phi_v1 = (u8)0;
+        phi_v1 += 1;
+        phi_v0 = temp_v0;
+        if (temp_a3 != temp_v0) {
+            goto loop_3;
+        }
+        phi_return = temp_v0;
+        phi_v0_3 = temp_v0;
+        if (temp_v0 != arg1) {
+block_5:
+            phi_v1_2 = arg0 + phi_v0_3;
+            phi_v0_2 = phi_v0_3;
+loop_6:
+            temp_v0_2 = phi_v0_2 + 4;
+            phi_v1_2->unk1 = (u8)0;
+            phi_v1_2->unk2 = (u8)0;
+            phi_v1_2->unk3 = (u8)0;
+            temp_v1 = phi_v1_2 + 4;
+            temp_v1->unk-4 = (u8)0;
+            phi_v1_2 = temp_v1;
+            phi_v0_2 = temp_v0_2;
+            phi_return = temp_v0_2;
+            if (temp_v0_2 != arg1) {
+                goto loop_6;
+            }
         }
     }
     return phi_return;

--- a/tests/end_to_end/loop_nested/irix-o2-out.c
+++ b/tests/end_to_end/loop_nested/irix-o2-out.c
@@ -29,44 +29,43 @@ loop_1:
             temp_t1 = arg0 & 3;
             phi_a1_2 = 0;
             phi_v1_5 = phi_v1_3;
-            if (temp_t1 != 0) {
-                phi_a3 = 1;
-                phi_v1_4 = phi_v1_3;
-                phi_a2 = phi_v0 * 0;
-loop_4:
-                temp_v1 = phi_v1_4 + phi_a2;
-                phi_a3 += 1;
-                phi_v1_4 = temp_v1;
-                phi_a2 += phi_v0;
-                if (temp_t1 != phi_a3) {
-                    goto loop_4;
-                }
-                phi_a1_2 = phi_a3;
-                phi_v1_2 = temp_v1;
-                phi_v1_5 = temp_v1;
-                if (phi_a3 != arg0) {
-block_6:
-                    phi_a1 = phi_a1_2;
-                    phi_a2_2 = phi_v0 * phi_a1_2;
-                    phi_a3_2 = phi_v0 * (phi_a1_2 + 1);
-                    phi_t0 = phi_v0 * (phi_a1_2 + 2);
-                    phi_t1 = phi_v0 * (phi_a1_2 + 3);
-loop_7:
-                    temp_v1_2 = phi_v1_5 + phi_a2_2 + phi_a3_2 + phi_t0 + phi_t1;
-                    temp_a1 = phi_a1 + 4;
-                    phi_a1 = temp_a1;
-                    phi_v1_2 = temp_v1_2;
-                    phi_v1_5 = temp_v1_2;
-                    phi_a2_2 += phi_v0 * 4;
-                    phi_a3_2 += phi_v0 * 4;
-                    phi_t0 += phi_v0 * 4;
-                    phi_t1 += phi_v0 * 4;
-                    if (temp_a1 != arg0) {
-                        goto loop_7;
-                    }
-                }
-            } else {
+            if (temp_t1 == 0) {
                 goto block_6;
+            }
+            phi_a3 = 1;
+            phi_v1_4 = phi_v1_3;
+            phi_a2 = phi_v0 * 0;
+loop_4:
+            temp_v1 = phi_v1_4 + phi_a2;
+            phi_a3 += 1;
+            phi_v1_4 = temp_v1;
+            phi_a2 += phi_v0;
+            if (temp_t1 != phi_a3) {
+                goto loop_4;
+            }
+            phi_a1_2 = phi_a3;
+            phi_v1_2 = temp_v1;
+            phi_v1_5 = temp_v1;
+            if (phi_a3 != arg0) {
+block_6:
+                phi_a1 = phi_a1_2;
+                phi_a2_2 = phi_v0 * phi_a1_2;
+                phi_a3_2 = phi_v0 * (phi_a1_2 + 1);
+                phi_t0 = phi_v0 * (phi_a1_2 + 2);
+                phi_t1 = phi_v0 * (phi_a1_2 + 3);
+loop_7:
+                temp_v1_2 = phi_v1_5 + phi_a2_2 + phi_a3_2 + phi_t0 + phi_t1;
+                temp_a1 = phi_a1 + 4;
+                phi_a1 = temp_a1;
+                phi_v1_2 = temp_v1_2;
+                phi_v1_5 = temp_v1_2;
+                phi_a2_2 += phi_v0 * 4;
+                phi_a3_2 += phi_v0 * 4;
+                phi_t0 += phi_v0 * 4;
+                phi_t1 += phi_v0 * 4;
+                if (temp_a1 != arg0) {
+                    goto loop_7;
+                }
             }
         }
         temp_v0 = phi_v0 + 1;

--- a/tests/end_to_end/loop_nested/irix-o2-out.c
+++ b/tests/end_to_end/loop_nested/irix-o2-out.c
@@ -11,53 +11,53 @@ s32 test(s32 arg0) {
     s32 phi_a1_2;
     s32 phi_v1_2;
     s32 phi_v1_3;
+    s32 phi_v1_4;
     s32 phi_a2;
+    s32 phi_v1_5;
+    s32 phi_a2_2;
     s32 phi_a3_2;
     s32 phi_t0;
     s32 phi_t1;
-    s32 phi_v1_4;
-    s32 phi_a2_2;
-    s32 phi_v1_5;
 
     phi_v0 = 0;
     phi_v1 = 0;
-    phi_v1_5 = 0;
+    phi_v1_3 = 0;
     if (arg0 > 0) {
 loop_1:
-        phi_v1_2 = phi_v1_5;
+        phi_v1_2 = phi_v1_3;
         if (arg0 > 0) {
             temp_t1 = arg0 & 3;
             phi_a1_2 = 0;
-            phi_v1_3 = phi_v1_5;
+            phi_v1_5 = phi_v1_3;
             if (temp_t1 != 0) {
                 phi_a3 = 1;
-                phi_v1_4 = phi_v1_5;
-                phi_a2_2 = phi_v0 * 0;
+                phi_v1_4 = phi_v1_3;
+                phi_a2 = phi_v0 * 0;
 loop_4:
-                temp_v1 = phi_v1_4 + phi_a2_2;
+                temp_v1 = phi_v1_4 + phi_a2;
                 phi_a3 += 1;
                 phi_v1_4 = temp_v1;
-                phi_a2_2 += phi_v0;
+                phi_a2 += phi_v0;
                 if (temp_t1 != phi_a3) {
                     goto loop_4;
                 }
                 phi_a1_2 = phi_a3;
                 phi_v1_2 = temp_v1;
-                phi_v1_3 = temp_v1;
+                phi_v1_5 = temp_v1;
                 if (phi_a3 != arg0) {
 block_6:
                     phi_a1 = phi_a1_2;
-                    phi_a2 = phi_v0 * phi_a1_2;
+                    phi_a2_2 = phi_v0 * phi_a1_2;
                     phi_a3_2 = phi_v0 * (phi_a1_2 + 1);
                     phi_t0 = phi_v0 * (phi_a1_2 + 2);
                     phi_t1 = phi_v0 * (phi_a1_2 + 3);
 loop_7:
-                    temp_v1_2 = phi_v1_3 + phi_a2 + phi_a3_2 + phi_t0 + phi_t1;
+                    temp_v1_2 = phi_v1_5 + phi_a2_2 + phi_a3_2 + phi_t0 + phi_t1;
                     temp_a1 = phi_a1 + 4;
                     phi_a1 = temp_a1;
                     phi_v1_2 = temp_v1_2;
-                    phi_v1_3 = temp_v1_2;
-                    phi_a2 += phi_v0 * 4;
+                    phi_v1_5 = temp_v1_2;
+                    phi_a2_2 += phi_v0 * 4;
                     phi_a3_2 += phi_v0 * 4;
                     phi_t0 += phi_v0 * 4;
                     phi_t1 += phi_v0 * 4;
@@ -72,7 +72,7 @@ loop_7:
         temp_v0 = phi_v0 + 1;
         phi_v0 = temp_v0;
         phi_v1 = phi_v1_2;
-        phi_v1_5 = phi_v1_2;
+        phi_v1_3 = phi_v1_2;
         if (temp_v0 != arg0) {
             goto loop_1;
         }

--- a/tests/end_to_end/multi-switch/irix-o2-out.c
+++ b/tests/end_to_end/multi-switch/irix-o2-out.c
@@ -12,10 +12,10 @@ s32 test(s32 arg0) {
         if (arg0 >= 0x6C) {
             phi_a0_2 = arg0;
             if (arg0 != 0xC8) {
-                phi_a0_3 = arg0;
+                phi_a0_4 = arg0;
             default: // switch 2
 block_23:
-                phi_a0 = phi_a0_3 / 2;
+                phi_a0 = phi_a0_4 / 2;
                 D_410210 = phi_a0;
                 return 2;
             }
@@ -23,19 +23,19 @@ block_23:
         case 2: // switch 2
             return (phi_a0_2 + 1) ^ phi_a0_2;
         }
-        phi_a0_3 = arg0;
+        phi_a0_4 = arg0;
         if (temp_t6 < 7U) {
             phi_a0_2 = arg0;
-            phi_a0_4 = arg0;
+            phi_a0_3 = arg0;
             phi_a0_5 = arg0;
             goto **(&jtbl_4001D0 + (temp_t6 * 4)); // switch 1
         case 1: // switch 1
 block_21:
-            phi_a0 = phi_a0_4;
-            phi_a0_5 = phi_a0_4;
+            phi_a0 = phi_a0_3;
+            phi_a0_5 = phi_a0_3;
             if (D_410210 == 0) {
             default: // switch 1
-                phi_a0_3 = phi_a0_5 - 1;
+                phi_a0_4 = phi_a0_5 - 1;
                 goto block_23;
             }
             // Duplicate return node #24. Try simplifying control flow for better match
@@ -52,7 +52,7 @@ block_21:
     } else {
         if (arg0 >= 8) {
             if (arg0 != 0x32) {
-                phi_a0_3 = arg0;
+                phi_a0_4 = arg0;
                 goto block_23;
             }
             phi_a0 = arg0 + 1;
@@ -62,10 +62,10 @@ block_21:
         }
         temp_t7 = arg0 - 1;
         if (arg0 >= -0x31) {
-            phi_a0_3 = arg0;
+            phi_a0_4 = arg0;
             if (temp_t7 < 7U) {
                 phi_a0_2 = arg0;
-                phi_a0_3 = arg0;
+                phi_a0_4 = arg0;
                 goto **(&jtbl_4001EC + (temp_t7 * 4)); // switch 2
             case 0: // switch 2
                 return arg0 * arg0;
@@ -75,14 +75,14 @@ block_21:
                 return (phi_a0_2 + 1) ^ phi_a0_2;
             case 5: // switch 2
             case 6: // switch 2
-                phi_a0_4 = arg0 * 2;
+                phi_a0_3 = arg0 * 2;
                 goto block_21;
             } else {
                 goto block_23;
             }
         } else {
             if (arg0 != -0x32) {
-                phi_a0_3 = arg0;
+                phi_a0_4 = arg0;
                 goto block_23;
             }
             phi_a0 = arg0 - 1;

--- a/tests/end_to_end/multi-switch/irix-o2-out.c
+++ b/tests/end_to_end/multi-switch/irix-o2-out.c
@@ -60,7 +60,25 @@ block_21:
         return 2;
     } else {
         temp_t7 = arg0 - 1;
-        if (arg0 < -0x31) {
+        if (arg0 >= -0x31) {
+            phi_a0_4 = arg0;
+            if (temp_t7 >= 7U) {
+                goto block_23;
+            }
+            phi_a0_2 = arg0;
+            phi_a0_4 = arg0;
+            goto **(&jtbl_4001EC + (temp_t7 * 4)); // switch 2
+        case 0: // switch 2
+            return arg0 * arg0;
+        case 1: // switch 2
+            phi_a0_2 = arg0 - 1;
+            // Duplicate return node #16. Try simplifying control flow for better match
+            return (phi_a0_2 + 1) ^ phi_a0_2;
+        case 5: // switch 2
+        case 6: // switch 2
+            phi_a0_3 = arg0 * 2;
+            goto block_21;
+        } else {
             if (arg0 != -0x32) {
                 phi_a0_4 = arg0;
                 goto block_23;
@@ -70,22 +88,5 @@ block_21:
             D_410210 = phi_a0;
             return 2;
         }
-        phi_a0_4 = arg0;
-        if (temp_t7 >= 7U) {
-            goto block_23;
-        }
-        phi_a0_2 = arg0;
-        phi_a0_4 = arg0;
-        goto **(&jtbl_4001EC + (temp_t7 * 4)); // switch 2
-    case 0: // switch 2
-        return arg0 * arg0;
-    case 1: // switch 2
-        phi_a0_2 = arg0 - 1;
-        // Duplicate return node #16. Try simplifying control flow for better match
-        return (phi_a0_2 + 1) ^ phi_a0_2;
-    case 5: // switch 2
-    case 6: // switch 2
-        phi_a0_3 = arg0 * 2;
-        goto block_21;
     }
 }

--- a/tests/end_to_end/multi-switch/irix-o2-out.c
+++ b/tests/end_to_end/multi-switch/irix-o2-out.c
@@ -22,9 +22,11 @@ block_23:
         case 0: // switch 1
         case 2: // switch 2
             return (phi_a0_2 + 1) ^ phi_a0_2;
-        }
-        phi_a0_4 = arg0;
-        if (temp_t6 < 7U) {
+        } else {
+            phi_a0_4 = arg0;
+            if (temp_t6 >= 7U) {
+                goto block_23;
+            }
             phi_a0_2 = arg0;
             phi_a0_3 = arg0;
             phi_a0_5 = arg0;
@@ -46,41 +48,19 @@ block_21:
             // Duplicate return node #24. Try simplifying control flow for better match
             D_410210 = phi_a0;
             return 2;
-        } else {
+        }
+    } else if (arg0 >= 8) {
+        if (arg0 != 0x32) {
+            phi_a0_4 = arg0;
             goto block_23;
         }
+        phi_a0 = arg0 + 1;
+        // Duplicate return node #24. Try simplifying control flow for better match
+        D_410210 = phi_a0;
+        return 2;
     } else {
-        if (arg0 >= 8) {
-            if (arg0 != 0x32) {
-                phi_a0_4 = arg0;
-                goto block_23;
-            }
-            phi_a0 = arg0 + 1;
-            // Duplicate return node #24. Try simplifying control flow for better match
-            D_410210 = phi_a0;
-            return 2;
-        }
         temp_t7 = arg0 - 1;
-        if (arg0 >= -0x31) {
-            phi_a0_4 = arg0;
-            if (temp_t7 < 7U) {
-                phi_a0_2 = arg0;
-                phi_a0_4 = arg0;
-                goto **(&jtbl_4001EC + (temp_t7 * 4)); // switch 2
-            case 0: // switch 2
-                return arg0 * arg0;
-            case 1: // switch 2
-                phi_a0_2 = arg0 - 1;
-                // Duplicate return node #16. Try simplifying control flow for better match
-                return (phi_a0_2 + 1) ^ phi_a0_2;
-            case 5: // switch 2
-            case 6: // switch 2
-                phi_a0_3 = arg0 * 2;
-                goto block_21;
-            } else {
-                goto block_23;
-            }
-        } else {
+        if (arg0 < -0x31) {
             if (arg0 != -0x32) {
                 phi_a0_4 = arg0;
                 goto block_23;
@@ -90,5 +70,22 @@ block_21:
             D_410210 = phi_a0;
             return 2;
         }
+        phi_a0_4 = arg0;
+        if (temp_t7 >= 7U) {
+            goto block_23;
+        }
+        phi_a0_2 = arg0;
+        phi_a0_4 = arg0;
+        goto **(&jtbl_4001EC + (temp_t7 * 4)); // switch 2
+    case 0: // switch 2
+        return arg0 * arg0;
+    case 1: // switch 2
+        phi_a0_2 = arg0 - 1;
+        // Duplicate return node #16. Try simplifying control flow for better match
+        return (phi_a0_2 + 1) ^ phi_a0_2;
+    case 5: // switch 2
+    case 6: // switch 2
+        phi_a0_3 = arg0 * 2;
+        goto block_21;
     }
 }

--- a/tests/end_to_end/nested_ifs/irix-o2-out.c
+++ b/tests/end_to_end/nested_ifs/irix-o2-out.c
@@ -4,12 +4,12 @@ void test(s32 arg0) {
     temp_a1 = arg0;
     if (arg0 == 7) {
         func_004000F0(1, temp_a1);
-        return;
+    } else {
+        arg0 = temp_a1;
+        func_004000F0(2, temp_a1);
+        if (arg0 == 8) {
+            func_004000F0(3, arg0);
+        }
+        func_004000F0(4);
     }
-    arg0 = temp_a1;
-    func_004000F0(2, temp_a1);
-    if (arg0 == 8) {
-        func_004000F0(3, arg0);
-    }
-    func_004000F0(4);
 }

--- a/tests/end_to_end/nested_ifs2/irix-o2-out.c
+++ b/tests/end_to_end/nested_ifs2/irix-o2-out.c
@@ -9,7 +9,7 @@ void test(s32 arg0) {
             func_004000F0(2, arg0);
         }
         func_004000F0(3);
-        return;
+    } else {
+        func_004000F0(4, temp_a1);
     }
-    func_004000F0(4, temp_a1);
 }

--- a/tests/end_to_end/nested_ifs3/irix-o2-out.c
+++ b/tests/end_to_end/nested_ifs3/irix-o2-out.c
@@ -9,12 +9,12 @@ void test(s32 arg0) {
             func_00400114(2, arg0);
         }
         func_00400114(3);
-        return;
+    } else {
+        arg0 = temp_a1;
+        func_00400114(4, temp_a1);
+        if (arg0 == 9) {
+            func_00400114(5, arg0);
+        }
+        func_00400114(6);
     }
-    arg0 = temp_a1;
-    func_00400114(4, temp_a1);
-    if (arg0 == 9) {
-        func_00400114(5, arg0);
-    }
-    func_00400114(6);
 }

--- a/tests/end_to_end/nested_ifs4/irix-g-out.c
+++ b/tests/end_to_end/nested_ifs4/irix-g-out.c
@@ -5,11 +5,11 @@ void test(s32 arg0) {
             func_0040012C(2);
         }
         func_0040012C(3);
-        return;
+    } else {
+        func_0040012C(4);
+        if (arg0 == 9) {
+            func_0040012C(5);
+        }
+        func_0040012C(6);
     }
-    func_0040012C(4);
-    if (arg0 == 9) {
-        func_0040012C(5);
-    }
-    func_0040012C(6);
 }

--- a/tests/end_to_end/nested_ifs4/irix-o2-out.c
+++ b/tests/end_to_end/nested_ifs4/irix-o2-out.c
@@ -9,12 +9,12 @@ void test(s32 arg0) {
             func_00400114(2, arg0);
         }
         func_00400114(3);
-        return;
+    } else {
+        arg0 = temp_a1;
+        func_00400114(4, temp_a1);
+        if (arg0 == 9) {
+            func_00400114(5, arg0);
+        }
+        func_00400114(6);
     }
-    arg0 = temp_a1;
-    func_00400114(4, temp_a1);
-    if (arg0 == 9) {
-        func_00400114(5, arg0);
-    }
-    func_00400114(6);
 }

--- a/tests/end_to_end/switch-with-if/irix-o2-out.c
+++ b/tests/end_to_end/switch-with-if/irix-o2-out.c
@@ -21,7 +21,9 @@ void test(s32 arg0) {
     }
 block_7:
     temp_t1 = arg0 - 1;
-    if (temp_t1 < 6U) {
+    if (temp_t1 >= 6U) {
+        // Duplicate return node #14. Try simplifying control flow for better match
+    } else {
         goto **(&jtbl_4001B8 + (temp_t1 * 4)); // switch 2
     case 0: // switch 2
         D_4101D0 = 1;
@@ -38,7 +40,5 @@ block_7:
         D_4101D0 = 2;
         // Duplicate return node #14. Try simplifying control flow for better match
         return;
-    } else {
-        // Duplicate return node #14. Try simplifying control flow for better match
     }
 }

--- a/tests/end_to_end/switch/irix-g-out.c
+++ b/tests/end_to_end/switch/irix-g-out.c
@@ -4,31 +4,30 @@ s32 test(s32 arg0) {
     s32 phi_a0_2;
 
     temp_t6 = arg0 - 1;
-    if (temp_t6 < 7U) {
-        phi_a0_2 = arg0;
-        goto **(&jtbl_400150 + (temp_t6 * 4));
-    case 0:
-        return arg0 * arg0;
-    case 1:
-        phi_a0_2 = arg0 - 1;
-    case 2:
-        return phi_a0_2 * 2;
-    case 3:
-        phi_a0 = arg0 + 1;
-        D_410170 = phi_a0;
-        return 2;
-    case 4:
-block_7:
-        phi_a0 = arg0 / 2;
-        // Duplicate return node #8. Try simplifying control flow for better match
-        D_410170 = phi_a0;
-        return 2;
-    default:
-        phi_a0 = arg0 * 2;
-        // Duplicate return node #8. Try simplifying control flow for better match
-        D_410170 = phi_a0;
-        return 2;
-    } else {
+    if (temp_t6 >= 7U) {
         goto block_7;
     }
+    phi_a0_2 = arg0;
+    goto **(&jtbl_400150 + (temp_t6 * 4));
+case 0:
+    return arg0 * arg0;
+case 1:
+    phi_a0_2 = arg0 - 1;
+case 2:
+    return phi_a0_2 * 2;
+case 3:
+    phi_a0 = arg0 + 1;
+    D_410170 = phi_a0;
+    return 2;
+case 4:
+block_7:
+    phi_a0 = arg0 / 2;
+    // Duplicate return node #8. Try simplifying control flow for better match
+    D_410170 = phi_a0;
+    return 2;
+default:
+    phi_a0 = arg0 * 2;
+    // Duplicate return node #8. Try simplifying control flow for better match
+    D_410170 = phi_a0;
+    return 2;
 }

--- a/tests/end_to_end/switch/irix-o2-andor-out.c
+++ b/tests/end_to_end/switch/irix-o2-andor-out.c
@@ -4,31 +4,30 @@ s32 test(s32 arg0) {
     s32 phi_a0_2;
 
     temp_t6 = arg0 - 1;
-    if (temp_t6 < 7U) {
-        phi_a0_2 = arg0;
-        goto **(&jtbl_400130 + (temp_t6 * 4));
-    case 0:
-        return arg0 * arg0;
-    case 1:
-        phi_a0_2 = arg0 - 1;
-    case 2:
-        return phi_a0_2 * 2;
-    case 3:
-        phi_a0 = arg0 + 1;
-        D_410150 = phi_a0;
-        return 2;
-    case 4:
-block_7:
-        phi_a0 = arg0 / 2;
-        // Duplicate return node #8. Try simplifying control flow for better match
-        D_410150 = phi_a0;
-        return 2;
-    default:
-        phi_a0 = arg0 * 2;
-        // Duplicate return node #8. Try simplifying control flow for better match
-        D_410150 = phi_a0;
-        return 2;
-    } else {
+    if (temp_t6 >= 7U) {
         goto block_7;
     }
+    phi_a0_2 = arg0;
+    goto **(&jtbl_400130 + (temp_t6 * 4));
+case 0:
+    return arg0 * arg0;
+case 1:
+    phi_a0_2 = arg0 - 1;
+case 2:
+    return phi_a0_2 * 2;
+case 3:
+    phi_a0 = arg0 + 1;
+    D_410150 = phi_a0;
+    return 2;
+case 4:
+block_7:
+    phi_a0 = arg0 / 2;
+    // Duplicate return node #8. Try simplifying control flow for better match
+    D_410150 = phi_a0;
+    return 2;
+default:
+    phi_a0 = arg0 * 2;
+    // Duplicate return node #8. Try simplifying control flow for better match
+    D_410150 = phi_a0;
+    return 2;
 }

--- a/tests/end_to_end/switch/irix-o2-out.c
+++ b/tests/end_to_end/switch/irix-o2-out.c
@@ -4,31 +4,30 @@ s32 test(s32 arg0) {
     s32 phi_a0_2;
 
     temp_t6 = arg0 - 1;
-    if (temp_t6 < 7U) {
-        phi_a0_2 = arg0;
-        goto **(&jpt_400130 + (temp_t6 * 4));
-    case 0:
-        return arg0 * arg0;
-    case 1:
-        phi_a0_2 = arg0 - 1;
-    case 2:
-        return phi_a0_2 * 2;
-    case 3:
-        phi_a0 = arg0 + 1;
-        D_410150 = phi_a0;
-        return 2;
-    case 4:
-block_7:
-        phi_a0 = arg0 / 2;
-        // Duplicate return node #8. Try simplifying control flow for better match
-        D_410150 = phi_a0;
-        return 2;
-    default:
-        phi_a0 = arg0 * 2;
-        // Duplicate return node #8. Try simplifying control flow for better match
-        D_410150 = phi_a0;
-        return 2;
-    } else {
+    if (temp_t6 >= 7U) {
         goto block_7;
     }
+    phi_a0_2 = arg0;
+    goto **(&jpt_400130 + (temp_t6 * 4));
+case 0:
+    return arg0 * arg0;
+case 1:
+    phi_a0_2 = arg0 - 1;
+case 2:
+    return phi_a0_2 * 2;
+case 3:
+    phi_a0 = arg0 + 1;
+    D_410150 = phi_a0;
+    return 2;
+case 4:
+block_7:
+    phi_a0 = arg0 / 2;
+    // Duplicate return node #8. Try simplifying control flow for better match
+    D_410150 = phi_a0;
+    return 2;
+default:
+    phi_a0 = arg0 * 2;
+    // Duplicate return node #8. Try simplifying control flow for better match
+    D_410150 = phi_a0;
+    return 2;
 }


### PR DESCRIPTION
In order by commits. The tests were re-blessed after each change, so you can see the results of each code change.

- Fix `run_tests.py` to find rodata/data for Paper Mario
    - Now papermario tests pass that depend on rodata, like `func_8013AA9C`, don't error out. (This doesn't show up in the repo though)
- `if (A) { B; } else { goto C; }` --> `if (!A) { goto C; } B;`
    - Could be `goto C;` or `return C;` -- as long as the body ends in a jump.
    - Output structure changes in some cases; `B` clause unindented by one.
    - The `andor-mixed` test (and `render_models` in Paper Mario) have (imo) more readable flow with `if (...) { goto ...; }` up front. The `goto`s are all now _forward_ jumps in the C source.
    - I pushed some logic out of `Body.add_if_else()` into `IfElseStatement.format()` because it requires the body to be built: the checks for the `sub_if` work "outside-in" so the outermost `IfElseStatement` needs to be built & processed first.
         - One minor downside is that now this logic comes *after* `elide_empty_returns()` is applied -- but I think this isn't too bad in practice.
- In `flow_graph.py`, calculate `BaseNode.parents` from `.children()` and remove `.add_parent()`
    - Assignment of phis depended on the order of `.parents`, so some suffixes got swapped around in the test outputs (e.g. `phi_a0_3`/`phi_a0_4`)
    - The `.parents` list is now sorted, which should make it more robust to future changes