### PR TITLE
Prevent `Type.unify()` from recursing forever

### DIFF
--- a/tests/end_to_end/recursive-type/irix-g-out.c
+++ b/tests/end_to_end/recursive-type/irix-g-out.c
@@ -1,0 +1,1 @@
+CRASHED

--- a/tests/end_to_end/recursive-type/irix-g-out.c
+++ b/tests/end_to_end/recursive-type/irix-g-out.c
@@ -1,1 +1,7 @@
-CRASHED
+void test(? *arg0, ? *arg1) {
+    arg0 = &arg0;
+    arg1 = &arg1;
+    func_00400090(arg0, arg1);
+    arg0 = (? *) arg1;
+    func_00400090(arg0, arg1);
+}

--- a/tests/end_to_end/recursive-type/irix-g.s
+++ b/tests/end_to_end/recursive-type/irix-g.s
@@ -1,0 +1,37 @@
+.set noat      # allow manual use of $at
+.set noreorder # don't insert nops after branches
+
+
+glabel func_00400090
+/* 000090 00400090 8CAE0000 */  lw    $t6, ($a1)
+/* 000094 00400094 AC8E0000 */  sw    $t6, ($a0)
+/* 000098 00400098 03E00008 */  jr    $ra
+/* 00009C 0040009C 00000000 */   nop
+
+/* 0000A0 004000A0 03E00008 */  jr    $ra
+/* 0000A4 004000A4 00000000 */   nop
+
+glabel test
+/* 0000A8 004000A8 27BDFFE8 */  addiu $sp, $sp, -0x18
+/* 0000AC 004000AC AFBF0014 */  sw    $ra, 0x14($sp)
+/* 0000B0 004000B0 AFA40018 */  sw    $a0, 0x18($sp)
+/* 0000B4 004000B4 AFA5001C */  sw    $a1, 0x1c($sp)
+/* 0000B8 004000B8 27AE0018 */  addiu $t6, $sp, 0x18
+/* 0000BC 004000BC AFAE0018 */  sw    $t6, 0x18($sp)
+/* 0000C0 004000C0 27AF001C */  addiu $t7, $sp, 0x1c
+/* 0000C4 004000C4 AFAF001C */  sw    $t7, 0x1c($sp)
+/* 0000C8 004000C8 8FA40018 */  lw    $a0, 0x18($sp)
+/* 0000CC 004000CC 0C100024 */  jal   func_00400090
+/* 0000D0 004000D0 8FA5001C */   lw    $a1, 0x1c($sp)
+/* 0000D4 004000D4 8FB8001C */  lw    $t8, 0x1c($sp)
+/* 0000D8 004000D8 AFB80018 */  sw    $t8, 0x18($sp)
+/* 0000DC 004000DC 8FA40018 */  lw    $a0, 0x18($sp)
+/* 0000E0 004000E0 0C100024 */  jal   func_00400090
+/* 0000E4 004000E4 8FA5001C */   lw    $a1, 0x1c($sp)
+/* 0000E8 004000E8 10000001 */  b     .L004000F0
+/* 0000EC 004000EC 00000000 */   nop
+.L004000F0:
+/* 0000F0 004000F0 8FBF0014 */  lw    $ra, 0x14($sp)
+/* 0000F4 004000F4 27BD0018 */  addiu $sp, $sp, 0x18
+/* 0000F8 004000F8 03E00008 */  jr    $ra
+/* 0000FC 004000FC 00000000 */   nop

--- a/tests/end_to_end/recursive-type/irix-o2-out.c
+++ b/tests/end_to_end/recursive-type/irix-o2-out.c
@@ -1,0 +1,1 @@
+CRASHED

--- a/tests/end_to_end/recursive-type/irix-o2-out.c
+++ b/tests/end_to_end/recursive-type/irix-o2-out.c
@@ -1,1 +1,12 @@
-CRASHED
+void test(? *arg0, ? *arg1) {
+    ? *temp_a0;
+    ? *temp_a1;
+
+    temp_a1 = &arg1;
+    temp_a0 = &arg0;
+    arg0 = temp_a0;
+    arg1 = temp_a1;
+    func_00400090(temp_a0, temp_a1);
+    arg0 = (? *) arg1;
+    func_00400090((? *) arg1, arg1);
+}

--- a/tests/end_to_end/recursive-type/irix-o2.s
+++ b/tests/end_to_end/recursive-type/irix-o2.s
@@ -1,0 +1,27 @@
+.set noat      # allow manual use of $at
+.set noreorder # don't insert nops after branches
+
+
+glabel func_00400090
+/* 000090 00400090 8CAE0000 */  lw    $t6, ($a1)
+/* 000094 00400094 03E00008 */  jr    $ra
+/* 000098 00400098 AC8E0000 */   sw    $t6, ($a0)
+
+glabel test
+/* 00009C 0040009C 27BDFFE8 */  addiu $sp, $sp, -0x18
+/* 0000A0 004000A0 AFA40018 */  sw    $a0, 0x18($sp)
+/* 0000A4 004000A4 AFA5001C */  sw    $a1, 0x1c($sp)
+/* 0000A8 004000A8 27A5001C */  addiu $a1, $sp, 0x1c
+/* 0000AC 004000AC 27A40018 */  addiu $a0, $sp, 0x18
+/* 0000B0 004000B0 AFBF0014 */  sw    $ra, 0x14($sp)
+/* 0000B4 004000B4 AFA40018 */  sw    $a0, 0x18($sp)
+/* 0000B8 004000B8 0C100024 */  jal   func_00400090
+/* 0000BC 004000BC AFA5001C */   sw    $a1, 0x1c($sp)
+/* 0000C0 004000C0 8FA5001C */  lw    $a1, 0x1c($sp)
+/* 0000C4 004000C4 AFA50018 */  sw    $a1, 0x18($sp)
+/* 0000C8 004000C8 0C100024 */  jal   func_00400090
+/* 0000CC 004000CC 00A02025 */   move  $a0, $a1
+/* 0000D0 004000D0 8FBF0014 */  lw    $ra, 0x14($sp)
+/* 0000D4 004000D4 27BD0018 */  addiu $sp, $sp, 0x18
+/* 0000D8 004000D8 03E00008 */  jr    $ra
+/* 0000DC 004000DC 00000000 */   nop

--- a/tests/end_to_end/recursive-type/orig.c
+++ b/tests/end_to_end/recursive-type/orig.c
@@ -1,0 +1,12 @@
+void foo(void **a, void **b) {
+    *a = *b;
+}
+
+void test(void *a, void *b) {
+    a = &a;
+    b = &b;
+
+    foo(a, b);
+    a = b;
+    foo(a, b);
+}


### PR DESCRIPTION
Fixes #81 and [Trello](https://trello.com/c/Z8ZhygMP/51-type-unification-can-recurse-forever).

The motivation for fixing this was the IDO recomp project, trying to run `./mips_to_c.py` on `uopt.s` from that lead to a *bunch* of these errors. After this PR IDO's `uopt.s` decompiles without `RecursionError` -- it only has 4 errors over the whole file.

Between the other projects (OOT, MM, PM), the only file that hit a `RecursionError` was MM's `boot/fault.asm` when run without context.

I made `Type.unify()` just give up if it detects any amount of recursion. In theory, there may be certain cases where it *could* succeed? 
I could forsee needing a more robust solution if we implemented "pure" `Type` representations of structs: but for now, recursive structs like `struct foo { struct foo * x; }` are all handled by the `CType` machinery. 

I ran this change against all of (OOT, MM, PM) with & without context, [the output is here](https://gist.github.com/zbanks/b56c6eb15cdac74ae0751f96ce7a5fef). Most of the diffs were in files without context, where mips2c had inferred some really wacky types. This diff leads to some `? *` -> `void *` or `void **`. 