### PR TITLE
Support for "left-style" pointers with new --pointer-style option

### DIFF
--- a/src/flow_graph.py
+++ b/src/flow_graph.py
@@ -785,6 +785,10 @@ class BaseNode(abc.ABC):
     def children(self) -> List["Node"]:
         ...
 
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        ...
+
 
 @attr.s(eq=False)
 class BasicNode(BaseNode):
@@ -794,7 +798,7 @@ class BasicNode(BaseNode):
         # TODO: Should we also include the fallthrough node if `emit_goto` is True?
         return [self.successor]
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         return "".join(
             [
                 f"{self.block}\n",
@@ -815,7 +819,7 @@ class ConditionalNode(BaseNode):
             return [self.conditional_edge]
         return [self.conditional_edge, self.fallthrough_edge]
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         return "".join(
             [
                 f"{self.block}\n",
@@ -844,7 +848,7 @@ class ReturnNode(BaseNode):
     def is_real(self) -> bool:
         return self.index == 0
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         return "".join(
             [
                 f"{self.block}\n",
@@ -868,7 +872,7 @@ class SwitchNode(BaseNode):
                 children.append(node)
         return children
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         targets = ", ".join(str(c.block.index) for c in self.cases)
         return f"{self.block}\n# {self.block.index} -> {targets}"
 
@@ -891,7 +895,7 @@ class TerminalNode(BaseNode):
     def children(self) -> List["Node"]:
         return []
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         return "return"
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -223,6 +223,14 @@ def parse_flags(flags: List[str]) -> Options:
         help="put braces on separate lines",
     )
     group.add_argument(
+        "--pointer-style",
+        dest="pointer_style",
+        help="control whether to output pointer asterisks next to the type name (left) "
+             "or next to the variable name (right)",
+        choices=["left", "right"],
+        default="right"
+    )
+    group.add_argument(
         "--dump-typemap",
         dest="dump_typemap",
         action="store_true",
@@ -313,6 +321,7 @@ def parse_flags(flags: List[str]) -> Options:
         newline_after_function=args.allman,
         newline_after_if=args.allman,
         newline_before_else=args.allman,
+        pointer_style_left=args.pointer_style.lower() == "left",
     )
     filenames = args.filename
 

--- a/src/main.py
+++ b/src/main.py
@@ -228,7 +228,7 @@ def parse_flags(flags: List[str]) -> Options:
         help="control whether to output pointer asterisks next to the type name (left) "
              "or next to the variable name (right)",
         choices=["left", "right"],
-        default="right"
+        default="right",
     )
     group.add_argument(
         "--dump-typemap",
@@ -321,7 +321,7 @@ def parse_flags(flags: List[str]) -> Options:
         newline_after_function=args.allman,
         newline_after_if=args.allman,
         newline_before_else=args.allman,
-        pointer_style_left=args.pointer_style.lower() == "left",
+        pointer_style_left=args.pointer_style == "left",
     )
     filenames = args.filename
 

--- a/src/options.py
+++ b/src/options.py
@@ -9,6 +9,7 @@ class CodingStyle:
     newline_after_function: bool = attr.ib()
     newline_after_if: bool = attr.ib()
     newline_before_else: bool = attr.ib()
+    pointer_style_left: bool = attr.ib()
 
 
 @attr.s
@@ -46,6 +47,7 @@ DEFAULT_CODING_STYLE: CodingStyle = CodingStyle(
     newline_after_function=False,
     newline_after_if=False,
     newline_before_else=False,
+    pointer_style_left=False,
 )
 
 

--- a/src/types.py
+++ b/src/types.py
@@ -218,7 +218,20 @@ class Type:
             bitsize=None,
         )
         set_decl_name(decl)
-        return to_c(decl)
+        ret = to_c(decl)
+
+        if fmt.coding_style.pointer_style_left:
+            # Keep going until the result is unmodified
+            while True:
+                replaced = ret\
+                    .replace(" *", "* ")\
+                    .replace("* )", "*)")\
+                    .replace("* ,", "*,")
+                if replaced == ret:
+                    break
+                ret = replaced
+
+        return ret
 
     def _to_ctype(self, seen: Set["TypeData"], fmt: Formatter) -> CType:
         def simple_ctype(typename: str) -> ca.TypeDecl:

--- a/tests/end_to_end/known_called_function/irix-g-flags.txt
+++ b/tests/end_to_end/known_called_function/irix-g-flags.txt
@@ -1,1 +1,1 @@
---context orig.c
+--context orig.c --pointer-style left

--- a/tests/end_to_end/known_called_function/irix-g-out.c
+++ b/tests/end_to_end/known_called_function/irix-g-out.c
@@ -1,5 +1,5 @@
-void test(s32 x, s16 *y, s32 z, s8 *r, s16 *s, s32 *t, s32 *u) {
-    s32 *sp1C;
+void test(s32 x, s16* y, s32 z, s8* r, s16* s, s32* t, s32* u) {
+    s32* sp1C;
 
     sp1C = NULL;
 loop_1:


### PR DESCRIPTION
This PR adds a new runtime flag which allows the user to configure pointers to be next to the type name rather than the variable name. Default behavior is unchanged.