### PR TITLE
Use dataclasses instead of attrs

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: 3.6
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade mypy dataclasses pycparser coverage
+        python -m pip install --upgrade mypy dataclasses types-dataclasses pycparser coverage
     - name: Run tests
       run: |
         ./run_tests.py

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: 3.6
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade mypy attrs pycparser coverage
+        python -m pip install --upgrade mypy dataclasses pycparser coverage
     - name: Run tests
       run: |
         ./run_tests.py

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An online version is available at https://simonsoftware.se/other/mips_to_c.py.
 
 ## Install
 
-Make sure you have Python 3.6 or later installed, then do `python3 -m pip install --upgrade attrs pycparser`.
+Make sure you have Python 3.6 or later installed, then do `python3 -m pip install --upgrade pycparser` (also `dataclasses` if not on 3.7+).
 
 You might need to install `pip` first; on Ubuntu this can be done with:
 ```bash

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import argparse
-import attr
 import contextlib
+from dataclasses import dataclass, field
 import difflib
 import io
 import logging
@@ -18,23 +18,23 @@ from src.options import Options
 CRASH_STRING = "CRASHED\n"
 
 
-@attr.s(frozen=True, slots=True)
+@dataclass(frozen=True)
 class TestOptions:
-    should_overwrite: bool = attr.ib()
-    diff_context: int = attr.ib()
-    filter_re: Pattern[str] = attr.ib()
-    parallel: Optional[int] = attr.ib(default=None)
-    coverage: Any = attr.ib(default=None)
+    should_overwrite: bool
+    diff_context: int
+    filter_re: Pattern[str]
+    parallel: Optional[int] = None
+    coverage: Any = None
 
 
-@attr.s(frozen=True, slots=True)
+@dataclass(frozen=True, order=True)
 class TestCase:
-    name: str = attr.ib()
-    asm_file: Path = attr.ib()
-    output_file: Path = attr.ib()
-    brief_crashes: bool = attr.ib(default=True)
-    flags_path: Optional[Path] = attr.ib(default=None)
-    flags: List[str] = attr.ib(factory=list)
+    name: str
+    asm_file: Path
+    output_file: Path
+    brief_crashes: bool = True
+    flags_path: Optional[Path] = None
+    flags: List[str] = field(default_factory=list)
 
 
 def set_up_logging(debug: bool) -> None:

--- a/src/c_types.py
+++ b/src/c_types.py
@@ -2,12 +2,12 @@
 based on a C AST. Based on the pycparser library."""
 
 import copy
+from dataclasses import dataclass, field
 import functools
 import re
 from collections import defaultdict
 from typing import Any, Dict, Iterator, List, Match, Optional, Set, Tuple, Union
 
-import attr
 from pycparser import c_ast as ca
 from pycparser.c_ast import ArrayDecl, FuncDecl, IdentifierType, PtrDecl, TypeDecl
 from pycparser.c_generator import CGenerator
@@ -21,54 +21,54 @@ StructUnion = Union[ca.Struct, ca.Union]
 SimpleType = Union[PtrDecl, TypeDecl]
 
 
-@attr.s
+@dataclass
 class StructField:
-    type: CType = attr.ib()
-    size: int = attr.ib()
-    name: str = attr.ib()
+    type: CType
+    size: int
+    name: str
 
 
-@attr.s
+@dataclass
 class Struct:
-    fields: Dict[int, List[StructField]] = attr.ib()
+    fields: Dict[int, List[StructField]]
     # TODO: bitfields
-    size: int = attr.ib()
-    align: int = attr.ib()
+    size: int
+    align: int
 
 
-@attr.s
+@dataclass
 class Array:
-    subtype: "DetailedStructMember" = attr.ib()
-    subctype: CType = attr.ib()
-    subsize: int = attr.ib()
-    dim: int = attr.ib()
+    subtype: "DetailedStructMember"
+    subctype: CType
+    subsize: int
+    dim: int
 
 
 DetailedStructMember = Union[Array, Struct, None]
 
 
-@attr.s
+@dataclass
 class Param:
-    type: CType = attr.ib()
-    name: Optional[str] = attr.ib()
+    type: CType
+    name: Optional[str]
 
 
-@attr.s
+@dataclass
 class Function:
-    type: CType = attr.ib()
-    ret_type: Optional[CType] = attr.ib()
-    params: Optional[List[Param]] = attr.ib()
-    is_variadic: bool = attr.ib()
+    type: CType
+    ret_type: Optional[CType]
+    params: Optional[List[Param]]
+    is_variadic: bool
 
 
-@attr.s
+@dataclass
 class TypeMap:
-    typedefs: Dict[str, CType] = attr.ib(factory=dict)
-    var_types: Dict[str, CType] = attr.ib(factory=dict)
-    functions: Dict[str, Function] = attr.ib(factory=dict)
-    named_structs: Dict[str, Struct] = attr.ib(factory=dict)
-    anon_structs: Dict[int, Struct] = attr.ib(factory=dict)
-    enum_values: Dict[str, int] = attr.ib(factory=dict)
+    typedefs: Dict[str, CType] = field(default_factory=dict)
+    var_types: Dict[str, CType] = field(default_factory=dict)
+    functions: Dict[str, Function] = field(default_factory=dict)
+    named_structs: Dict[str, Struct] = field(default_factory=dict)
+    anon_structs: Dict[int, Struct] = field(default_factory=dict)
+    enum_values: Dict[str, int] = field(default_factory=dict)
 
 
 def to_c(node: ca.Node) -> str:

--- a/src/error.py
+++ b/src/error.py
@@ -1,9 +1,9 @@
-import attr
+from dataclasses import dataclass
 
 
-@attr.s
+@dataclass
 class DecompFailure(Exception):
-    message: str = attr.ib()
+    message: str
 
     def __str__(self) -> str:
         return self.message

--- a/src/if_statements.py
+++ b/src/if_statements.py
@@ -900,7 +900,7 @@ def get_function_text(function_info: FunctionInfo, options: Options) -> str:
             any_decl = True
 
         for reg_var in function_info.stack_info.reg_vars.values():
-            if reg_var.register not in function_info.stack_info.used_reg_vars:
+            if reg_var.reg not in function_info.stack_info.used_reg_vars:
                 continue
             type_decl = reg_var.type.to_decl(reg_var.format(fmt), fmt)
             function_lines.append(SimpleStatement(f"{type_decl};").format(fmt))

--- a/src/if_statements.py
+++ b/src/if_statements.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
+from dataclasses import dataclass, field, replace
 from typing import Dict, List, Optional, Set, Tuple, Union
-
-import attr
 
 from .flow_graph import (
     BasicNode,
@@ -25,27 +24,27 @@ from .translate import Statement as TrStatement
 from .translate import Type, format_expr, simplify_condition
 
 
-@attr.s
+@dataclass
 class Context:
-    flow_graph: FlowGraph = attr.ib()
-    fmt: Formatter = attr.ib()
-    options: Options = attr.ib()
-    is_void: bool = attr.ib(default=True)
-    switch_nodes: Dict[SwitchNode, int] = attr.ib(factory=dict)
-    case_nodes: Dict[Node, List[Tuple[int, int]]] = attr.ib(
-        factory=lambda: defaultdict(list)
+    flow_graph: FlowGraph
+    fmt: Formatter
+    options: Options
+    is_void: bool = True
+    switch_nodes: Dict[SwitchNode, int] = field(default_factory=dict)
+    case_nodes: Dict[Node, List[Tuple[int, int]]] = field(
+        default_factory=lambda: defaultdict(list)
     )
-    goto_nodes: Set[Node] = attr.ib(factory=set)
-    loop_nodes: Set[Node] = attr.ib(factory=set)
-    emitted_nodes: Set[Node] = attr.ib(factory=set)
-    has_warned: bool = attr.ib(default=False)
+    goto_nodes: Set[Node] = field(default_factory=set)
+    loop_nodes: Set[Node] = field(default_factory=set)
+    emitted_nodes: Set[Node] = field(default_factory=set)
+    has_warned: bool = False
 
 
-@attr.s
+@dataclass
 class IfElseStatement:
-    condition: Condition = attr.ib()
-    if_body: "Body" = attr.ib()
-    else_body: Optional["Body"] = attr.ib(default=None)
+    condition: Condition
+    if_body: "Body"
+    else_body: Optional["Body"] = None
 
     def should_write(self) -> bool:
         return True
@@ -85,7 +84,7 @@ class IfElseStatement:
         """Return an IfElseStatement with the condition negated and the if/else
         bodies swapped. The caller must check that `else_body` is present."""
         assert self.else_body is not None, "checked by caller"
-        return attr.evolve(
+        return replace(
             self,
             condition=self.condition.negated(),
             if_body=self.else_body,
@@ -93,10 +92,10 @@ class IfElseStatement:
         )
 
 
-@attr.s
+@dataclass
 class SwitchStatement:
-    jump: "SimpleStatement" = attr.ib()
-    body: "Body" = attr.ib()
+    jump: "SimpleStatement"
+    body: "Body"
 
     def should_write(self) -> bool:
         return True
@@ -109,10 +108,10 @@ class SwitchStatement:
         return "\n".join(lines)
 
 
-@attr.s
+@dataclass
 class SimpleStatement:
-    contents: Optional[Union[str, TrStatement]] = attr.ib()
-    is_jump: bool = attr.ib(default=False)
+    contents: Optional[Union[str, TrStatement]]
+    is_jump: bool = False
 
     def should_write(self) -> bool:
         return self.contents is not None
@@ -129,10 +128,10 @@ class SimpleStatement:
         self.contents = None
 
 
-@attr.s
+@dataclass
 class LabelStatement:
-    context: Context = attr.ib()
-    node: Node = attr.ib()
+    context: Context
+    node: Node
 
     def should_write(self) -> bool:
         return (
@@ -151,10 +150,10 @@ class LabelStatement:
         return "\n".join(lines)
 
 
-@attr.s
+@dataclass
 class DoWhileLoop:
-    body: "Body" = attr.ib()
-    condition: Condition = attr.ib()
+    body: "Body"
+    condition: Condition
 
     def should_write(self) -> bool:
         return True
@@ -182,10 +181,10 @@ Statement = Union[
 ]
 
 
-@attr.s
+@dataclass
 class Body:
-    print_node_comment: bool = attr.ib()
-    statements: List[Statement] = attr.ib(factory=list)
+    print_node_comment: bool
+    statements: List[Statement] = field(default_factory=list)
 
     def extend(self, other: "Body") -> None:
         """Add the contents of `other` into ourselves"""
@@ -216,7 +215,7 @@ class Body:
             # Transform `if (A) { B; return C; } else { D; }`
             # into `if (A) { B; return C; } D;`,
             # which reduces indentation to make the output more readable
-            self.statements.append(attr.evolve(if_else, else_body=None))
+            self.statements.append(replace(if_else, else_body=None))
             if if_else.else_body is not None:
                 self.extend(if_else.else_body)
             return

--- a/src/options.py
+++ b/src/options.py
@@ -1,39 +1,38 @@
 import contextlib
+from dataclasses import dataclass
 from typing import Dict, Iterator, List, Optional, Union
 
-import attr
 
-
-@attr.s
+@dataclass
 class CodingStyle:
-    newline_after_function: bool = attr.ib()
-    newline_after_if: bool = attr.ib()
-    newline_before_else: bool = attr.ib()
-    pointer_style_left: bool = attr.ib()
+    newline_after_function: bool
+    newline_after_if: bool
+    newline_before_else: bool
+    pointer_style_left: bool
 
 
-@attr.s
+@dataclass
 class Options:
-    filenames: List[str] = attr.ib()
-    function_indexes_or_names: List[Union[int, str]] = attr.ib()
-    debug: bool = attr.ib()
-    void: bool = attr.ib()
-    ifs: bool = attr.ib()
-    andor_detection: bool = attr.ib()
-    skip_casts: bool = attr.ib()
-    reg_vars: List[str] = attr.ib()
-    goto_patterns: List[str] = attr.ib()
-    stop_on_error: bool = attr.ib()
-    print_assembly: bool = attr.ib()
-    visualize_flowgraph: bool = attr.ib()
-    c_context: Optional[str] = attr.ib()
-    dump_typemap: bool = attr.ib()
-    pdb_translate: bool = attr.ib()
-    preproc_defines: Dict[str, int] = attr.ib()
-    coding_style: CodingStyle = attr.ib()
-    sanitize_tracebacks: bool = attr.ib()
-    valid_syntax: bool = attr.ib()
-    emit_globals: bool = attr.ib()
+    filenames: List[str]
+    function_indexes_or_names: List[Union[int, str]]
+    debug: bool
+    void: bool
+    ifs: bool
+    andor_detection: bool
+    skip_casts: bool
+    reg_vars: List[str]
+    goto_patterns: List[str]
+    stop_on_error: bool
+    print_assembly: bool
+    visualize_flowgraph: bool
+    c_context: Optional[str]
+    dump_typemap: bool
+    pdb_translate: bool
+    preproc_defines: Dict[str, int]
+    coding_style: CodingStyle
+    sanitize_tracebacks: bool
+    valid_syntax: bool
+    emit_globals: bool
 
     def formatter(self) -> "Formatter":
         return Formatter(
@@ -51,14 +50,14 @@ DEFAULT_CODING_STYLE: CodingStyle = CodingStyle(
 )
 
 
-@attr.s
+@dataclass
 class Formatter:
-    coding_style: CodingStyle = attr.ib(default=DEFAULT_CODING_STYLE)
-    indent_step: str = attr.ib(default=" " * 4)
-    skip_casts: bool = attr.ib(default=False)
-    extra_indent: int = attr.ib(default=0)
-    debug: bool = attr.ib(default=False)
-    valid_syntax: bool = attr.ib(default=False)
+    coding_style: CodingStyle = DEFAULT_CODING_STYLE
+    indent_step: str = " " * 4
+    skip_casts: bool = False
+    extra_indent: int = 0
+    debug: bool = False
+    valid_syntax: bool = False
 
     def indent(self, line: str, indent: int = 0) -> str:
         return self.indent_step * max(indent + self.extra_indent, 0) + line

--- a/src/translate.py
+++ b/src/translate.py
@@ -335,10 +335,10 @@ class StackInfo:
 
     def add_register_var(self, reg: Register) -> None:
         type = Type.floatish() if reg.is_float() else Type.intptr()
-        self.reg_vars[reg] = RegisterVar(register=reg, type=type)
+        self.reg_vars[reg] = RegisterVar(reg=reg, type=type)
 
     def use_register_var(self, var: "RegisterVar") -> None:
-        self.used_reg_vars.add(var.register)
+        self.used_reg_vars.add(var.reg)
 
     def is_stack_reg(self, reg: Register) -> bool:
         if reg.register_name == "sp":
@@ -946,14 +946,14 @@ class LocalVar(Expression):
 
 @dataclass(frozen=True, eq=False)
 class RegisterVar(Expression):
+    reg: Register
     type: Type
-    register: Register
 
     def dependencies(self) -> List[Expression]:
         return []
 
     def format(self, fmt: Formatter) -> str:
-        return self.register.register_name
+        return self.reg.register_name
 
 
 @dataclass(frozen=True, eq=True)
@@ -3257,7 +3257,7 @@ def translate_node_body(node: Node, regs: RegInfo, stack_info: StackInfo) -> Blo
             if dest is not None:
                 stack_info.use_register_var(dest)
                 # Avoid emitting x = x, but still refresh EvalOnceExpr's etc.
-                if not (isinstance(uw_expr, RegisterVar) and uw_expr.register == reg):
+                if not (isinstance(uw_expr, RegisterVar) and uw_expr.reg == reg):
                     source = as_type(expr, dest.type, True)
                     source.use()
                     to_write.append(StoreStmt(source=source, dest=dest))

--- a/src/translate.py
+++ b/src/translate.py
@@ -1,12 +1,11 @@
 import abc
+from dataclasses import dataclass, field, replace
 import math
 import struct
 import sys
 import traceback
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Tuple, Union
-
-import attr
 
 from .c_types import TypeMap
 from .error import DecompFailure
@@ -136,9 +135,9 @@ SAVED_REGS: List[Register] = list(
 )
 
 
-@attr.s
+@dataclass
 class InstrProcessingFailure(Exception):
-    instr: Instruction = attr.ib()
+    instr: Instruction
 
     def __str__(self) -> str:
         return f"Error while processing instruction:\n{self.instr}"
@@ -205,28 +204,28 @@ def as_function_ptr(expr: "Expression") -> "Expression":
     return as_type(expr, Type.ptr(Type.function()), True)
 
 
-@attr.s
+@dataclass
 class StackInfo:
-    function: Function = attr.ib()
-    global_info: "GlobalInfo" = attr.ib()
-    allocated_stack_size: int = attr.ib(default=0)
-    is_leaf: bool = attr.ib(default=True)
-    is_variadic: bool = attr.ib(default=False)
-    uses_framepointer: bool = attr.ib(default=False)
-    subroutine_arg_top: int = attr.ib(default=0)
-    return_addr_location: int = attr.ib(default=0)
-    callee_save_reg_locations: Dict[Register, int] = attr.ib(factory=dict)
-    callee_save_reg_region: Tuple[int, int] = attr.ib(default=(0, 0))
-    unique_type_map: Dict[Any, "Type"] = attr.ib(factory=dict)
-    local_vars: List["LocalVar"] = attr.ib(factory=list)
-    temp_vars: List["EvalOnceStmt"] = attr.ib(factory=list)
-    phi_vars: List["PhiExpr"] = attr.ib(factory=list)
-    reg_vars: Dict[Register, "RegisterVar"] = attr.ib(factory=dict)
-    used_reg_vars: Set[Register] = attr.ib(factory=set)
-    arguments: List["PassedInArg"] = attr.ib(factory=list)
-    temp_name_counter: Dict[str, int] = attr.ib(factory=dict)
-    nonzero_accesses: Set["Expression"] = attr.ib(factory=set)
-    param_names: Dict[int, str] = attr.ib(factory=dict)
+    function: Function
+    global_info: "GlobalInfo"
+    allocated_stack_size: int = 0
+    is_leaf: bool = True
+    is_variadic: bool = False
+    uses_framepointer: bool = False
+    subroutine_arg_top: int = 0
+    return_addr_location: int = 0
+    callee_save_reg_locations: Dict[Register, int] = field(default_factory=dict)
+    callee_save_reg_region: Tuple[int, int] = (0, 0)
+    unique_type_map: Dict[Any, "Type"] = field(default_factory=dict)
+    local_vars: List["LocalVar"] = field(default_factory=list)
+    temp_vars: List["EvalOnceStmt"] = field(default_factory=list)
+    phi_vars: List["PhiExpr"] = field(default_factory=list)
+    reg_vars: Dict[Register, "RegisterVar"] = field(default_factory=dict)
+    used_reg_vars: Set[Register] = field(default_factory=set)
+    arguments: List["PassedInArg"] = field(default_factory=list)
+    temp_name_counter: Dict[str, int] = field(default_factory=dict)
+    nonzero_accesses: Set["Expression"] = field(default_factory=set)
+    param_names: Dict[int, str] = field(default_factory=dict)
 
     def temp_var(self, prefix: str) -> str:
         counter = self.temp_name_counter.get(prefix, 0) + 1
@@ -336,7 +335,7 @@ class StackInfo:
 
     def add_register_var(self, reg: Register) -> None:
         type = Type.floatish() if reg.is_float() else Type.intptr()
-        self.reg_vars[reg] = RegisterVar(reg, type)
+        self.reg_vars[reg] = RegisterVar(register=reg, type=type)
 
     def use_register_var(self, var: "RegisterVar") -> None:
         self.used_reg_vars.add(var.register)
@@ -531,12 +530,12 @@ def escape_byte(b: int) -> bytes:
     return bs
 
 
-@attr.s(eq=False)
+@dataclass(eq=False)
 class Var:
-    stack_info: StackInfo = attr.ib(repr=False)
-    prefix: str = attr.ib()
-    num_usages: int = attr.ib(default=0)
-    name: Optional[str] = attr.ib(default=None)
+    stack_info: StackInfo = field(repr=False)
+    prefix: str
+    num_usages: int = 0
+    name: Optional[str] = None
 
     def format(self, fmt: Formatter) -> str:
         if self.name is None:
@@ -604,10 +603,10 @@ class Statement(abc.ABC):
         return '"' + self.format(fmt) + '"'
 
 
-@attr.s(frozen=True, eq=False)
+@dataclass(frozen=True, eq=False)
 class ErrorExpr(Condition):
-    desc: Optional[str] = attr.ib(default=None)
-    type: Type = attr.ib(factory=Type.any_reg)
+    desc: Optional[str] = None
+    type: Type = field(default_factory=Type.any_reg)
 
     def dependencies(self) -> List[Expression]:
         return []
@@ -621,9 +620,9 @@ class ErrorExpr(Condition):
         return "MIPS2C_ERROR()"
 
 
-@attr.s(frozen=True, eq=False)
+@dataclass(frozen=True, eq=False)
 class SecondF64Half(Expression):
-    type: Type = attr.ib(factory=Type.any_reg)
+    type: Type = field(default_factory=Type.any_reg)
 
     def dependencies(self) -> List[Expression]:
         return []
@@ -632,13 +631,13 @@ class SecondF64Half(Expression):
         return "(second half of f64)"
 
 
-@attr.s(frozen=True, eq=False)
+@dataclass(frozen=True, eq=False)
 class BinaryOp(Condition):
-    left: Expression = attr.ib()
-    op: str = attr.ib()
-    right: Expression = attr.ib()
-    type: Type = attr.ib()
-    floating: bool = attr.ib(default=False)
+    left: Expression
+    op: str
+    right: Expression
+    type: Type
+    floating: bool = False
 
     @staticmethod
     def int(left: Expression, op: str, right: Expression) -> "BinaryOp":
@@ -796,11 +795,11 @@ class BinaryOp(Condition):
         return f"({lhs} {self.op} {self.right.format(fmt)})"
 
 
-@attr.s(frozen=True, eq=False)
+@dataclass(frozen=True, eq=False)
 class UnaryOp(Condition):
-    op: str = attr.ib()
-    expr: Expression = attr.ib()
-    type: Type = attr.ib()
+    op: str
+    expr: Expression
+    type: Type
 
     def dependencies(self) -> List[Expression]:
         return [self.expr]
@@ -814,11 +813,11 @@ class UnaryOp(Condition):
         return f"{self.op}{self.expr.format(fmt)}"
 
 
-@attr.s(frozen=True, eq=False)
+@dataclass(frozen=True, eq=False)
 class ExprCondition(Condition):
-    expr: Expression = attr.ib()
-    type: Type = attr.ib()
-    is_negated: bool = attr.ib(default=False)
+    expr: Expression
+    type: Type
+    is_negated: bool = False
 
     def dependencies(self) -> List[Expression]:
         return [self.expr]
@@ -831,10 +830,10 @@ class ExprCondition(Condition):
         return f"{neg}{self.expr.format(fmt)}"
 
 
-@attr.s(frozen=True, eq=False)
+@dataclass(frozen=True, eq=False)
 class CommaConditionExpr(Condition):
-    statements: List["Statement"] = attr.ib()
-    condition: "Condition" = attr.ib()
+    statements: List["Statement"]
+    condition: "Condition"
     type: Type = Type.bool()
 
     def dependencies(self) -> List[Expression]:
@@ -851,12 +850,12 @@ class CommaConditionExpr(Condition):
         return f"({comma_joined}, {self.condition.format(fmt)})"
 
 
-@attr.s(frozen=True, eq=False)
+@dataclass(frozen=True, eq=False)
 class Cast(Expression):
-    expr: Expression = attr.ib()
-    type: Type = attr.ib()
-    reinterpret: bool = attr.ib(default=False)
-    silent: bool = attr.ib(default=True)
+    expr: Expression
+    type: Type
+    reinterpret: bool = False
+    silent: bool = True
 
     def dependencies(self) -> List[Expression]:
         return [self.expr]
@@ -916,11 +915,11 @@ class Cast(Expression):
         return f"({self.type.format(fmt)}) {self.expr.format(fmt)}"
 
 
-@attr.s(frozen=True, eq=False)
+@dataclass(frozen=True, eq=False)
 class FuncCall(Expression):
-    function: Expression = attr.ib()
-    args: List[Expression] = attr.ib()
-    type: Type = attr.ib()
+    function: Expression
+    args: List[Expression]
+    type: Type
 
     def dependencies(self) -> List[Expression]:
         return self.args + [self.function]
@@ -933,10 +932,10 @@ class FuncCall(Expression):
         return f"{self.function.format(fmt)}({args})"
 
 
-@attr.s(frozen=True, eq=True)
+@dataclass(frozen=True, eq=True)
 class LocalVar(Expression):
-    value: int = attr.ib()
-    type: Type = attr.ib(eq=False)
+    value: int
+    type: Type = field(compare=False)
 
     def dependencies(self) -> List[Expression]:
         return []
@@ -945,10 +944,10 @@ class LocalVar(Expression):
         return f"sp{format_hex(self.value)}"
 
 
-@attr.s(frozen=True, eq=False)
+@dataclass(frozen=True, eq=False)
 class RegisterVar(Expression):
-    register: Register = attr.ib()
-    type: Type = attr.ib()
+    type: Type
+    register: Register
 
     def dependencies(self) -> List[Expression]:
         return []
@@ -957,12 +956,12 @@ class RegisterVar(Expression):
         return self.register.register_name
 
 
-@attr.s(frozen=True, eq=True)
+@dataclass(frozen=True, eq=True)
 class PassedInArg(Expression):
-    value: int = attr.ib()
-    copied: bool = attr.ib(eq=False)
-    stack_info: StackInfo = attr.ib(eq=False, repr=False)
-    type: Type = attr.ib(eq=False)
+    value: int
+    copied: bool = field(compare=False)
+    stack_info: StackInfo = field(compare=False, repr=False)
+    type: Type = field(compare=False)
 
     def dependencies(self) -> List[Expression]:
         return []
@@ -973,10 +972,10 @@ class PassedInArg(Expression):
         return name or f"arg{format_hex(self.value // 4)}"
 
 
-@attr.s(frozen=True, eq=True)
+@dataclass(frozen=True, eq=True)
 class SubroutineArg(Expression):
-    value: int = attr.ib()
-    type: Type = attr.ib(eq=False)
+    value: int
+    type: Type = field(compare=False)
 
     def dependencies(self) -> List[Expression]:
         return []
@@ -985,20 +984,20 @@ class SubroutineArg(Expression):
         return f"subroutine_arg{format_hex(self.value // 4)}"
 
 
-@attr.s(eq=True, hash=True)
+@dataclass(eq=True, unsafe_hash=True)
 class StructAccess(Expression):
     # Represents struct_var->offset.
     # This has eq=True since it represents a live expression and not an access
     # at a certain point in time -- this sometimes helps get rid of phi nodes.
     # prevent_later_uses makes sure it's not used after writes/function calls
     # that may invalidate it.
-    struct_var: Expression = attr.ib()
-    offset: int = attr.ib()
-    target_size: Optional[int] = attr.ib()
-    field_name: Optional[str] = attr.ib(eq=False)
-    stack_info: StackInfo = attr.ib(eq=False, repr=False)
-    type: Type = attr.ib(eq=False)
-    has_late_field_name: bool = attr.ib(default=False, eq=False)
+    struct_var: Expression
+    offset: int
+    target_size: Optional[int]
+    field_name: Optional[str] = field(compare=False)
+    stack_info: StackInfo = field(compare=False, repr=False)
+    type: Type = field(compare=False)
+    has_late_field_name: bool = field(default=False, compare=False)
 
     def dependencies(self) -> List[Expression]:
         return [self.struct_var]
@@ -1073,12 +1072,12 @@ class StructAccess(Expression):
                 return f"{parenthesize_for_struct_access(var, fmt)}.{field_name}"
 
 
-@attr.s(frozen=True, eq=True)
+@dataclass(frozen=True, eq=True)
 class ArrayAccess(Expression):
     # Represents ptr[index]. eq=True for symmetry with StructAccess.
-    ptr: Expression = attr.ib()
-    index: Expression = attr.ib()
-    type: Type = attr.ib(eq=False)
+    ptr: Expression
+    index: Expression
+    type: Type = field(compare=False)
 
     def dependencies(self) -> List[Expression]:
         return [self.ptr, self.index]
@@ -1089,12 +1088,12 @@ class ArrayAccess(Expression):
         return f"{base}[{index}]"
 
 
-@attr.s(eq=False)
+@dataclass(eq=False)
 class GlobalSymbol(Expression):
-    symbol_name: str = attr.ib()
-    type: Type = attr.ib()
-    asm_data_entry: Optional[AsmDataEntry] = attr.ib(default=None)
-    type_in_typemap: bool = attr.ib(default=False)
+    symbol_name: str
+    type: Type
+    asm_data_entry: Optional[AsmDataEntry] = None
+    type_in_typemap: bool = False
     # `array_dim=None` indicates that the symbol is not an array
     # `array_dim=0` indicates that it *is* an array, but the dimension is unknown
     # Otherwise, it is the dimension of the array.
@@ -1103,7 +1102,7 @@ class GlobalSymbol(Expression):
     # Otherwise, this defaults to `None` and is set using heuristics in
     # `GlobalInfo.global_decls()` after the AST has been built.
     # So, this value should not be relied on during translate.
-    array_dim: Optional[int] = attr.ib(default=None)
+    array_dim: Optional[int] = None
 
     def dependencies(self) -> List[Expression]:
         return []
@@ -1135,10 +1134,10 @@ class GlobalSymbol(Expression):
         return self.symbol_name
 
 
-@attr.s(frozen=True, eq=True)
+@dataclass(frozen=True, eq=True)
 class Literal(Expression):
-    value: int = attr.ib()
-    type: Type = attr.ib(eq=False, factory=Type.any)
+    value: int
+    type: Type = field(compare=False, default_factory=Type.any)
 
     def dependencies(self) -> List[Expression]:
         return []
@@ -1171,10 +1170,10 @@ class Literal(Expression):
         return prefix + mid + suffix
 
 
-@attr.s(frozen=True, eq=True)
+@dataclass(frozen=True, eq=True)
 class AddressOf(Expression):
-    expr: Expression = attr.ib()
-    type: Type = attr.ib(eq=False, factory=Type.ptr)
+    expr: Expression
+    type: Type = field(compare=False, default_factory=Type.ptr)
 
     def dependencies(self) -> List[Expression]:
         return [self.expr]
@@ -1193,11 +1192,11 @@ class AddressOf(Expression):
         return f"&{self.expr.format(fmt)}"
 
 
-@attr.s(frozen=True)
+@dataclass(frozen=True)
 class Lwl(Expression):
-    load_expr: Expression = attr.ib()
-    key: Tuple[int, object] = attr.ib()
-    type: Type = attr.ib(eq=False, factory=Type.any_reg)
+    load_expr: Expression
+    key: Tuple[int, object]
+    type: Type = field(compare=False, default_factory=Type.any_reg)
 
     def dependencies(self) -> List[Expression]:
         return [self.load_expr]
@@ -1206,10 +1205,10 @@ class Lwl(Expression):
         return f"MIPS2C_LWL({self.load_expr.format(fmt)})"
 
 
-@attr.s(frozen=True)
+@dataclass(frozen=True)
 class Load3Bytes(Expression):
-    load_expr: Expression = attr.ib()
-    type: Type = attr.ib(eq=False, factory=Type.any_reg)
+    load_expr: Expression
+    type: Type = field(compare=False, default_factory=Type.any_reg)
 
     def dependencies(self) -> List[Expression]:
         return [self.load_expr]
@@ -1220,10 +1219,10 @@ class Load3Bytes(Expression):
         return f"(first 3 bytes) {self.load_expr.format(fmt)}"
 
 
-@attr.s(frozen=True)
+@dataclass(frozen=True)
 class UnalignedLoad(Expression):
-    load_expr: Expression = attr.ib()
-    type: Type = attr.ib(eq=False, factory=Type.any_reg)
+    load_expr: Expression
+    type: Type = field(compare=False, default_factory=Type.any_reg)
 
     def dependencies(self) -> List[Expression]:
         return [self.load_expr]
@@ -1234,30 +1233,30 @@ class UnalignedLoad(Expression):
         return f"(unaligned s32) {self.load_expr.format(fmt)}"
 
 
-@attr.s(frozen=False, eq=False)
+@dataclass(frozen=False, eq=False)
 class EvalOnceExpr(Expression):
-    wrapped_expr: Expression = attr.ib()
-    var: Var = attr.ib()
-    type: Type = attr.ib()
+    wrapped_expr: Expression
+    var: Var
+    type: Type
 
     # True for function calls/errors
-    emit_exactly_once: bool = attr.ib()
+    emit_exactly_once: bool
 
     # Mutable state:
 
     # True if this EvalOnceExpr should be totally transparent and not emit a variable,
     # It may dynamically change from true to false due to forced emissions.
     # Initially, it is based on is_trivial_expression.
-    trivial: bool = attr.ib()
+    trivial: bool
 
     # True if this EvalOnceExpr is wrapped by a ForceVarExpr which has been triggered.
     # This state really live in ForceVarExpr, but there's a hack in RegInfo.__getitem__
     # where we strip off ForceVarExpr's... This is a mess, sorry. :(
-    forced_emit: bool = attr.ib(default=False)
+    forced_emit: bool = False
 
     # The number of expressions that depend on this EvalOnceExpr; we emit a variable
     # if this is > 1.
-    num_usages: int = attr.ib(default=0)
+    num_usages: int = 0
 
     def dependencies(self) -> List[Expression]:
         # (this is a bit iffy since state can change over time, but improves uses_expr)
@@ -1280,10 +1279,10 @@ class EvalOnceExpr(Expression):
             return self.var.format(fmt)
 
 
-@attr.s(eq=False)
+@dataclass(eq=False)
 class ForceVarExpr(Expression):
-    wrapped_expr: EvalOnceExpr = attr.ib()
-    type: Type = attr.ib()
+    wrapped_expr: EvalOnceExpr
+    type: Type
 
     def dependencies(self) -> List[Expression]:
         return [self.wrapped_expr]
@@ -1306,16 +1305,16 @@ class ForceVarExpr(Expression):
         return self.wrapped_expr.format(fmt)
 
 
-@attr.s(frozen=False, eq=False)
+@dataclass(frozen=False, eq=False)
 class PhiExpr(Expression):
-    reg: Register = attr.ib()
-    node: Node = attr.ib()
-    type: Type = attr.ib()
-    used_phis: List["PhiExpr"] = attr.ib()
-    name: Optional[str] = attr.ib(default=None)
-    num_usages: int = attr.ib(default=0)
-    replacement_expr: Optional[Expression] = attr.ib(default=None)
-    used_by: Optional["PhiExpr"] = attr.ib(default=None)
+    reg: Register
+    node: Node
+    type: Type
+    used_phis: List["PhiExpr"]
+    name: Optional[str] = None
+    num_usages: int = 0
+    replacement_expr: Optional[Expression] = None
+    used_by: Optional["PhiExpr"] = None
 
     def dependencies(self) -> List[Expression]:
         return []
@@ -1350,9 +1349,9 @@ class PhiExpr(Expression):
         return self.get_var_name()
 
 
-@attr.s
+@dataclass
 class EvalOnceStmt(Statement):
-    expr: EvalOnceExpr = attr.ib()
+    expr: EvalOnceExpr
 
     def need_decl(self) -> bool:
         return self.expr.need_decl()
@@ -1370,10 +1369,10 @@ class EvalOnceStmt(Statement):
         return f"{self.expr.var.format(fmt)} = {val_str};"
 
 
-@attr.s
+@dataclass
 class SetPhiStmt(Statement):
-    phi: PhiExpr = attr.ib()
-    expr: Expression = attr.ib()
+    phi: PhiExpr
+    expr: Expression
 
     def should_write(self) -> bool:
         expr = self.expr
@@ -1392,9 +1391,9 @@ class SetPhiStmt(Statement):
         return format_assignment(self.phi.propagates_to(), self.expr, fmt)
 
 
-@attr.s
+@dataclass
 class ExprStmt(Statement):
-    expr: Expression = attr.ib()
+    expr: Expression
 
     def should_write(self) -> bool:
         return True
@@ -1403,10 +1402,10 @@ class ExprStmt(Statement):
         return f"{format_expr(self.expr, fmt)};"
 
 
-@attr.s
+@dataclass
 class StoreStmt(Statement):
-    source: Expression = attr.ib()
-    dest: Expression = attr.ib()
+    source: Expression
+    dest: Expression
 
     def should_write(self) -> bool:
         return True
@@ -1422,9 +1421,9 @@ class StoreStmt(Statement):
         return format_assignment(dest, source, fmt)
 
 
-@attr.s
+@dataclass
 class CommentStmt(Statement):
-    contents: str = attr.ib()
+    contents: str
 
     def should_write(self) -> bool:
         return True
@@ -1433,10 +1432,10 @@ class CommentStmt(Statement):
         return f"// {self.contents}"
 
 
-@attr.s(frozen=True)
+@dataclass(frozen=True)
 class AddressMode:
-    offset: int = attr.ib()
-    rhs: Register = attr.ib()
+    offset: int
+    rhs: Register
 
     def __str__(self) -> str:
         if self.offset:
@@ -1445,10 +1444,10 @@ class AddressMode:
             return f"({self.rhs})"
 
 
-@attr.s(frozen=True)
+@dataclass(frozen=True)
 class RawSymbolRef:
-    offset: int = attr.ib()
-    sym: AsmGlobalSymbol = attr.ib()
+    offset: int
+    sym: AsmGlobalSymbol
 
     def __str__(self) -> str:
         if self.offset:
@@ -1457,10 +1456,10 @@ class RawSymbolRef:
             return self.sym.symbol_name
 
 
-@attr.s
+@dataclass
 class RegInfo:
-    contents: Dict[Register, Expression] = attr.ib()
-    stack_info: StackInfo = attr.ib(repr=False)
+    contents: Dict[Register, Expression]
+    stack_info: StackInfo = field(repr=False)
 
     def __getitem__(self, key: Register) -> Expression:
         if key == Register("zero"):
@@ -1507,20 +1506,20 @@ class RegInfo:
         )
 
 
-@attr.s
+@dataclass
 class BlockInfo:
     """
     Contains translated assembly code (to_write), the block's branch condition,
     and block's final register states.
     """
 
-    to_write: List[Statement] = attr.ib()
-    return_value: Optional[Expression] = attr.ib()
-    switch_value: Optional[Expression] = attr.ib()
-    branch_condition: Optional[Condition] = attr.ib()
-    final_register_states: RegInfo = attr.ib()
-    has_custom_return: bool = attr.ib()
-    has_function_call: bool = attr.ib()
+    to_write: List[Statement]
+    return_value: Optional[Expression]
+    switch_value: Optional[Expression]
+    branch_condition: Optional[Condition]
+    final_register_states: RegInfo
+    has_custom_return: bool
+    has_function_call: bool
 
     def __str__(self) -> str:
         newline = "\n\t"
@@ -1533,11 +1532,11 @@ class BlockInfo:
         )
 
 
-@attr.s
+@dataclass
 class InstrArgs:
-    raw_args: List[Argument] = attr.ib()
-    regs: RegInfo = attr.ib(repr=False)
-    stack_info: StackInfo = attr.ib(repr=False)
+    raw_args: List[Argument]
+    regs: RegInfo = field(repr=False)
+    stack_info: StackInfo = field(repr=False)
 
     def raw_arg(self, index: int) -> Argument:
         assert index >= 0
@@ -2206,7 +2205,7 @@ def handle_lwr(args: InstrArgs, old_value: Expression) -> Expression:
     if isinstance(uw_old_value, Lwl) and uw_old_value.key[0] == lwl_key[0]:
         return UnalignedLoad(uw_old_value.load_expr)
     if ref.offset % 4 == 2:
-        left_mem_ref = attr.evolve(ref, offset=ref.offset - 2)
+        left_mem_ref = replace(ref, offset=ref.offset - 2)
         load_expr = deref_unaligned(left_mem_ref, args.regs, args.stack_info)
         return Load3Bytes(load_expr)
     return ErrorExpr("Unable to handle lwr; missing a corresponding lwl")
@@ -2254,7 +2253,7 @@ def handle_swr(args: InstrArgs) -> Optional[StoreStmt]:
         # Elide swr's that don't come from 3-byte-loading lwr's; they probably
         # come with a corresponding swl which has already been emitted.
         return None
-    real_target = attr.evolve(target, offset=target.offset - 2)
+    real_target = replace(target, offset=target.offset - 2)
     dest = deref_unaligned(real_target, args.regs, args.stack_info, store=True)
     return StoreStmt(source=expr, dest=dest)
 
@@ -2546,12 +2545,12 @@ def strip_macros(arg: Argument) -> Argument:
         return arg
 
 
-@attr.s
+@dataclass
 class AbiStackSlot:
-    offset: int = attr.ib()
-    reg: Optional[Register] = attr.ib()
-    name: Optional[str] = attr.ib()
-    type: Type = attr.ib()
+    offset: int
+    reg: Optional[Register]
+    name: Optional[str]
+    type: Type
 
 
 def function_abi(
@@ -3713,12 +3712,12 @@ def resolve_types_late(stack_info: StackInfo) -> None:
             var.type.unify(Type.ptr(type))
 
 
-@attr.s
+@dataclass
 class GlobalInfo:
-    asm_data: AsmData = attr.ib()
-    local_functions: Set[str] = attr.ib()
-    typemap: Optional[TypeMap] = attr.ib()
-    global_symbol_map: Dict[str, GlobalSymbol] = attr.ib(factory=dict)
+    asm_data: AsmData
+    local_functions: Set[str]
+    typemap: Optional[TypeMap]
+    global_symbol_map: Dict[str, GlobalSymbol] = field(default_factory=dict)
 
     def asm_data_value(self, sym_name: str) -> Optional[AsmDataEntry]:
         return self.asm_data.values.get(sym_name)
@@ -3949,11 +3948,11 @@ class GlobalInfo:
         return "".join(line for _, line in lines)
 
 
-@attr.s
+@dataclass
 class FunctionInfo:
-    stack_info: StackInfo = attr.ib()
-    flow_graph: FlowGraph = attr.ib()
-    return_type: Type = attr.ib()
+    stack_info: StackInfo
+    flow_graph: FlowGraph
+    return_type: Type
 
 
 def translate_to_ast(

--- a/src/types.py
+++ b/src/types.py
@@ -1,7 +1,7 @@
 import copy
+from dataclasses import dataclass, field
 from typing import List, Optional, Set, Tuple, Union
 
-import attr
 import pycparser.c_ast as ca
 
 from .c_types import (
@@ -22,7 +22,7 @@ from .error import DecompFailure
 from .options import Formatter
 
 
-@attr.s(eq=False)
+@dataclass(eq=False)
 class TypeData:
     K_INT = 1
     K_PTR = 2
@@ -38,15 +38,15 @@ class TypeData:
     UNSIGNED = 2
     ANY_SIGN = 3
 
-    kind: int = attr.ib(default=K_ANY)
-    size: Optional[int] = attr.ib(default=None)
-    uf_parent: Optional["TypeData"] = attr.ib(default=None)
+    kind: int = K_ANY
+    size: Optional[int] = None
+    uf_parent: Optional["TypeData"] = None
 
-    sign: int = attr.ib(default=ANY_SIGN)  # K_INT
-    ptr_to: Optional["Type"] = attr.ib(default=None)  # K_PTR
-    typemap: Optional[TypeMap] = attr.ib(default=None)  # K_CTYPE
-    ctype_ref: Optional[CType] = attr.ib(default=None)  # K_CTYPE
-    fn_sig: Optional["FunctionSignature"] = attr.ib(default=None)  # K_FN
+    sign: int = ANY_SIGN  # K_INT
+    ptr_to: Optional["Type"] = None  # K_PTR
+    typemap: Optional[TypeMap] = None  # K_CTYPE
+    ctype_ref: Optional[CType] = None  # K_CTYPE
+    fn_sig: Optional["FunctionSignature"] = None  # K_FN
 
     def get_representative(self) -> "TypeData":
         if self.uf_parent is None:
@@ -55,7 +55,7 @@ class TypeData:
         return self.uf_parent
 
 
-@attr.s(eq=False, repr=False)
+@dataclass(eq=False, repr=False)
 class Type:
     """
     Type information for an expression, which may improve over time. The least
@@ -67,7 +67,7 @@ class Type:
     become floats.
     """
 
-    _data: TypeData = attr.ib()
+    _data: TypeData
 
     def unify(self, other: "Type", *, seen: Optional[Set["TypeData"]] = None) -> bool:
         """
@@ -225,10 +225,9 @@ class Type:
         if fmt.coding_style.pointer_style_left:
             # Keep going until the result is unmodified
             while True:
-                replaced = ret\
-                    .replace(" *", "* ")\
-                    .replace("* )", "*)")\
-                    .replace("* ,", "*,")
+                replaced = (
+                    ret.replace(" *", "* ").replace("* )", "*)").replace("* ,", "*,")
+                )
                 if replaced == ret:
                     break
                 ret = replaced
@@ -418,18 +417,18 @@ class Type:
         return Type(TypeData(kind=TypeData.K_VOID, size=0))
 
 
-@attr.s(eq=False)
+@dataclass(eq=False)
 class FunctionParam:
-    type: Type = attr.ib(factory=Type.any)
-    name: str = attr.ib(default="")
+    type: Type = field(default_factory=Type.any)
+    name: str = ""
 
 
-@attr.s(eq=False)
+@dataclass(eq=False)
 class FunctionSignature:
-    return_type: Type = attr.ib(factory=Type.any)
-    params: List[FunctionParam] = attr.ib(factory=list)
-    params_known: bool = attr.ib(default=False)
-    is_variadic: bool = attr.ib(default=False)
+    return_type: Type = field(default_factory=Type.any)
+    params: List[FunctionParam] = field(default_factory=list)
+    params_known: bool = False
+    is_variadic: bool = False
 
     def unify(self, other: "FunctionSignature", *, seen: Set[TypeData]) -> bool:
         if self.params_known and other.params_known:


### PR DESCRIPTION
Something weird is happening with
```
@dataclass(frozen=True, eq=False)
class RegisterVar(Expression):
    type: Type
    register: Register
```
where if the two fields swap places there's an error
```
Traceback (most recent call last):
  File "./mips_to_c.py", line 2, in <module>
    from src.main import main
  File "./mips_to_c/src/main.py", line 11, in <module>
    from .if_statements import get_function_text
  File "./mips_to_c/src/if_statements.py", line 15, in <module>
    from .translate import (
  File "./mips_to_c/src/translate.py", line 948, in <module>
    class RegisterVar(Expression):
  File "/usr/lib/python3.7/dataclasses.py", line 1002, in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash, frozen)
  File "/usr/lib/python3.7/dataclasses.py", line 921, in _process_class
    globals,
  File "/usr/lib/python3.7/dataclasses.py", line 491, in _init_fn
    raise TypeError(f'non-default argument {f.name!r} '
TypeError: non-default argument 'type' follows default argument
```