### PR TITLE
Website features

### DIFF
--- a/src/flow_graph.py
+++ b/src/flow_graph.py
@@ -1362,7 +1362,7 @@ def build_flowgraph(function: Function, asm_data: AsmData) -> FlowGraph:
     return FlowGraph(nodes)
 
 
-def visualize_flowgraph(flow_graph: FlowGraph) -> None:
+def visualize_flowgraph(flow_graph: FlowGraph) -> str:
     import graphviz as g
 
     fmt = Formatter(debug=True)
@@ -1406,8 +1406,4 @@ def visualize_flowgraph(flow_graph: FlowGraph) -> None:
             assert isinstance(node, TerminalNode)
             label += "// exit\l"
         dot.node(node.name(), label=label)
-    dot.render("graphviz_render.gv")
-    print("Rendered to graphviz_render.gv.pdf")
-    print(
-        "Key: black = successor, red = conditional edge, blue = fallthrough edge, green = switch case"
-    )
+    return dot.pipe("svg").decode("utf-8", "replace")

--- a/src/flow_graph.py
+++ b/src/flow_graph.py
@@ -1406,4 +1406,5 @@ def visualize_flowgraph(flow_graph: FlowGraph) -> str:
             assert isinstance(node, TerminalNode)
             label += "// exit\l"
         dot.node(node.name(), label=label)
-    return dot.pipe("svg").decode("utf-8", "replace")
+    svg_bytes: bytes = dot.pipe("svg")
+    return svg_bytes.decode("utf-8", "replace")

--- a/src/main.py
+++ b/src/main.py
@@ -102,7 +102,7 @@ def run(options: Options) -> int:
         fn_info = function_infos[0]
         if isinstance(fn_info, Exception):
             raise fn_info
-        visualize_flowgraph(fn_info.flow_graph)
+        print(visualize_flowgraph(fn_info.flow_graph))
         return 0
 
     fmt = options.formatter()
@@ -240,7 +240,7 @@ def parse_flags(flags: List[str]) -> Options:
         "--visualize",
         dest="visualize",
         action="store_true",
-        help="display a visualization of the control flow graph using graphviz",
+        help="print an SVG visualization of the control flow graph using graphviz",
     )
     group.add_argument(
         "--sanitize-tracebacks",
@@ -340,6 +340,10 @@ def parse_flags(flags: List[str]) -> Options:
             functions.append(int(fn))
         except ValueError:
             functions.append(fn)
+
+    # The debug output interferes with the visualize output
+    if args.visualize:
+        args.debug = False
 
     return Options(
         filenames=filenames,

--- a/website.py
+++ b/website.py
@@ -89,15 +89,15 @@ try:
             if "dark" in form:
                 print(
                     """
-    <head>
-    <style>
-    body {
-        background-color: #454545;
-        color: #c0c0c0;
-    }
-    </style>
-    </head>
-    """
+<head>
+<style>
+body {
+    background-color: #454545;
+    color: #c0c0c0;
+}
+</style>
+</head>
+"""
                 )
             print("<body><pre><plaintext>", end="")
             print(res.stdout.decode("utf-8", "replace"))
@@ -167,19 +167,19 @@ label {
 <body>
 <form action="?go" method="post">
 <div class="main">
-<div>
+  <div>
     MIPS assembly:
-</div>
-<div style="flex: 20;">
+  </div>
+  <div style="flex: 20;">
     <textarea name="source"></textarea>
-</div>
-<div style="margin-top: 10px;">
+  </div>
+  <div style="margin-top: 10px;">
     Existing C source, preprocessed (optional):
-</div>
-<div style="flex: 11;">
+  </div>
+  <div style="flex: 11;">
     <textarea name="context"></textarea>
-</div>
-<div style="margin-top: 10px;" id="options">
+  </div>
+  <div style="margin-top: 10px;" id="options">
     <input type="submit" value="Decompile">
     <input type="submit" name="visualize" value="Visualize">
     <label>Function: <select name="functionselect"></select></label>
@@ -202,15 +202,15 @@ label {
     <label><input type="checkbox" name="noifs">Use gotos for everything</label> (to use a goto for a single branch, add "# GOTO" to the asm)
     <label><input type="checkbox" name="usesidebar">Output sidebar</label>
     <label><input type="checkbox" name="dark">Dark mode</label>
-</div>
+  </div>
 </div>
 <div class="sidebar">
-<div>
+  <div>
     Output:
-</div>
-<div style="flex: 1;">
+  </div>
+  <div style="flex: 1;">
     <iframe src="about:blank" name="outputframe"></iframe>
-</div>
+  </div>
 </div>
 <script>
 var formEl = document.getElementsByTagName("form")[0]

--- a/website.py
+++ b/website.py
@@ -9,15 +9,14 @@ import sys
 # cgi tracebacks
 cgitb.enable()
 
-form = cgi.FieldStorage()
-do_visualize = "visualize" in form
-if do_visualize:
-    print(f"Content-Type: image/svg+xml; charset=utf-8")
-else:
-    print(f"Content-Type: text/html; charset=utf-8")
-print()
-sys.stdout.flush()
 
+def print_headers(content_type: str) -> None:
+    print(f"Content-Type: {content_type}; charset=utf-8")
+    print()
+    sys.stdout.flush()
+
+
+form = cgi.FieldStorage()
 if "source" in form:
     source = form["source"].value if "source" in form else ""
     context = form["context"].value if "context" in form else None
@@ -42,7 +41,7 @@ if "source" in form:
         cmd.extend(["--pointer-style", "left"])
     if "globals" in form:
         cmd.append("--emit-globals")
-    if do_visualize:
+    if "visualize" in form:
         cmd.append("--visualize")
     function = form["functionselect"].value if "functionselect" in form else "all"
     if function != "all":
@@ -80,9 +79,11 @@ if "source" in form:
             input=source,
             timeout=15,
         )
-    if do_visualize and res.returncode == 0:
+    if "visualize" in form and res.returncode == 0:
+        print_headers(content_type="image/svg+xml")
         print(res.stdout.decode("utf-8", "replace"))
     else:
+        print_headers(content_type="text/html")
         print("<!DOCTYPE html><html>")
         if "dark" in form:
             print(
@@ -102,6 +103,7 @@ body {
 elif "?go" in os.environ.get("REQUEST_URI", ""):
     pass
 else:
+    print_headers(content_type="text/html")
     print(
         """
 <!DOCTYPE html><html>

--- a/website.py
+++ b/website.py
@@ -3,6 +3,7 @@ import tempfile
 import cgi
 import cgitb
 import os
+import string
 import subprocess
 import sys
 
@@ -43,9 +44,13 @@ if "source" in form:
         cmd.append("--emit-globals")
     if "visualize" in form:
         cmd.append("--visualize")
+
     function = form["functionselect"].value if "functionselect" in form else "all"
-    if function != "all":
+    FUNCTION_ALPHABET = string.ascii_letters + string.digits + "_"
+    function = "".join(c for c in function if c in FUNCTION_ALPHABET)
+    if function and function != "all":
         cmd.extend(["--function", function])
+
     regvars = ""
     if "regvarsselect" in form:
         sel = form["regvarsselect"].value
@@ -53,7 +58,7 @@ if "source" in form:
             regvars = sel
         elif sel == "custom":
             regvars = form.getvalue("regvars", "")
-            REG_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789,"
+            REG_ALPHABET = string.ascii_lowercase + string.digits + ","
             regvars = "".join(c for c in regvars if c in REG_ALPHABET)
 
     if regvars:

--- a/website.py
+++ b/website.py
@@ -16,54 +16,63 @@ def print_headers(content_type: str) -> None:
     sys.stdout.flush()
 
 
-form = cgi.FieldStorage()
-if "source" in form:
-    source = form["source"].value if "source" in form else ""
-    context = form["context"].value if "context" in form else None
-    if "glabel" not in source:
-        source = "glabel foo\n" + source
-    source = bytes(source, "utf-8")
-    script_path = os.path.join(os.path.dirname(__file__), "mips_to_c.py")
-    cmd = ["python3", script_path, "/dev/stdin"]
-    if "debug" in form:
-        cmd.append("--debug")
-    if "void" in form:
-        cmd.append("--void")
-    if "noifs" in form:
-        cmd.append("--no-ifs")
-    if "noandor" in form:
-        cmd.append("--no-andor")
-    if "nocasts" in form:
-        cmd.append("--no-casts")
-    if "allman" in form:
-        cmd.append("--allman")
-    if "leftptr" in form:
-        cmd.extend(["--pointer-style", "left"])
-    if "globals" in form:
-        cmd.append("--emit-globals")
-    if "visualize" in form:
-        cmd.append("--visualize")
-    function = form["functionselect"].value if "functionselect" in form else "all"
-    if function != "all":
-        cmd.extend(["--function", function])
-    regvars = ""
-    if "regvarsselect" in form:
-        sel = form["regvarsselect"].value
-        if sel in ("saved", "most", "all"):
-            regvars = sel
-        elif sel == "custom":
-            regvars = form.getvalue("regvars", "")
-            REG_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789,"
-            regvars = "".join(c for c in regvars if c in REG_ALPHABET)
+try:
+    form = cgi.FieldStorage()
+    if "source" in form:
+        source = form["source"].value if "source" in form else ""
+        context = form["context"].value if "context" in form else None
+        if "glabel" not in source:
+            source = "glabel foo\n" + source
+        source = bytes(source, "utf-8")
+        script_path = os.path.join(os.path.dirname(__file__), "mips_to_c.py")
+        cmd = ["python3", script_path, "/dev/stdin"]
+        if "debug" in form:
+            cmd.append("--debug")
+        if "void" in form:
+            cmd.append("--void")
+        if "noifs" in form:
+            cmd.append("--no-ifs")
+        if "noandor" in form:
+            cmd.append("--no-andor")
+        if "nocasts" in form:
+            cmd.append("--no-casts")
+        if "allman" in form:
+            cmd.append("--allman")
+        if "leftptr" in form:
+            cmd.extend(["--pointer-style", "left"])
+        if "globals" in form:
+            cmd.append("--emit-globals")
+        if "visualize" in form:
+            cmd.append("--visualize")
+        function = form["functionselect"].value if "functionselect" in form else "all"
+        if function != "all":
+            cmd.extend(["--function", function])
+        regvars = ""
+        if "regvarsselect" in form:
+            sel = form["regvarsselect"].value
+            if sel in ("saved", "most", "all"):
+                regvars = sel
+            elif sel == "custom":
+                regvars = form.getvalue("regvars", "")
+                REG_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789,"
+                regvars = "".join(c for c in regvars if c in REG_ALPHABET)
 
-    if regvars:
-        cmd.append("--reg-vars")
-        cmd.append(regvars)
-    if context:
-        with tempfile.NamedTemporaryFile() as f:
-            f.write(bytes(context, "utf-8"))
-            f.file.close()
-            cmd.extend(["--context", f.name])
+        if regvars:
+            cmd.append("--reg-vars")
+            cmd.append(regvars)
+        if context:
+            with tempfile.NamedTemporaryFile() as f:
+                f.write(bytes(context, "utf-8"))
+                f.file.close()
+                cmd.extend(["--context", f.name])
+                res = subprocess.run(
+                    cmd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    input=source,
+                    timeout=15,
+                )
+        else:
             res = subprocess.run(
                 cmd,
                 stdout=subprocess.PIPE,
@@ -71,244 +80,239 @@ if "source" in form:
                 input=source,
                 timeout=15,
             )
-    else:
-        res = subprocess.run(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            input=source,
-            timeout=15,
-        )
-    if "visualize" in form and res.returncode == 0:
-        print_headers(content_type="image/svg+xml")
-        print(res.stdout.decode("utf-8", "replace"))
+        if "visualize" in form and res.returncode == 0:
+            print_headers(content_type="image/svg+xml")
+            print(res.stdout.decode("utf-8", "replace"))
+        else:
+            print_headers(content_type="text/html")
+            print("<!DOCTYPE html><html>")
+            if "dark" in form:
+                print(
+                    """
+    <head>
+    <style>
+    body {
+        background-color: #454545;
+        color: #c0c0c0;
+    }
+    </style>
+    </head>
+    """
+                )
+            print("<body><pre><plaintext>", end="")
+            print(res.stdout.decode("utf-8", "replace"))
+    elif "?go" in os.environ.get("REQUEST_URI", ""):
+        pass
     else:
         print_headers(content_type="text/html")
-        print("<!DOCTYPE html><html>")
-        if "dark" in form:
-            print(
-                """
-<head>
-<style>
-body {
-    background-color: #454545;
-    color: #c0c0c0;
-}
-</style>
-</head>
-"""
-            )
-        print("<body><pre><plaintext>", end="")
-        print(res.stdout.decode("utf-8", "replace"))
-elif "?go" in os.environ.get("REQUEST_URI", ""):
-    pass
-else:
-    print_headers(content_type="text/html")
-    print(
-        """
-<!DOCTYPE html><html>
-<head>
-<style>
-* {
-    box-sizing: border-box;
-}
-html, body, form, .main, .sidebar {
-    margin: 0;
-    height: 100%;
-}
-textarea, .sidebar iframe {
-    width: 100%;
-    height: 100%;
-    border: 1px solid #bbb;
-    margin: 1px 0;
-}
-label {
-    white-space: nowrap;
-}
-[data-regvars]:not([data-regvars=custom]) [name=regvars] {
-    display: none;
-}
-[name=regvars] {
-    width: 150px;
-}
-.main, .sidebar {
-    display: flex;
-    flex-direction: column;
-    padding: 10px;
-}
-.sidebar {
-    display: none;
-}
-.has-sidebar form {
-    display: flex;
-    flex-direction: row;
-}
-.has-sidebar .main, .has-sidebar .sidebar {
-    flex: 1;
-}
-.has-sidebar .sidebar {
-    display: flex;
-}
-.dark-theme {
-    background-color: #2d2d2d;
-    color: #c0c0c0;
-}
-.dark-theme div,
-.dark-theme body,
-.dark-theme form,
-.dark-theme textarea {
-    background-color: rgba(255, 255, 255, 0.0225);
-    color: #c0c0c0;
-    box-shadow: 1px 1px 10px 0px black;
-}
-</style>
-</head>
-<body>
-<form action="?go" method="post">
-<div class="main">
-  <div>
-    MIPS assembly:
-  </div>
-  <div style="flex: 20;">
-    <textarea name="source"></textarea>
-  </div>
-  <div style="margin-top: 10px;">
-    Existing C source, preprocessed (optional):
-  </div>
-  <div style="flex: 11;">
-    <textarea name="context"></textarea>
-  </div>
-  <div style="margin-top: 10px;" id="options">
-    <input type="submit" value="Decompile">
-    <input type="submit" name="visualize" value="Visualize">
-    <label>Function: <select name="functionselect"></select></label>
-    <label>Use single var for:
-    <select name="regvarsselect">
-    <option value="none">none</option>
-    <option value="saved">saved regs</option>
-    <option value="all">all regs</option>
-    <option value="custom">custom</option>
-    </select>
-    </label>
-    <input name="regvars" value="">
-    <label><input type="checkbox" name="void">Force void return type</label>
-    <label><input type="checkbox" name="debug">Debug info</label>
-    <label><input type="checkbox" name="noandor">Disable &amp;&amp;/||</label>
-    <label><input type="checkbox" name="nocasts">Hide type casts</label>
-    <label><input type="checkbox" name="allman">Allman braces</label>
-    <label><input type="checkbox" name="leftptr">* to the left</label>
-    <label><input type="checkbox" name="globals" checked>Global declarations</label>
-    <label><input type="checkbox" name="noifs">Use gotos for everything</label> (to use a goto for a single branch, add "# GOTO" to the asm)
-    <label><input type="checkbox" name="usesidebar">Output sidebar</label>
-    <label><input type="checkbox" name="dark">Dark mode</label>
-  </div>
-</div>
-<div class="sidebar">
-  <div>
-    Output:
-  </div>
-  <div style="flex: 1;">
-    <iframe src="about:blank" name="outputframe"></iframe>
-  </div>
-</div>
-<script>
-var formEl = document.getElementsByTagName("form")[0]
-var sourceEl = document.getElementsByName("source")[0];
-var contextEl = document.getElementsByName("context")[0];
-var sidebarCheckboxEl = document.getElementsByName("usesidebar")[0];
-var savedSource = localStorage.mips_to_c_saved_source;
-var savedContext = localStorage.mips_to_c_saved_context;
-var savedOptions = localStorage.mips_to_c_saved_options;
-if (savedSource) sourceEl.value = savedSource;
-if (savedContext) contextEl.value = savedContext;
-if (savedOptions) {
-    savedOptions = JSON.parse(savedOptions);
-    for (var key in savedOptions) {
-        var el = document.getElementsByName(key)[0], val = savedOptions[key];
-        if (el) {
-            if (el.type === "checkbox")
-                el.checked = val === "yes";
-            else
-                el.value = val;
+        print(
+            """
+    <!DOCTYPE html><html>
+    <head>
+    <style>
+    * {
+        box-sizing: border-box;
+    }
+    html, body, form, .main, .sidebar {
+        margin: 0;
+        height: 100%;
+    }
+    textarea, .sidebar iframe {
+        width: 100%;
+        height: 100%;
+        border: 1px solid #bbb;
+        margin: 1px 0;
+    }
+    label {
+        white-space: nowrap;
+    }
+    [data-regvars]:not([data-regvars=custom]) [name=regvars] {
+        display: none;
+    }
+    [name=regvars] {
+        width: 150px;
+    }
+    .main, .sidebar {
+        display: flex;
+        flex-direction: column;
+        padding: 10px;
+    }
+    .sidebar {
+        display: none;
+    }
+    .has-sidebar form {
+        display: flex;
+        flex-direction: row;
+    }
+    .has-sidebar .main, .has-sidebar .sidebar {
+        flex: 1;
+    }
+    .has-sidebar .sidebar {
+        display: flex;
+    }
+    .dark-theme {
+        background-color: #2d2d2d;
+        color: #c0c0c0;
+    }
+    .dark-theme div,
+    .dark-theme body,
+    .dark-theme form,
+    .dark-theme textarea {
+        background-color: rgba(255, 255, 255, 0.0225);
+        color: #c0c0c0;
+        box-shadow: 1px 1px 10px 0px black;
+    }
+    </style>
+    </head>
+    <body>
+    <form action="?go" method="post">
+    <div class="main">
+    <div>
+        MIPS assembly:
+    </div>
+    <div style="flex: 20;">
+        <textarea name="source"></textarea>
+    </div>
+    <div style="margin-top: 10px;">
+        Existing C source, preprocessed (optional):
+    </div>
+    <div style="flex: 11;">
+        <textarea name="context"></textarea>
+    </div>
+    <div style="margin-top: 10px;" id="options">
+        <input type="submit" value="Decompile">
+        <input type="submit" name="visualize" value="Visualize">
+        <label>Function: <select name="functionselect"></select></label>
+        <label>Use single var for:
+        <select name="regvarsselect">
+        <option value="none">none</option>
+        <option value="saved">saved regs</option>
+        <option value="all">all regs</option>
+        <option value="custom">custom</option>
+        </select>
+        </label>
+        <input name="regvars" value="">
+        <label><input type="checkbox" name="void">Force void return type</label>
+        <label><input type="checkbox" name="debug">Debug info</label>
+        <label><input type="checkbox" name="noandor">Disable &amp;&amp;/||</label>
+        <label><input type="checkbox" name="nocasts">Hide type casts</label>
+        <label><input type="checkbox" name="allman">Allman braces</label>
+        <label><input type="checkbox" name="leftptr">* to the left</label>
+        <label><input type="checkbox" name="globals" checked>Global declarations</label>
+        <label><input type="checkbox" name="noifs">Use gotos for everything</label> (to use a goto for a single branch, add "# GOTO" to the asm)
+        <label><input type="checkbox" name="usesidebar">Output sidebar</label>
+        <label><input type="checkbox" name="dark">Dark mode</label>
+    </div>
+    </div>
+    <div class="sidebar">
+    <div>
+        Output:
+    </div>
+    <div style="flex: 1;">
+        <iframe src="about:blank" name="outputframe"></iframe>
+    </div>
+    </div>
+    <script>
+    var formEl = document.getElementsByTagName("form")[0]
+    var sourceEl = document.getElementsByName("source")[0];
+    var contextEl = document.getElementsByName("context")[0];
+    var sidebarCheckboxEl = document.getElementsByName("usesidebar")[0];
+    var savedSource = localStorage.mips_to_c_saved_source;
+    var savedContext = localStorage.mips_to_c_saved_context;
+    var savedOptions = localStorage.mips_to_c_saved_options;
+    if (savedSource) sourceEl.value = savedSource;
+    if (savedContext) contextEl.value = savedContext;
+    if (savedOptions) {
+        savedOptions = JSON.parse(savedOptions);
+        for (var key in savedOptions) {
+            var el = document.getElementsByName(key)[0], val = savedOptions[key];
+            if (el) {
+                if (el.type === "checkbox")
+                    el.checked = val === "yes";
+                else
+                    el.value = val;
+            }
         }
     }
-}
 
-var darkModeCheckbox = document.getElementsByName("dark")[0];
-if (!savedOptions || !("dark" in savedOptions)) {
-    darkModeCheckbox.checked = window.matchMedia("prefers-color-scheme: dark").matches;
-}
+    var darkModeCheckbox = document.getElementsByName("dark")[0];
+    if (!savedOptions || !("dark" in savedOptions)) {
+        darkModeCheckbox.checked = window.matchMedia("prefers-color-scheme: dark").matches;
+    }
 
-function updateDarkMode() {
-    document.documentElement.className = darkModeCheckbox.checked ? "dark-theme" : "";
-}
-updateDarkMode();
-darkModeCheckbox.addEventListener("change", updateDarkMode);
+    function updateDarkMode() {
+        document.documentElement.className = darkModeCheckbox.checked ? "dark-theme" : "";
+    }
+    updateDarkMode();
+    darkModeCheckbox.addEventListener("change", updateDarkMode);
 
-function updateFunctions() {
-    var functionSelect = document.getElementsByName("functionselect")[0];
-    var prevValue = functionSelect.value;
-    var options = "<option value='all'>all functions</option>";
-    for (var line of sourceEl.value.split("\\n")) {
-        //var match = line.match(/^\\w*glabel\\w*([A-Za-z0-9_]+)/)
-        var match = line.match(/^\\s*glabel\\s+([A-Za-z0-9_]+)/)
-        if (match) {
+    function updateFunctions() {
+        var functionSelect = document.getElementsByName("functionselect")[0];
+        var prevValue = functionSelect.value;
+        functionSelect.innerHTML = "<option value='all'>all functions</option>";
+        for (let match of sourceEl.value.matchAll(/^\\s*glabel\\s+([A-Za-z0-9_]+)/mg)) {
             var name = match[1];
-            options += "<option value='" + name + "' " + (name == prevValue ? "selected" : "") + ">" + name + "</option>";
+
+            var option = document.createElement("option");
+            option.value = name;
+            option.innerText = name;
+            option.selected = (name == prevValue);
+            functionSelect.appendChild(option);
         }
     }
+    updateFunctions();
+    sourceEl.addEventListener("blur", updateFunctions);
 
-    functionSelect.innerHTML = options;
-}
-updateFunctions();
-sourceEl.addEventListener("blur", updateFunctions);
-
-var regVarsSelect = document.getElementsByName("regvarsselect")[0];
-function updateRegVars(e) {
-    document.body.setAttribute("data-regvars", regVarsSelect.value);
-    if (regVarsSelect.value === "custom" && e) {
-        document.getElementsByName("regvars")[0].value = "s0,s1,s2";
+    var regVarsSelect = document.getElementsByName("regvarsselect")[0];
+    function updateRegVars(e) {
+        document.body.setAttribute("data-regvars", regVarsSelect.value);
+        if (regVarsSelect.value === "custom" && e) {
+            document.getElementsByName("regvars")[0].value = "s0,s1,s2";
+        }
     }
-}
-updateRegVars();
-regVarsSelect.addEventListener("change", updateRegVars);
+    updateRegVars();
+    regVarsSelect.addEventListener("change", updateRegVars);
 
-sourceEl.addEventListener("change", function() {
-    localStorage.mips_to_c_saved_source = sourceEl.value;
-});
-contextEl.addEventListener("change", function() {
-    localStorage.mips_to_c_saved_context = contextEl.value;
-});
-document.getElementById("options").addEventListener("change", function(event) {
-    var shouldSave = ["usesidebar", "allman", "leftptr", "globals", "nocasts", "noandor", "dark", "regvarsselect", "regvars"];
-    var options = {};
-    for (var key of shouldSave) {
-        var el = document.getElementsByName(key)[0];
-        options[key] = (el.type === "checkbox" ?
-            (el.checked ? "yes" : "no") :
-            el.value);
+    sourceEl.addEventListener("change", function() {
+        localStorage.mips_to_c_saved_source = sourceEl.value;
+    });
+    contextEl.addEventListener("change", function() {
+        localStorage.mips_to_c_saved_context = contextEl.value;
+    });
+    document.getElementById("options").addEventListener("change", function(event) {
+        var shouldSave = ["usesidebar", "allman", "leftptr", "globals", "nocasts", "noandor", "dark", "regvarsselect", "regvars"];
+        var options = {};
+        for (var key of shouldSave) {
+            var el = document.getElementsByName(key)[0];
+            options[key] = (el.type === "checkbox" ?
+                (el.checked ? "yes" : "no") :
+                el.value);
+        }
+        localStorage.mips_to_c_saved_options = JSON.stringify(options);
+    });
+
+    function updateSidebar() {
+        document.body.classList.toggle("has-sidebar", sidebarCheckboxEl.checked);
+        formEl.setAttribute("target", sidebarCheckboxEl.checked ? "outputframe" : "");
+        try {
+            document.getElementsByName("outputframe")[0].contentDocument.body.innerHTML = "";
+        } catch (e) {}
     }
-    localStorage.mips_to_c_saved_options = JSON.stringify(options);
-});
-
-function updateSidebar() {
-    document.body.classList.toggle("has-sidebar", sidebarCheckboxEl.checked);
-    formEl.setAttribute("target", sidebarCheckboxEl.checked ? "outputframe" : "");
-    try {
-        document.getElementsByName("outputframe")[0].contentDocument.body.innerHTML = "";
-    } catch (e) {}
-}
-updateSidebar();
-sidebarCheckboxEl.addEventListener("change", updateSidebar);
-formEl.addEventListener("submit", function() {
-    if (!sidebarCheckboxEl.checked) return;
-    try {
-        document.getElementsByName("outputframe")[0].contentDocument.body.innerHTML = "Decompiling...";
-    } catch (e) {}
-});
-</script>
-</form>
-</body>
-</html>
-"""
-    )
+    updateSidebar();
+    sidebarCheckboxEl.addEventListener("change", updateSidebar);
+    formEl.addEventListener("submit", function() {
+        if (!sidebarCheckboxEl.checked) return;
+        try {
+            document.getElementsByName("outputframe")[0].contentDocument.body.innerHTML = "Decompiling...";
+        } catch (e) {}
+    });
+    </script>
+    </form>
+    </body>
+    </html>
+    """
+        )
+except:
+    # Set the headers for the cgitb traceback
+    print_headers(content_type="text/html")
+    raise

--- a/website.py
+++ b/website.py
@@ -107,209 +107,209 @@ try:
         print_headers(content_type="text/html")
         print(
             """
-    <!DOCTYPE html><html>
-    <head>
-    <style>
-    * {
-        box-sizing: border-box;
-    }
-    html, body, form, .main, .sidebar {
-        margin: 0;
-        height: 100%;
-    }
-    textarea, .sidebar iframe {
-        width: 100%;
-        height: 100%;
-        border: 1px solid #bbb;
-        margin: 1px 0;
-    }
-    label {
-        white-space: nowrap;
-    }
-    [data-regvars]:not([data-regvars=custom]) [name=regvars] {
-        display: none;
-    }
-    [name=regvars] {
-        width: 150px;
-    }
-    .main, .sidebar {
-        display: flex;
-        flex-direction: column;
-        padding: 10px;
-    }
-    .sidebar {
-        display: none;
-    }
-    .has-sidebar form {
-        display: flex;
-        flex-direction: row;
-    }
-    .has-sidebar .main, .has-sidebar .sidebar {
-        flex: 1;
-    }
-    .has-sidebar .sidebar {
-        display: flex;
-    }
-    .dark-theme {
-        background-color: #2d2d2d;
-        color: #c0c0c0;
-    }
-    .dark-theme div,
-    .dark-theme body,
-    .dark-theme form,
-    .dark-theme textarea {
-        background-color: rgba(255, 255, 255, 0.0225);
-        color: #c0c0c0;
-        box-shadow: 1px 1px 10px 0px black;
-    }
-    </style>
-    </head>
-    <body>
-    <form action="?go" method="post">
-    <div class="main">
-    <div>
-        MIPS assembly:
-    </div>
-    <div style="flex: 20;">
-        <textarea name="source"></textarea>
-    </div>
-    <div style="margin-top: 10px;">
-        Existing C source, preprocessed (optional):
-    </div>
-    <div style="flex: 11;">
-        <textarea name="context"></textarea>
-    </div>
-    <div style="margin-top: 10px;" id="options">
-        <input type="submit" value="Decompile">
-        <input type="submit" name="visualize" value="Visualize">
-        <label>Function: <select name="functionselect"></select></label>
-        <label>Use single var for:
-        <select name="regvarsselect">
-        <option value="none">none</option>
-        <option value="saved">saved regs</option>
-        <option value="all">all regs</option>
-        <option value="custom">custom</option>
-        </select>
-        </label>
-        <input name="regvars" value="">
-        <label><input type="checkbox" name="void">Force void return type</label>
-        <label><input type="checkbox" name="debug">Debug info</label>
-        <label><input type="checkbox" name="noandor">Disable &amp;&amp;/||</label>
-        <label><input type="checkbox" name="nocasts">Hide type casts</label>
-        <label><input type="checkbox" name="allman">Allman braces</label>
-        <label><input type="checkbox" name="leftptr">* to the left</label>
-        <label><input type="checkbox" name="globals" checked>Global declarations</label>
-        <label><input type="checkbox" name="noifs">Use gotos for everything</label> (to use a goto for a single branch, add "# GOTO" to the asm)
-        <label><input type="checkbox" name="usesidebar">Output sidebar</label>
-        <label><input type="checkbox" name="dark">Dark mode</label>
-    </div>
-    </div>
-    <div class="sidebar">
-    <div>
-        Output:
-    </div>
-    <div style="flex: 1;">
-        <iframe src="about:blank" name="outputframe"></iframe>
-    </div>
-    </div>
-    <script>
-    var formEl = document.getElementsByTagName("form")[0]
-    var sourceEl = document.getElementsByName("source")[0];
-    var contextEl = document.getElementsByName("context")[0];
-    var sidebarCheckboxEl = document.getElementsByName("usesidebar")[0];
-    var savedSource = localStorage.mips_to_c_saved_source;
-    var savedContext = localStorage.mips_to_c_saved_context;
-    var savedOptions = localStorage.mips_to_c_saved_options;
-    if (savedSource) sourceEl.value = savedSource;
-    if (savedContext) contextEl.value = savedContext;
-    if (savedOptions) {
-        savedOptions = JSON.parse(savedOptions);
-        for (var key in savedOptions) {
-            var el = document.getElementsByName(key)[0], val = savedOptions[key];
-            if (el) {
-                if (el.type === "checkbox")
-                    el.checked = val === "yes";
-                else
-                    el.value = val;
-            }
+<!DOCTYPE html><html>
+<head>
+<style>
+* {
+    box-sizing: border-box;
+}
+html, body, form, .main, .sidebar {
+    margin: 0;
+    height: 100%;
+}
+textarea, .sidebar iframe {
+    width: 100%;
+    height: 100%;
+    border: 1px solid #bbb;
+    margin: 1px 0;
+}
+label {
+    white-space: nowrap;
+}
+[data-regvars]:not([data-regvars=custom]) [name=regvars] {
+    display: none;
+}
+[name=regvars] {
+    width: 150px;
+}
+.main, .sidebar {
+    display: flex;
+    flex-direction: column;
+    padding: 10px;
+}
+.sidebar {
+    display: none;
+}
+.has-sidebar form {
+    display: flex;
+    flex-direction: row;
+}
+.has-sidebar .main, .has-sidebar .sidebar {
+    flex: 1;
+}
+.has-sidebar .sidebar {
+    display: flex;
+}
+.dark-theme {
+    background-color: #2d2d2d;
+    color: #c0c0c0;
+}
+.dark-theme div,
+.dark-theme body,
+.dark-theme form,
+.dark-theme textarea {
+    background-color: rgba(255, 255, 255, 0.0225);
+    color: #c0c0c0;
+    box-shadow: 1px 1px 10px 0px black;
+}
+</style>
+</head>
+<body>
+<form action="?go" method="post">
+<div class="main">
+<div>
+    MIPS assembly:
+</div>
+<div style="flex: 20;">
+    <textarea name="source"></textarea>
+</div>
+<div style="margin-top: 10px;">
+    Existing C source, preprocessed (optional):
+</div>
+<div style="flex: 11;">
+    <textarea name="context"></textarea>
+</div>
+<div style="margin-top: 10px;" id="options">
+    <input type="submit" value="Decompile">
+    <input type="submit" name="visualize" value="Visualize">
+    <label>Function: <select name="functionselect"></select></label>
+    <label>Use single var for:
+    <select name="regvarsselect">
+    <option value="none">none</option>
+    <option value="saved">saved regs</option>
+    <option value="all">all regs</option>
+    <option value="custom">custom</option>
+    </select>
+    </label>
+    <input name="regvars" value="">
+    <label><input type="checkbox" name="void">Force void return type</label>
+    <label><input type="checkbox" name="debug">Debug info</label>
+    <label><input type="checkbox" name="noandor">Disable &amp;&amp;/||</label>
+    <label><input type="checkbox" name="nocasts">Hide type casts</label>
+    <label><input type="checkbox" name="allman">Allman braces</label>
+    <label><input type="checkbox" name="leftptr">* to the left</label>
+    <label><input type="checkbox" name="globals" checked>Global declarations</label>
+    <label><input type="checkbox" name="noifs">Use gotos for everything</label> (to use a goto for a single branch, add "# GOTO" to the asm)
+    <label><input type="checkbox" name="usesidebar">Output sidebar</label>
+    <label><input type="checkbox" name="dark">Dark mode</label>
+</div>
+</div>
+<div class="sidebar">
+<div>
+    Output:
+</div>
+<div style="flex: 1;">
+    <iframe src="about:blank" name="outputframe"></iframe>
+</div>
+</div>
+<script>
+var formEl = document.getElementsByTagName("form")[0]
+var sourceEl = document.getElementsByName("source")[0];
+var contextEl = document.getElementsByName("context")[0];
+var sidebarCheckboxEl = document.getElementsByName("usesidebar")[0];
+var savedSource = localStorage.mips_to_c_saved_source;
+var savedContext = localStorage.mips_to_c_saved_context;
+var savedOptions = localStorage.mips_to_c_saved_options;
+if (savedSource) sourceEl.value = savedSource;
+if (savedContext) contextEl.value = savedContext;
+if (savedOptions) {
+    savedOptions = JSON.parse(savedOptions);
+    for (var key in savedOptions) {
+        var el = document.getElementsByName(key)[0], val = savedOptions[key];
+        if (el) {
+            if (el.type === "checkbox")
+                el.checked = val === "yes";
+            else
+                el.value = val;
         }
     }
+}
 
-    var darkModeCheckbox = document.getElementsByName("dark")[0];
-    if (!savedOptions || !("dark" in savedOptions)) {
-        darkModeCheckbox.checked = window.matchMedia("prefers-color-scheme: dark").matches;
+var darkModeCheckbox = document.getElementsByName("dark")[0];
+if (!savedOptions || !("dark" in savedOptions)) {
+    darkModeCheckbox.checked = window.matchMedia("prefers-color-scheme: dark").matches;
+}
+
+function updateDarkMode() {
+    document.documentElement.className = darkModeCheckbox.checked ? "dark-theme" : "";
+}
+updateDarkMode();
+darkModeCheckbox.addEventListener("change", updateDarkMode);
+
+function updateFunctions() {
+    var functionSelect = document.getElementsByName("functionselect")[0];
+    var prevValue = functionSelect.value;
+    functionSelect.innerHTML = "<option value='all'>all functions</option>";
+    for (let match of sourceEl.value.matchAll(/^\\s*glabel\\s+([A-Za-z0-9_]+)/mg)) {
+        var name = match[1];
+
+        var option = document.createElement("option");
+        option.value = name;
+        option.innerText = name;
+        option.selected = (name == prevValue);
+        functionSelect.appendChild(option);
     }
+}
+updateFunctions();
+sourceEl.addEventListener("blur", updateFunctions);
 
-    function updateDarkMode() {
-        document.documentElement.className = darkModeCheckbox.checked ? "dark-theme" : "";
+var regVarsSelect = document.getElementsByName("regvarsselect")[0];
+function updateRegVars(e) {
+    document.body.setAttribute("data-regvars", regVarsSelect.value);
+    if (regVarsSelect.value === "custom" && e) {
+        document.getElementsByName("regvars")[0].value = "s0,s1,s2";
     }
-    updateDarkMode();
-    darkModeCheckbox.addEventListener("change", updateDarkMode);
+}
+updateRegVars();
+regVarsSelect.addEventListener("change", updateRegVars);
 
-    function updateFunctions() {
-        var functionSelect = document.getElementsByName("functionselect")[0];
-        var prevValue = functionSelect.value;
-        functionSelect.innerHTML = "<option value='all'>all functions</option>";
-        for (let match of sourceEl.value.matchAll(/^\\s*glabel\\s+([A-Za-z0-9_]+)/mg)) {
-            var name = match[1];
-
-            var option = document.createElement("option");
-            option.value = name;
-            option.innerText = name;
-            option.selected = (name == prevValue);
-            functionSelect.appendChild(option);
-        }
+sourceEl.addEventListener("change", function() {
+    localStorage.mips_to_c_saved_source = sourceEl.value;
+});
+contextEl.addEventListener("change", function() {
+    localStorage.mips_to_c_saved_context = contextEl.value;
+});
+document.getElementById("options").addEventListener("change", function(event) {
+    var shouldSave = ["usesidebar", "allman", "leftptr", "globals", "nocasts", "noandor", "dark", "regvarsselect", "regvars"];
+    var options = {};
+    for (var key of shouldSave) {
+        var el = document.getElementsByName(key)[0];
+        options[key] = (el.type === "checkbox" ?
+            (el.checked ? "yes" : "no") :
+            el.value);
     }
-    updateFunctions();
-    sourceEl.addEventListener("blur", updateFunctions);
+    localStorage.mips_to_c_saved_options = JSON.stringify(options);
+});
 
-    var regVarsSelect = document.getElementsByName("regvarsselect")[0];
-    function updateRegVars(e) {
-        document.body.setAttribute("data-regvars", regVarsSelect.value);
-        if (regVarsSelect.value === "custom" && e) {
-            document.getElementsByName("regvars")[0].value = "s0,s1,s2";
-        }
-    }
-    updateRegVars();
-    regVarsSelect.addEventListener("change", updateRegVars);
-
-    sourceEl.addEventListener("change", function() {
-        localStorage.mips_to_c_saved_source = sourceEl.value;
-    });
-    contextEl.addEventListener("change", function() {
-        localStorage.mips_to_c_saved_context = contextEl.value;
-    });
-    document.getElementById("options").addEventListener("change", function(event) {
-        var shouldSave = ["usesidebar", "allman", "leftptr", "globals", "nocasts", "noandor", "dark", "regvarsselect", "regvars"];
-        var options = {};
-        for (var key of shouldSave) {
-            var el = document.getElementsByName(key)[0];
-            options[key] = (el.type === "checkbox" ?
-                (el.checked ? "yes" : "no") :
-                el.value);
-        }
-        localStorage.mips_to_c_saved_options = JSON.stringify(options);
-    });
-
-    function updateSidebar() {
-        document.body.classList.toggle("has-sidebar", sidebarCheckboxEl.checked);
-        formEl.setAttribute("target", sidebarCheckboxEl.checked ? "outputframe" : "");
-        try {
-            document.getElementsByName("outputframe")[0].contentDocument.body.innerHTML = "";
-        } catch (e) {}
-    }
-    updateSidebar();
-    sidebarCheckboxEl.addEventListener("change", updateSidebar);
-    formEl.addEventListener("submit", function() {
-        if (!sidebarCheckboxEl.checked) return;
-        try {
-            document.getElementsByName("outputframe")[0].contentDocument.body.innerHTML = "Decompiling...";
-        } catch (e) {}
-    });
-    </script>
-    </form>
-    </body>
-    </html>
+function updateSidebar() {
+    document.body.classList.toggle("has-sidebar", sidebarCheckboxEl.checked);
+    formEl.setAttribute("target", sidebarCheckboxEl.checked ? "outputframe" : "");
+    try {
+        document.getElementsByName("outputframe")[0].contentDocument.body.innerHTML = "";
+    } catch (e) {}
+}
+updateSidebar();
+sidebarCheckboxEl.addEventListener("change", updateSidebar);
+formEl.addEventListener("submit", function() {
+    if (!sidebarCheckboxEl.checked) return;
+    try {
+        document.getElementsByName("outputframe")[0].contentDocument.body.innerHTML = "Decompiling...";
+    } catch (e) {}
+});
+</script>
+</form>
+</body>
+</html>
     """
         )
 except:


### PR DESCRIPTION
- "Visualize" button that renders an SVG (requires graphviz)
    - Do you have `graphviz` installed on the server?
    - @simonlindholm Are you OK with the security implications of this? The library's render operations all shell out to a graphviz executable. I could remove this, or have it disabled in `website.py` unless an environment variable is set?
- Checkbox for `--emit-globals`, enabled by default
- Dropdown for selecting function to decomp, default to `all`. (Before it would decomp the first function defined)
   - There's a regex in JS to pick out function names from the assembly, looking for "glabel". It has a lot of false positives (all variable labels), but I think it's an improvement?