### PR TITLE
CType initializers

### DIFF
--- a/src/c_types.py
+++ b/src/c_types.py
@@ -33,6 +33,7 @@ class Struct:
     type: CType
     fields: Dict[int, List[StructField]]
     # TODO: bitfields
+    has_bitfields: bool
     size: int
     align: int
 
@@ -445,6 +446,7 @@ def do_parse_struct(struct: Union[ca.Struct, ca.Union], typemap: TypeMap) -> Str
     align = 1
     offset = 0
     bit_offset = 0
+    has_bitfields = False
     for decl in struct.decls:
         if not isinstance(decl, ca.Decl):
             continue
@@ -460,6 +462,7 @@ def do_parse_struct(struct: Union[ca.Struct, ca.Union], typemap: TypeMap) -> Str
             #   'type' (lw/lh/lb, unsigned counterparts). If it straddles a 'type'
             #   alignment boundary, skip all bits up to that boundary and then use the
             #   next 'b' bits from there instead.
+            has_bitfields = True
             width = parse_constant_int(decl.bitsize, typemap)
             ssize, salign, substr = parse_struct_member(
                 type, field_name, typemap, allow_unsized=False
@@ -537,7 +540,9 @@ def do_parse_struct(struct: Union[ca.Struct, ca.Union], typemap: TypeMap) -> Str
 
     size = union_size if is_union else offset
     size = (size + align - 1) & -align
-    return Struct(type=ctype, fields=fields, size=size, align=align)
+    return Struct(
+        type=ctype, fields=fields, has_bitfields=has_bitfields, size=size, align=align
+    )
 
 
 def add_builtin_typedefs(source: str) -> str:

--- a/src/options.py
+++ b/src/options.py
@@ -58,6 +58,7 @@ class Formatter:
     extra_indent: int = 0
     debug: bool = False
     valid_syntax: bool = False
+    line_length: int = 80
 
     def indent(self, line: str, indent: int = 0) -> str:
         return self.indent_step * max(indent + self.extra_indent, 0) + line
@@ -69,3 +70,22 @@ class Formatter:
             yield
         finally:
             self.extra_indent -= 1
+
+    def format_array(self, elements: List[str]) -> str:
+        # If there are no newlines & the output would be short, put it all on one line.
+        # Here, "line length" is just used as a rough guideline: we aren't accounting
+        # for the LHS of the assignment or any indentation.
+        if not any("\n" in el or len(el) > self.line_length for el in elements):
+            output = f"{{{', '.join(elements)}}}"
+            if len(output) < self.line_length:
+                return output
+
+        # Otherwise, put each element on its own line (and include a trailing comma)
+        output = "{\n"
+        for el in elements:
+            # Add 1 indentation level to the string
+            el = el.replace("\n", "\n" + self.indent_step)
+            output += self.indent(f"{el},\n", 1)
+        output += "}"
+
+        return output

--- a/src/translate.py
+++ b/src/translate.py
@@ -3808,10 +3808,12 @@ class GlobalInfo:
                 members = []
                 for field in ctype_fields:
                     if isinstance(field, int):
-                        # Padding; read the bytes but throw them away
-                        read_uint(field)
+                        # Check that all padding bytes are 0
+                        padding = read_uint(field)
+                        if padding != 0:
+                            return None
                     else:
-                        m = for_type(*field)
+                        m = for_type(field, None)
                         if m is None:
                             return None
                         members.append(m)

--- a/src/translate.py
+++ b/src/translate.py
@@ -3813,7 +3813,7 @@ class GlobalInfo:
                         if padding != 0:
                             return None
                     else:
-                        m = for_type(field, None)
+                        m = for_element_type(field)
                         if m is None:
                             return None
                         members.append(m)

--- a/src/types.py
+++ b/src/types.py
@@ -260,7 +260,6 @@ class Type:
             # Choose the first field in a union, or the unexpanded name in a struct
             field = fields[0]
             field_type = type_from_ctype(field.type, data.typemap, array_decay=False)
-            assert field_type is not None
             size, align = field_type.get_size_align_bytes()
             output.append(field_type)
             position = offset + size

--- a/src/types.py
+++ b/src/types.py
@@ -212,13 +212,13 @@ class Type:
 
     def get_ctype_fields(
         self,
-    ) -> Optional[List[Union[int, Tuple["Type", Optional[int]]]]]:
+    ) -> Optional[List[Union[int, "Type"]]]:
         """
         If self is a CType, get a list of fields, suitable for creating an initializer,
         or return None if an initializer cannot be made (e.g. a struct with bitfields)
 
         Struct padding is represented by an int in the list, otherwise the list members
-        denote the field's Type & array dimension.
+        denote the field's Type.
         """
         data = self.data()
         if data.kind != TypeData.K_CTYPE or data.ctype_ref is None:
@@ -232,8 +232,10 @@ class Type:
         if isinstance(ctype, ca.ArrayDecl):
             inner_type, dim = ptr_type_from_ctype(ctype, data.typemap)
             field_type = inner_type.get_pointer_target()
-            assert dim is not None and field_type is not None
-            return [(field_type, None)] * dim
+            if not dim or field_type is None:
+                # Do not support zero-sized arrays
+                return None
+            return [field_type] * dim
 
         # Lookup the c_types.Struct representation
         if not isinstance(ctype, ca.TypeDecl):
@@ -245,7 +247,7 @@ class Type:
             # Bitfields aren't supported; they aren't represented in `struct.fields`
             return None
 
-        output: List[Union[int, Tuple[Type, Optional[int]]]] = []
+        output: List[Union[int, Type]] = []
         position = 0
         for offset, fields in sorted(struct.fields.items()):
             if offset < position:
@@ -257,14 +259,11 @@ class Type:
 
             # Choose the first field in a union, or the unexpanded name in a struct
             field = fields[0]
-            field_ptr, dim = ptr_type_from_ctype(field.type, data.typemap)
-            field_type = field_ptr.get_pointer_target()
+            field_type = type_from_ctype(field.type, data.typemap, array_decay=False)
             assert field_type is not None
             size, align = field_type.get_size_align_bytes()
-            full_size = size * (1 if dim is None else dim)
-            assert full_size == field.size
-            output.append((field_type, dim))
-            position = offset + full_size
+            output.append(field_type)
+            position = offset + size
 
         assert position <= struct.size
         if position < struct.size:
@@ -569,7 +568,7 @@ def type_from_ctype(ctype: CType, typemap: TypeMap, array_decay: bool = True) ->
             size *= dim
         return Type._ctype(real_ctype, typemap, size=size)
     if isinstance(real_ctype, ca.PtrDecl):
-        return ptr_type_from_ctype(real_ctype.type, typemap)[0]
+        return Type.ptr(type_from_ctype(real_ctype.type, typemap, array_decay=False))
     if isinstance(real_ctype, ca.FuncDecl):
         fn = parse_function(real_ctype)
         assert fn is not None
@@ -691,7 +690,7 @@ def find_substruct_array(
     struct = get_struct(ctype.type, typemap)
     if not struct:
         return None
-    for off, fields in struct.fields.items():
+    for off, fields in sorted(struct.fields.items()):
         if offset < off:
             continue
         for field in fields:

--- a/tests/end_to_end/global_decls/irix-o2-out.c
+++ b/tests/end_to_end/global_decls/irix-o2-out.c
@@ -1,11 +1,21 @@
 MIPS2C_UNK extern_fn(struct A *); // extern
 MIPS2C_UNK static_fn(struct A *); // static
 extern f32 extern_float;
+struct A static_A = {
+    (u8)1,
+    {1, 2, 3, 4, 5},
+    {
+        {{1.0f, 2.0f, 3.0f, 4.0f}, {5.0f, 6.0f, 7.0f, 8.0f}, {9.0f, 0.0f, 1.0f, 2.0f}},
+        {{1.5f, 2.5f, 3.5f, 4.5f}, {5.5f, 6.5f, 7.5f, 8.5f}, {9.5f, 0.5f, 1.5f, 2.5f}},
+    },
+    {NULL, &static_int},
+    &static_bss_A,
+};
 struct A *static_A_ptr = &static_A;
 s32 static_array[3] = {2, 4, 6};
+struct A static_bss_A;
 s32 static_bss_array[3];
 s32 static_int;
-struct A static_A; // const
 s32 static_ro_array[3] = {7, 8, 9}; // const
 
 s32 test(void) {

--- a/tests/end_to_end/global_decls/irix-o2.s
+++ b/tests/end_to_end/global_decls/irix-o2.s
@@ -45,13 +45,23 @@ glabel test
 /* 00014C 0040014C 27BD0018 */   addiu $sp, $sp, 0x18
 
 .rodata
-glabel static_A
-.word 0x01, 0x02, 0x03, 0x04, 0x05
-
 glabel static_ro_array
 .word 0x07, 0x08, 0x09
 
 .data
+glabel static_A
+.byte 1
+.space 3
+.word 0x01, 0x02, 0x03, 0x04, 0x05
+.float 1.0, 2.0, 3.0, 4.0
+.float 5.0, 6.0, 7.0, 8.0
+.float 9.0, 0.0, 1.0, 2.0
+.float 1.5, 2.5, 3.5, 4.5
+.float 5.5, 6.5, 7.5, 8.5
+.float 9.5, 0.5, 1.5, 2.5
+.word 0, static_int
+.word static_bss_A
+
 glabel static_A_ptr
 .word static_A
 
@@ -64,3 +74,6 @@ glabel static_int
 
 glabel static_bss_array
 .space 12
+
+glabel static_bss_A
+.space 42

--- a/tests/end_to_end/global_decls/orig.c
+++ b/tests/end_to_end/global_decls/orig.c
@@ -1,5 +1,10 @@
+struct A;
 struct A {
-    int x[5];
+    char value;
+    int array[5];
+    float array_3d[2][3][4];
+    int *pointer_array[2];
+    struct A *self_pointer;
 };
 
 //void extern_fn(struct A *a);
@@ -7,8 +12,20 @@ struct A {
 //void static_fn(struct A *a) { }
 
 static int static_int;
-static struct A static_A = {{1,2,3,4,5}};
-static struct A *static_A_ptr = &static_A;
+static struct A static_bss_A;
+static struct A *static_A_ptr = &static_bss_A;
+static struct A static_A = {
+    1,
+    {1, 2, 3, 4, 5},
+    { { {1.0f, 2.0f, 3.0f, 4.0f},
+        {5.0f, 6.0f, 7.0f, 8.0f},
+        {9.0f, 0.0f, 1.0f, 2.0f} },
+      { {1.5f, 2.5f, 3.5f, 4.5f},
+        {5.5f, 6.5f, 7.5f, 8.5f},
+        {9.5f, 0.5f, 1.5f, 2.5f} } },
+    { (void *) 0, &static_int },
+    &static_bss_A,
+};
 
 static int static_array[3] = {2, 4, 6};
 static const int static_ro_array[3] = {7, 8, 9};
@@ -22,26 +39,3 @@ int test(void) {
     static_bss_array[0] = static_array[0] + static_ro_array[0];
     return static_int;
 }
-
-/*
-.rodata
-glabel static_A
-.word 0x01, 0x02, 0x03, 0x04, 0x05
-
-glabel static_ro_array
-.word 0x07, 0x08, 0x09
-
-.data
-glabel static_A_ptr
-.word static_A
-
-glabel static_array
-.word 2, 4, 6
-
-.bss
-glabel static_int
-.space 4
-
-glabel static_bss_array
-.space 12
-*/


### PR DESCRIPTION
I had to fix one more underlying bug, where multidimensional arrays were not handled correctly. They would be repeatedly pointer-decayed down to their inner type, losing the intermediate dimensions.
The output of running this fix (`c5f411a`) against MM with context is [here](https://gist.github.com/zbanks/1fcd76417568f3757e8186bf37c50840). 
- Most of the differences are to matrix functions which take `float (*m)[4]`s as arguments instead of matrix structs. 
- Some matrix stack variables were previously (incorrectly) inferred to be `f32`, but are now marked as `?`. This doesn't seem too bad to me -- it's arguably more accurate?
- The first diff, `guMtxIdentF`, is a slight regression because mips2c is not able to deduce that the RHS of the assignments are floats. This appears to be pretty rare in practice though.

---

I think the CType initializers change is pretty straightforward. 
- I needed to mark structs with bitfields to know that the struct cannot be deserialized.
- CType arrays are treated like structs with N identical fields.
- `Formatter.format_array()` uses some very rough guidelines to avoid thousand-character lines.
- Comment globals where we failed to generate an initializer, to help distinguish `.bss` vs. `.data` symbols.
- Updated the `global_decls` test to have a more complicated struct.

I don't think this PR should interfere with the other open PRs for loops/ifs.