### PR TITLE
Make "emit globals" the default; change option to `--no-emit-globals`

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -179,7 +179,7 @@ def create_project_tests(
         ):
             continue
 
-        flags = ["--emit-globals"]
+        flags = []
         if context_file is not None:
             flags.extend(["--context", str(context_file)])
 

--- a/src/main.py
+++ b/src/main.py
@@ -198,11 +198,6 @@ def parse_flags(flags: List[str]) -> Options:
         "unusual statements. Macro definitions are in `mips2c_macros.h`.",
     )
     group.add_argument(
-        "--emit-globals",
-        dest="",
-        help=argparse.SUPPRESS,  # Now the default; see `--no-emit-globals`
-    )
-    group.add_argument(
         "--no-emit-globals",
         dest="emit_globals",
         action="store_false",

--- a/src/main.py
+++ b/src/main.py
@@ -143,7 +143,7 @@ def run(options: Options) -> int:
 def parse_flags(flags: List[str]) -> Options:
     parser = argparse.ArgumentParser(
         description="Decompile MIPS assembly to C.",
-        usage="%(prog)s [--context C_FILE] [--emit-globals] [-f FN ...] filename [filename ...]",
+        usage="%(prog)s [--context C_FILE] [-f FN ...] filename [filename ...]",
     )
 
     group = parser.add_argument_group("Input Options")
@@ -199,9 +199,14 @@ def parse_flags(flags: List[str]) -> Options:
     )
     group.add_argument(
         "--emit-globals",
+        dest="",
+        help=argparse.SUPPRESS,  # Now the default; see `--no-emit-globals`
+    )
+    group.add_argument(
+        "--no-emit-globals",
         dest="emit_globals",
-        action="store_true",
-        help="emit global declarations with inferred types.",
+        action="store_false",
+        help="do not emit global declarations with inferred types.",
     )
     group.add_argument(
         "--debug",

--- a/tests/end_to_end/abs-sqrt/irix-g-out.c
+++ b/tests/end_to_end/abs-sqrt/irix-g-out.c
@@ -1,3 +1,5 @@
+f32 test(f32 arg0); // static
+
 f32 test(f32 arg0) {
     f64 sp10;
 

--- a/tests/end_to_end/abs-sqrt/irix-o2-out.c
+++ b/tests/end_to_end/abs-sqrt/irix-o2-out.c
@@ -1,3 +1,5 @@
+f32 test(f32 arg0); // static
+
 f32 test(f32 arg0) {
     return (f32) sqrt(fabs((f64) sqrtf(fabsf(arg0))));
 }

--- a/tests/end_to_end/andor_assignment/irix-g-out.c
+++ b/tests/end_to_end/andor_assignment/irix-g-out.c
@@ -1,3 +1,6 @@
+s32 func_00400090(s32); // static
+s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3); // static
+
 s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
     s32 sp24;
     s32 sp20;

--- a/tests/end_to_end/andor_assignment/irix-o2-noandor-out.c
+++ b/tests/end_to_end/andor_assignment/irix-o2-noandor-out.c
@@ -1,3 +1,6 @@
+s32 func_00400090(s32); // static
+s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3); // static
+
 s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
     s32 sp2C;
     s32 sp24;

--- a/tests/end_to_end/andor_assignment/irix-o2-out.c
+++ b/tests/end_to_end/andor_assignment/irix-o2-out.c
@@ -1,3 +1,6 @@
+s32 func_00400090(s32); // static
+s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3); // static
+
 s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
     s32 sp24;
     s32 sp20;

--- a/tests/end_to_end/andor_mixed/irix-g-out.c
+++ b/tests/end_to_end/andor_mixed/irix-g-out.c
@@ -1,3 +1,5 @@
+s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3); // static
+
 s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
     s32 spC;
     s32 sp8;

--- a/tests/end_to_end/andor_mixed/irix-o2-out.c
+++ b/tests/end_to_end/andor_mixed/irix-o2-out.c
@@ -1,3 +1,5 @@
+s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3); // static
+
 s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
     s32 phi_v1;
 

--- a/tests/end_to_end/andor_return/irix-g-out.c
+++ b/tests/end_to_end/andor_return/irix-g-out.c
@@ -1,3 +1,5 @@
+s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3); // static
+
 s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
     if ((arg0 != 0) || (arg1 != 0)) {
         if ((arg2 != 0) || (arg3 != 0)) {

--- a/tests/end_to_end/andor_return/irix-o2-out.c
+++ b/tests/end_to_end/andor_return/irix-o2-out.c
@@ -1,3 +1,5 @@
+s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3); // static
+
 s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
     if ((arg0 != 0) || (arg1 != 0)) {
         if ((arg2 != 0) || (arg3 != 0)) {

--- a/tests/end_to_end/arguments/irix-g-out.c
+++ b/tests/end_to_end/arguments/irix-g-out.c
@@ -1,3 +1,7 @@
+void test(f32 arg0, s32 arg1, f32 arg2, s32 arg3, f32 arg4, s32 arg5); // static
+extern s32 D_4100F0;
+extern f32 D_4100F4;
+
 void test(f32 arg0, s32 arg1, f32 arg2, s32 arg3, f32 arg4, s32 arg5) {
     D_4100F4 = (f32) (arg0 + arg2 + arg4);
     D_4100F0 = (s32) (arg1 + arg3 + arg5);

--- a/tests/end_to_end/arguments/irix-o2-out.c
+++ b/tests/end_to_end/arguments/irix-o2-out.c
@@ -1,3 +1,7 @@
+void test(f32 arg0, s32 arg1, f32 arg2, s32 arg3, f32 arg4, s32 arg5); // static
+extern s32 D_4100E0;
+extern f32 D_4100E4;
+
 void test(f32 arg0, s32 arg1, f32 arg2, s32 arg3, f32 arg4, s32 arg5) {
     D_4100E4 = (f32) (arg0 + arg2 + arg4);
     D_4100E0 = (s32) (arg1 + arg3 + arg5);

--- a/tests/end_to_end/array-access/irix-g-flags.txt
+++ b/tests/end_to_end/array-access/irix-g-flags.txt
@@ -1,1 +1,1 @@
---context orig.c --emit-globals
+--context orig.c

--- a/tests/end_to_end/array-access/irix-o2-flags.txt
+++ b/tests/end_to_end/array-access/irix-o2-flags.txt
@@ -1,1 +1,1 @@
---context orig.c --emit-globals
+--context orig.c

--- a/tests/end_to_end/arrays/irix-g-out.c
+++ b/tests/end_to_end/arrays/irix-g-out.c
@@ -1,3 +1,7 @@
+s32 test(s32 arg0, s32 arg1, s32 arg2); // static
+extern ?32 D_400130;
+extern ? D_410140;
+
 s32 test(s32 arg0, s32 arg1, s32 arg2) {
     sp->unk0 = (?32) D_400130.unk0;
     sp->unk4 = (u16) D_400130.unk4;

--- a/tests/end_to_end/arrays/irix-o2-out.c
+++ b/tests/end_to_end/arrays/irix-o2-out.c
@@ -1,3 +1,7 @@
+s32 test(s32 arg0, s32 arg1, s32 arg2); // static
+extern ?32 D_400120;
+extern ? D_410130;
+
 s32 test(s32 arg0, s32 arg1, s32 arg2) {
     s32 temp_v1;
 

--- a/tests/end_to_end/branch-likely-b/manual-out.c
+++ b/tests/end_to_end/branch-likely-b/manual-out.c
@@ -1,3 +1,5 @@
+void test(); // static
+
 void test(void) {
     *NULL = 0;
     *(void *)1 = 0;

--- a/tests/end_to_end/branch-likely-general/manual-out.c
+++ b/tests/end_to_end/branch-likely-general/manual-out.c
@@ -1,3 +1,5 @@
+void test(s32 arg0); // static
+
 void test(s32 arg0) {
     if (arg0 == 0) {
         *NULL = 0;

--- a/tests/end_to_end/branch-likely-one-instruction/manual-out.c
+++ b/tests/end_to_end/branch-likely-one-instruction/manual-out.c
@@ -1,3 +1,5 @@
+s32 test(); // static
+
 s32 test(void) {
     s32 phi_a0;
 

--- a/tests/end_to_end/break/irix-g-out.c
+++ b/tests/end_to_end/break/irix-g-out.c
@@ -1,3 +1,6 @@
+void test(s32 arg0); // static
+extern s32 D_4101D0;
+
 void test(s32 arg0) {
     s32 sp4;
     s32 temp_t7;

--- a/tests/end_to_end/break/irix-o2-out.c
+++ b/tests/end_to_end/break/irix-o2-out.c
@@ -1,3 +1,6 @@
+s32 test(s32 arg0); // static
+extern s32 D_410150;
+
 s32 test(s32 arg0) {
     s32 temp_v0;
     s32 phi_v0;

--- a/tests/end_to_end/comparison/irix-o2-out.c
+++ b/tests/end_to_end/comparison/irix-o2-out.c
@@ -1,3 +1,6 @@
+s32 *test(s32 arg0, s32 arg1, s32 arg2); // static
+extern s32 D_410100;
+
 s32 *test(s32 arg0, s32 arg1, s32 arg2) {
     D_410100 = (s32) (arg0 == arg1);
     D_410100 = (s32) (arg0 != arg2);

--- a/tests/end_to_end/complicated_context/irix-g-flags.txt
+++ b/tests/end_to_end/complicated_context/irix-g-flags.txt
@@ -1,1 +1,1 @@
---context orig.c --emit-globals
+--context orig.c

--- a/tests/end_to_end/complicated_context/irix-o2-flags.txt
+++ b/tests/end_to_end/complicated_context/irix-o2-flags.txt
@@ -1,1 +1,1 @@
---context orig.c --emit-globals
+--context orig.c

--- a/tests/end_to_end/custom-return/irix-g-out.c
+++ b/tests/end_to_end/custom-return/irix-g-out.c
@@ -1,3 +1,7 @@
+u16 func_0040012C(?); // static
+u16 test(); // static
+extern s32 D_410150;
+
 u16 test(void) {
     u16 sp1E;
 

--- a/tests/end_to_end/custom-return/irix-o2-out.c
+++ b/tests/end_to_end/custom-return/irix-o2-out.c
@@ -1,3 +1,7 @@
+s32 func_0040010C(?); // static
+s32 test(); // static
+extern s32 D_410120;
+
 s32 test(void) {
     s32 temp_v0;
 

--- a/tests/end_to_end/division-by-power-of-two/ido53-o2-out.c
+++ b/tests/end_to_end/division-by-power-of-two/ido53-o2-out.c
@@ -1,3 +1,5 @@
+s32 test(s32 *arg0); // static
+
 s32 test(s32 *arg0) {
     s32 temp_v0;
 

--- a/tests/end_to_end/division-by-power-of-two/ido71-o2-out.c
+++ b/tests/end_to_end/division-by-power-of-two/ido71-o2-out.c
@@ -1,3 +1,5 @@
+s32 test(s32 *arg0); // static
+
 s32 test(s32 *arg0) {
     s32 temp_v0;
 

--- a/tests/end_to_end/division/irix-g-out.c
+++ b/tests/end_to_end/division/irix-g-out.c
@@ -1,3 +1,5 @@
+s32 test(s32 arg0, s32 arg1); // static
+
 s32 test(s32 arg0, s32 arg1) {
     return arg0 / arg1;
 }

--- a/tests/end_to_end/division/irix-o2-out.c
+++ b/tests/end_to_end/division/irix-o2-out.c
@@ -1,3 +1,5 @@
+s32 test(s32 arg0, s32 arg1); // static
+
 s32 test(s32 arg0, s32 arg1) {
     return arg0 / arg1;
 }

--- a/tests/end_to_end/doubles/irix-g-mips1-out.c
+++ b/tests/end_to_end/doubles/irix-g-mips1-out.c
@@ -1,3 +1,6 @@
+f64 test(f64 arg0, s32 arg2, f64 arg4); // static
+extern f64 D_4101B0;
+
 f64 test(f64 arg0, s32 arg2, f64 arg4) {
     f64 sp8;
     f32 sp4;

--- a/tests/end_to_end/doubles/irix-g-out.c
+++ b/tests/end_to_end/doubles/irix-g-out.c
@@ -1,3 +1,6 @@
+f64 test(f64 arg0, s32 arg2, f64 arg4); // static
+extern f64 D_410180;
+
 f64 test(f64 arg0, s32 arg2, f64 arg4) {
     f64 sp8;
     f64 sp0;

--- a/tests/end_to_end/doubles/irix-o2-mips1-out.c
+++ b/tests/end_to_end/doubles/irix-o2-mips1-out.c
@@ -1,3 +1,6 @@
+f64 test(f64 arg0, s32 arg2, f64 arg4); // static
+extern f64 D_410150;
+
 f64 test(f64 arg0, s32 arg2, f64 arg4) {
     f64 temp_f0;
 

--- a/tests/end_to_end/doubles/irix-o2-out.c
+++ b/tests/end_to_end/doubles/irix-o2-out.c
@@ -1,3 +1,6 @@
+f64 test(f64 arg0, s32 arg2, f64 arg4); // static
+extern f64 D_410150;
+
 f64 test(f64 arg0, s32 arg2, f64 arg4) {
     f64 temp_f0;
 

--- a/tests/end_to_end/empty-if/manual-out.c
+++ b/tests/end_to_end/empty-if/manual-out.c
@@ -1,3 +1,5 @@
+void test(s32 arg0, s32 arg1); // static
+
 void test(s32 arg0, s32 arg1) {
     if ((arg0 == 1) || (arg1 != 2)) {
 

--- a/tests/end_to_end/error/manual-out.c
+++ b/tests/end_to_end/error/manual-out.c
@@ -1,3 +1,5 @@
+? test(s32 arg0); // static
+
 ? test(s32 arg0) {
     s32 temp_t1;
 

--- a/tests/end_to_end/float-branch-evalonce/irix-o2-out.c
+++ b/tests/end_to_end/float-branch-evalonce/irix-o2-out.c
@@ -1,3 +1,6 @@
+f32 test(); // static
+extern f32 D_410120;
+
 f32 test(void) {
     f32 temp_f0;
     s32 temp_cond;

--- a/tests/end_to_end/float-conversions/irix-g-out.c
+++ b/tests/end_to_end/float-conversions/irix-g-out.c
@@ -1,3 +1,8 @@
+void test(); // static
+extern f32 D_410250;
+extern f64 D_410258;
+extern u32 D_410260;
+
 void test(void) {
     f64 temp_f18;
     u32 temp_t0;

--- a/tests/end_to_end/float-conversions/irix-o2-out.c
+++ b/tests/end_to_end/float-conversions/irix-o2-out.c
@@ -1,3 +1,8 @@
+u32 *test(); // static
+extern f32 D_410230;
+extern f64 D_410238;
+extern u32 D_410240;
+
 u32 *test(void) {
     f32 temp_f8;
     f64 temp_f18;

--- a/tests/end_to_end/float-fn/irix-g-out.c
+++ b/tests/end_to_end/float-fn/irix-g-out.c
@@ -1,3 +1,7 @@
+f32 func_004000DC(f32); // static
+f64 func_004000F4(f64); // static
+f32 test(f32 arg0); // static
+
 f32 test(f32 arg0) {
     arg0 = func_004000DC(arg0);
     arg0 = (f32) func_004000F4((f64) arg0);

--- a/tests/end_to_end/float-fn/irix-o2-out.c
+++ b/tests/end_to_end/float-fn/irix-o2-out.c
@@ -1,3 +1,7 @@
+f32 func_004000BC(); // static
+f64 func_004000C4(f64); // static
+f32 test(); // static
+
 f32 test(void) {
     return (f32) func_004000C4((f64) func_004000BC());
 }

--- a/tests/end_to_end/fn-write-reordering/irix-g-out.c
+++ b/tests/end_to_end/fn-write-reordering/irix-g-out.c
@@ -1,3 +1,8 @@
+s32 func_004000F0(); // static
+? func_00400108(s32); // static
+void test(); // static
+extern ?32 D_410120;
+
 void test(void) {
     s32 sp1C;
 

--- a/tests/end_to_end/fn-write-reordering/irix-o2-out.c
+++ b/tests/end_to_end/fn-write-reordering/irix-o2-out.c
@@ -1,3 +1,8 @@
+s32 func_004000E4(); // static
+? func_004000EC(s32); // static
+void test(); // static
+extern ?32 D_410100;
+
 void test(void) {
     s32 temp_v0;
 

--- a/tests/end_to_end/function-pointer/irix-g-out.c
+++ b/tests/end_to_end/function-pointer/irix-g-out.c
@@ -1,3 +1,5 @@
+s32 test(s32 (*arg0)(?32), ?32 arg1); // static
+
 s32 test(s32 (*arg0)(?32), ?32 arg1) {
     return arg0(arg1) + 1;
 }

--- a/tests/end_to_end/function-pointer/irix-o2-out.c
+++ b/tests/end_to_end/function-pointer/irix-o2-out.c
@@ -1,3 +1,5 @@
+s32 test(s32 (*arg0)(?, ?), ? arg1); // static
+
 s32 test(s32 (*arg0)(?, ?), ? arg1) {
     return arg0(arg1, arg0) + 1;
 }

--- a/tests/end_to_end/function-pointer2/irix-o2-flags.txt
+++ b/tests/end_to_end/function-pointer2/irix-o2-flags.txt
@@ -1,1 +1,1 @@
---context context.c --void --emit-globals
+--context context.c --void

--- a/tests/end_to_end/gcc-division-by-two/s16-out.c
+++ b/tests/end_to_end/gcc-division-by-two/s16-out.c
@@ -1,3 +1,5 @@
+s32 test(s16 arg0); // static
+
 s32 test(s16 arg0) {
     return (s32) arg0 / 2;
 }

--- a/tests/end_to_end/gcc-division-by-two/s32-out.c
+++ b/tests/end_to_end/gcc-division-by-two/s32-out.c
@@ -1,3 +1,5 @@
+s32 test(s32 arg0); // static
+
 s32 test(s32 arg0) {
     return arg0 / 2;
 }

--- a/tests/end_to_end/global_decls/irix-o2-flags.txt
+++ b/tests/end_to_end/global_decls/irix-o2-flags.txt
@@ -1,1 +1,1 @@
---context orig.c --valid-syntax --emit-globals
+--context orig.c --valid-syntax

--- a/tests/end_to_end/global_decls/irix-o2-noemitglobals-flags.txt
+++ b/tests/end_to_end/global_decls/irix-o2-noemitglobals-flags.txt
@@ -1,0 +1,1 @@
+--context orig.c --valid-syntax --no-emit-globals

--- a/tests/end_to_end/global_decls/irix-o2-noemitglobals-out.c
+++ b/tests/end_to_end/global_decls/irix-o2-noemitglobals-out.c
@@ -1,0 +1,8 @@
+s32 test(void) {
+    static_int *= 0x1C8;
+    extern_float = (f32) (extern_float * 456.0f);
+    static_fn(&static_A);
+    extern_fn(static_A_ptr);
+    *static_bss_array = *static_array + *static_ro_array;
+    return static_int;
+}

--- a/tests/end_to_end/global_decls/irix-o2-noemitglobals.s
+++ b/tests/end_to_end/global_decls/irix-o2-noemitglobals.s
@@ -1,0 +1,79 @@
+.set noat      # allow manual use of $at
+.set noreorder # don't insert nops after branches
+
+
+glabel static_fn
+/* 0000B8 004000B8 03E00008 */  jr    $ra
+/* 0000BC 004000BC AFA40000 */   sw    $a0, ($sp)
+
+glabel test
+/* 0000C0 004000C0 3C030041 */  lui   $v1, %hi(extern_float)
+/* 0000C4 004000C4 24630190 */  addiu $v1, $v1, %lo(extern_float)
+/* 0000C8 004000C8 3C020041 */  lui   $v0, %hi(static_int)
+/* 0000CC 004000CC 3C0143E4 */  lui   $at, 0x43e4
+/* 0000D0 004000D0 44813000 */  mtc1  $at, $f6
+/* 0000D4 004000D4 C4640000 */  lwc1  $f4, ($v1)
+/* 0000D8 004000D8 24420194 */  addiu $v0, $v0, %lo(static_int)
+/* 0000DC 004000DC 8C4E0000 */  lw    $t6, ($v0)
+/* 0000E0 004000E0 46062202 */  mul.s $f8, $f4, $f6
+/* 0000E4 004000E4 27BDFFE8 */  addiu $sp, $sp, -0x18
+/* 0000E8 004000E8 000E78C0 */  sll   $t7, $t6, 3
+/* 0000EC 004000EC 01EE7823 */  subu  $t7, $t7, $t6
+/* 0000F0 004000F0 000F78C0 */  sll   $t7, $t7, 3
+/* 0000F4 004000F4 01EE7821 */  addu  $t7, $t7, $t6
+/* 0000F8 004000F8 AFBF0014 */  sw    $ra, 0x14($sp)
+/* 0000FC 004000FC 000F78C0 */  sll   $t7, $t7, 3
+/* 000100 00400100 3C040041 */  lui   $a0, %hi(static_A)
+/* 000104 00400104 AC4F0000 */  sw    $t7, ($v0)
+/* 000108 00400108 E4680000 */  swc1  $f8, ($v1)
+/* 00010C 0040010C 0C10002E */  jal   static_fn
+/* 000110 00400110 24840160 */   addiu $a0, $a0, %lo(static_A)
+/* 000114 00400114 3C040041 */  lui   $a0, %hi(static_A_ptr)
+/* 000118 00400118 0C10002C */  jal   extern_fn
+/* 00011C 0040011C 8C840174 */   lw    $a0, %lo(static_A_ptr)($a0)
+/* 000120 00400120 3C180040 */  lui   $t8, %hi(static_array)
+/* 000124 00400124 3C190041 */  lui   $t9, %hi(static_ro_array)
+/* 000128 00400128 8F390178 */  lw    $t9, %lo(static_ro_array)($t9)
+/* 00012C 0040012C 8F180150 */  lw    $t8, %lo(static_array)($t8)
+/* 000130 00400130 8FBF0014 */  lw    $ra, 0x14($sp)
+/* 000134 00400134 3C020041 */  lui   $v0, %hi(static_int)
+/* 000138 00400138 3C010041 */  lui   $at, %hi(static_bss_array)
+/* 00013C 0040013C 8C420194 */  lw    $v0, %lo(static_int)($v0)
+/* 000140 00400140 03194021 */  addu  $t0, $t8, $t9
+/* 000144 00400144 AC280198 */  sw    $t0, %lo(static_bss_array)($at)
+/* 000148 00400148 03E00008 */  jr    $ra
+/* 00014C 0040014C 27BD0018 */   addiu $sp, $sp, 0x18
+
+.rodata
+glabel static_ro_array
+.word 0x07, 0x08, 0x09
+
+.data
+glabel static_A
+.byte 1
+.space 3
+.word 0x01, 0x02, 0x03, 0x04, 0x05
+.float 1.0, 2.0, 3.0, 4.0
+.float 5.0, 6.0, 7.0, 8.0
+.float 9.0, 0.0, 1.0, 2.0
+.float 1.5, 2.5, 3.5, 4.5
+.float 5.5, 6.5, 7.5, 8.5
+.float 9.5, 0.5, 1.5, 2.5
+.word 0, static_int
+.word static_bss_A
+
+glabel static_A_ptr
+.word static_A
+
+glabel static_array
+.word 2, 4, 6
+
+.bss
+glabel static_int
+.space 4
+
+glabel static_bss_array
+.space 12
+
+glabel static_bss_A
+.space 42

--- a/tests/end_to_end/ida/handwritten-out.c
+++ b/tests/end_to_end/ida/handwritten-out.c
@@ -1,3 +1,6 @@
+s32 test(); // static
+extern s32 symbol;
+
 s32 test(void) {
     s32 temp_a1;
 

--- a/tests/end_to_end/if-bitand/irix-o2-out.c
+++ b/tests/end_to_end/if-bitand/irix-o2-out.c
@@ -1,3 +1,6 @@
+s32 *test(); // static
+extern s32 D_410140;
+
 s32 *test(void) {
     if ((D_410140 & 1) != 0) {
         D_410140 = 0;

--- a/tests/end_to_end/if_postdec/irix-g-out.c
+++ b/tests/end_to_end/if_postdec/irix-g-out.c
@@ -1,3 +1,6 @@
+? test(); // static
+extern s32 D_4100F0;
+
 ? test(void) {
     s32 temp_t6;
 

--- a/tests/end_to_end/if_postdec/irix-o2-out.c
+++ b/tests/end_to_end/if_postdec/irix-o2-out.c
@@ -1,3 +1,6 @@
+? test(); // static
+extern s32 D_4100E0;
+
 ? test(void) {
     s32 temp_v1;
 

--- a/tests/end_to_end/int-float-doublelit/irix-g-out.c
+++ b/tests/end_to_end/int-float-doublelit/irix-g-out.c
@@ -1,3 +1,8 @@
+f32 test(f32 arg0, s32 arg1, f32 arg2, s32 arg3); // static
+extern f64 D_400180;
+extern s32 D_410190;
+extern f32 D_410194;
+
 f32 test(f32 arg0, s32 arg1, f32 arg2, s32 arg3) {
     D_410190 = (s32) arg0;
     D_410194 = (f32) arg1;

--- a/tests/end_to_end/int-float-doublelit/irix-o2-out.c
+++ b/tests/end_to_end/int-float-doublelit/irix-o2-out.c
@@ -1,3 +1,8 @@
+f32 test(f32 arg0, s32 arg1, f32 arg2, s32 arg3); // static
+extern f64 D_400130;
+extern s32 D_410140;
+extern f32 D_410144;
+
 f32 test(f32 arg0, s32 arg1, f32 arg2, s32 arg3) {
     f32 temp_f18;
     s32 temp_a3;

--- a/tests/end_to_end/int-float/irix-g-out.c
+++ b/tests/end_to_end/int-float/irix-g-out.c
@@ -1,3 +1,7 @@
+f32 test(f32 arg0, s32 arg1, f32 arg2, s32 arg3); // static
+extern s32 D_410130;
+extern f32 D_410134;
+
 f32 test(f32 arg0, s32 arg1, f32 arg2, s32 arg3) {
     D_410130 = (s32) arg0;
     D_410134 = (f32) arg1;

--- a/tests/end_to_end/int-float/irix-o2-out.c
+++ b/tests/end_to_end/int-float/irix-o2-out.c
@@ -1,3 +1,7 @@
+f32 test(f32 arg0, s32 arg1, f32 arg2, s32 arg3); // static
+extern s32 D_410110;
+extern f32 D_410114;
+
 f32 test(f32 arg0, s32 arg1, f32 arg2, s32 arg3) {
     f32 temp_f18;
     s32 temp_a3;

--- a/tests/end_to_end/jump-into-loop/irix-g-out.c
+++ b/tests/end_to_end/jump-into-loop/irix-g-out.c
@@ -1,3 +1,6 @@
+? func_0040010C(s32); // static
+s32 test(s32 arg0); // static
+
 s32 test(s32 arg0) {
 loop_3:
     func_0040010C(arg0);

--- a/tests/end_to_end/jump-into-loop/irix-o2-out.c
+++ b/tests/end_to_end/jump-into-loop/irix-o2-out.c
@@ -1,3 +1,6 @@
+? func_004000DC(s32); // static
+s32 test(s32 arg0); // static
+
 s32 test(s32 arg0) {
     s32 temp_t6;
     s32 phi_s0;

--- a/tests/end_to_end/large-struct-member-address/manual-out.c
+++ b/tests/end_to_end/large-struct-member-address/manual-out.c
@@ -1,3 +1,5 @@
+? foo(s8 *); // extern
+
 void test(struct A *a) {
     foo(&a->b);
 }

--- a/tests/end_to_end/large-struct-offset/irix-g-out.c
+++ b/tests/end_to_end/large-struct-offset/irix-g-out.c
@@ -1,3 +1,6 @@
+void *test(void *arg0); // static
+extern ?32 D_4100F0;
+
 void *test(void *arg0) {
     D_4100F0 = (?32) arg0->unk12348;
     return arg0 + 0x12348;

--- a/tests/end_to_end/large-struct-offset/irix-o2-out.c
+++ b/tests/end_to_end/large-struct-offset/irix-o2-out.c
@@ -1,3 +1,6 @@
+void *test(void *arg0); // static
+extern ?32 D_4100E0;
+
 void *test(void *arg0) {
     D_4100E0 = (?32) arg0->unk12348;
     return arg0 + 0x12348;

--- a/tests/end_to_end/load-types/irix-g-out.c
+++ b/tests/end_to_end/load-types/irix-g-out.c
@@ -1,3 +1,12 @@
+void test(); // static
+extern s8 D_410140;
+extern u8 D_410141;
+extern s16 D_410142;
+extern u16 D_410144;
+extern ?32 D_410148;
+extern ?32 D_41014C;
+extern ?32 D_410150;
+
 void test(void) {
     D_410150.unk0 = (?32) D_410140;
     D_410150.unk4 = (?32) D_410141;

--- a/tests/end_to_end/load-types/irix-o2-out.c
+++ b/tests/end_to_end/load-types/irix-o2-out.c
@@ -1,3 +1,12 @@
+?32 *test(); // static
+extern s8 D_410110;
+extern u8 D_410111;
+extern s16 D_410112;
+extern u16 D_410114;
+extern ?32 D_410118;
+extern ?32 D_41011C;
+extern ?32 D_410120;
+
 ?32 *test(void) {
     D_410120.unk0 = (?32) D_410110;
     D_410120.unk4 = (?32) D_410111;

--- a/tests/end_to_end/loop-selfassign-phi/irix-g-out.c
+++ b/tests/end_to_end/loop-selfassign-phi/irix-g-out.c
@@ -1,3 +1,6 @@
+s32 func_004000D8(s32); // static
+void test(s32 arg0); // static
+
 void test(s32 arg0) {
 loop_1:
     if (arg0 < 3) {

--- a/tests/end_to_end/loop-selfassign-phi/irix-o2-out.c
+++ b/tests/end_to_end/loop-selfassign-phi/irix-o2-out.c
@@ -1,3 +1,6 @@
+s32 func_004000F4(s32); // static
+void test(s32 arg0); // static
+
 void test(s32 arg0) {
     s32 phi_s0;
 

--- a/tests/end_to_end/loop/irix-g-out.c
+++ b/tests/end_to_end/loop/irix-g-out.c
@@ -1,3 +1,5 @@
+void test(s32 arg0, s32 arg1); // static
+
 void test(s32 arg0, s32 arg1) {
     s32 sp4;
     s32 temp_t9;

--- a/tests/end_to_end/loop/irix-o2-out.c
+++ b/tests/end_to_end/loop/irix-o2-out.c
@@ -1,3 +1,5 @@
+s32 test(s8 *arg0, s32 arg1); // static
+
 s32 test(s8 *arg0, s32 arg1) {
     s32 temp_a3;
     s32 temp_v0;

--- a/tests/end_to_end/loop_nested/irix-g-out.c
+++ b/tests/end_to_end/loop_nested/irix-g-out.c
@@ -1,3 +1,5 @@
+s32 test(s32 arg0); // static
+
 s32 test(s32 arg0) {
     s32 spC;
     s32 sp8;

--- a/tests/end_to_end/loop_nested/irix-o2-out.c
+++ b/tests/end_to_end/loop_nested/irix-o2-out.c
@@ -1,3 +1,5 @@
+s32 test(s32 arg0); // static
+
 s32 test(s32 arg0) {
     s32 temp_a1;
     s32 temp_t1;

--- a/tests/end_to_end/loop_with_if/irix-g-out.c
+++ b/tests/end_to_end/loop_with_if/irix-g-out.c
@@ -1,3 +1,5 @@
+s32 test(s32 arg0); // static
+
 s32 test(s32 arg0) {
     s32 sp4;
 

--- a/tests/end_to_end/loop_with_if/irix-o2-allman-out.c
+++ b/tests/end_to_end/loop_with_if/irix-o2-allman-out.c
@@ -1,3 +1,5 @@
+s32 test(s32 arg0); // static
+
 s32 test(s32 arg0)
 {
     s32 phi_v1;

--- a/tests/end_to_end/loop_with_if/irix-o2-out.c
+++ b/tests/end_to_end/loop_with_if/irix-o2-out.c
@@ -1,3 +1,5 @@
+s32 test(s32 arg0); // static
+
 s32 test(s32 arg0) {
     s32 phi_v1;
     s32 phi_v1_2;

--- a/tests/end_to_end/lwl/irix-g-out.c
+++ b/tests/end_to_end/lwl/irix-g-out.c
@@ -1,3 +1,13 @@
+? func_004000B0(?32 *); // static
+void test(); // static
+extern ?32 D_400170;
+extern ? D_400178;
+extern ?32 D_410180;
+extern ? D_410181;
+extern ? D_410189;
+extern ? D_410190;
+extern ?32 D_410198;
+
 void test(void) {
     ?32 sp18;
 

--- a/tests/end_to_end/lwl/irix-o2-out.c
+++ b/tests/end_to_end/lwl/irix-o2-out.c
@@ -1,3 +1,13 @@
+? func_004000B0(?32 *); // static
+void test(); // static
+extern ?32 D_400150;
+extern ? D_400158;
+extern ?32 D_410160;
+extern ? D_410161;
+extern ? D_410169;
+extern ? D_410170;
+extern ?32 D_410178;
+
 void test(void) {
     ?32 sp18;
 

--- a/tests/end_to_end/misc1/irix-g-out.c
+++ b/tests/end_to_end/misc1/irix-g-out.c
@@ -1,3 +1,9 @@
+s32 func_00400174(?, ?, s32, ?32, s32); // static
+? func_0040019C(?32, s32, s32); // static
+s32 test(s32 arg0, ?32 arg1); // static
+extern s32 D_4101C0;
+extern ? D_4101C8;
+
 s32 test(s32 arg0, ?32 arg1) {
     s32 sp2C;
     s32 sp28;

--- a/tests/end_to_end/misc1/irix-o2-out.c
+++ b/tests/end_to_end/misc1/irix-o2-out.c
@@ -1,3 +1,9 @@
+s32 func_00400140(?, ?, s32, ?, s32); // static
+? func_00400158(?32, s32, s32); // static
+s32 test(s32 arg0, ? arg1); // static
+extern s32 D_410170;
+extern ? D_410178;
+
 s32 test(s32 arg0, ? arg1) {
     s32 sp2C;
     s32 sp28;

--- a/tests/end_to_end/misc1/irix-o2-validsyntax-flags.txt
+++ b/tests/end_to_end/misc1/irix-o2-validsyntax-flags.txt
@@ -1,1 +1,1 @@
---valid-syntax --emit-globals
+--valid-syntax

--- a/tests/end_to_end/modulo-by-power-of-two/ido53-o2-out.c
+++ b/tests/end_to_end/modulo-by-power-of-two/ido53-o2-out.c
@@ -1,3 +1,5 @@
+s32 test(s32 *arg0); // static
+
 s32 test(s32 *arg0) {
     s32 temp_v0;
 

--- a/tests/end_to_end/modulo-by-power-of-two/ido71-o2-out.c
+++ b/tests/end_to_end/modulo-by-power-of-two/ido71-o2-out.c
@@ -1,3 +1,5 @@
+s32 test(s32 *arg0); // static
+
 s32 test(s32 *arg0) {
     s32 temp_v0;
 

--- a/tests/end_to_end/mult-by-constant/irix-g-out.c
+++ b/tests/end_to_end/mult-by-constant/irix-g-out.c
@@ -1,3 +1,6 @@
+void test(s32 arg0); // static
+extern s32 D_410250;
+
 void test(s32 arg0) {
     D_410250 = arg0;
     D_410250 = (s32) (arg0 * 2);

--- a/tests/end_to_end/mult-by-constant/irix-o2-out.c
+++ b/tests/end_to_end/mult-by-constant/irix-o2-out.c
@@ -1,3 +1,6 @@
+s32 *test(s32 arg0); // static
+extern s32 D_4101F0;
+
 s32 *test(s32 arg0) {
     D_4101F0 = arg0;
     D_4101F0 = (s32) (arg0 * 2);

--- a/tests/end_to_end/mult-by-two/irix-o2-out.c
+++ b/tests/end_to_end/mult-by-two/irix-o2-out.c
@@ -1,3 +1,7 @@
+f32 test(); // static
+extern f32 D_4100E0;
+extern f64 D_4100E8;
+
 f32 test(void) {
     f32 temp_f0;
 

--- a/tests/end_to_end/multi-switch/irix-o2-out.c
+++ b/tests/end_to_end/multi-switch/irix-o2-out.c
@@ -1,3 +1,8 @@
+s32 test(s32 arg0); // static
+extern s32 D_410210;
+static ? jtbl_4001D0; // unable to generate initializer; const
+static ? jtbl_4001EC; // unable to generate initializer; const
+
 s32 test(s32 arg0) {
     u32 temp_t6;
     u32 temp_t7;

--- a/tests/end_to_end/multiple-assigns/irix-g-out.c
+++ b/tests/end_to_end/multiple-assigns/irix-g-out.c
@@ -1,3 +1,6 @@
+s32 test(s32 arg0); // static
+extern s32 D_410150;
+
 s32 test(s32 arg0) {
     s32 sp4;
     s32 temp_a0;

--- a/tests/end_to_end/multiple-assigns/irix-o2-out.c
+++ b/tests/end_to_end/multiple-assigns/irix-o2-out.c
@@ -1,3 +1,6 @@
+s32 test(s32 arg0); // static
+extern s32 D_410120;
+
 s32 test(s32 arg0) {
     s32 sp4;
     s32 temp_a0;

--- a/tests/end_to_end/nested_ifs/irix-g-out.c
+++ b/tests/end_to_end/nested_ifs/irix-g-out.c
@@ -1,3 +1,6 @@
+? func_004000FC(?); // static
+void test(s32 arg0); // static
+
 void test(s32 arg0) {
     if (arg0 == 7) {
         func_004000FC(1);

--- a/tests/end_to_end/nested_ifs/irix-o2-out.c
+++ b/tests/end_to_end/nested_ifs/irix-o2-out.c
@@ -1,3 +1,6 @@
+? func_004000F0(?, s32); // static
+void test(s32 arg0); // static
+
 void test(s32 arg0) {
     s32 temp_a1;
 

--- a/tests/end_to_end/nested_ifs2/irix-g-out.c
+++ b/tests/end_to_end/nested_ifs2/irix-g-out.c
@@ -1,3 +1,6 @@
+? func_004000FC(?); // static
+void test(s32 arg0); // static
+
 void test(s32 arg0) {
     if (arg0 == 7) {
         func_004000FC(1);

--- a/tests/end_to_end/nested_ifs2/irix-o2-out.c
+++ b/tests/end_to_end/nested_ifs2/irix-o2-out.c
@@ -1,3 +1,6 @@
+? func_004000F0(?, s32); // static
+void test(s32 arg0); // static
+
 void test(s32 arg0) {
     s32 temp_a1;
 

--- a/tests/end_to_end/nested_ifs3/irix-g-out.c
+++ b/tests/end_to_end/nested_ifs3/irix-g-out.c
@@ -1,3 +1,6 @@
+? func_0040011C(?); // static
+void test(s32 arg0); // static
+
 void test(s32 arg0) {
     if (arg0 == 7) {
         func_0040011C(1);

--- a/tests/end_to_end/nested_ifs3/irix-o2-out.c
+++ b/tests/end_to_end/nested_ifs3/irix-o2-out.c
@@ -1,3 +1,6 @@
+? func_00400114(?, s32); // static
+void test(s32 arg0); // static
+
 void test(s32 arg0) {
     s32 temp_a1;
 

--- a/tests/end_to_end/nested_ifs4/irix-g-out.c
+++ b/tests/end_to_end/nested_ifs4/irix-g-out.c
@@ -1,3 +1,6 @@
+? func_0040012C(?); // static
+void test(s32 arg0); // static
+
 void test(s32 arg0) {
     if (arg0 == 7) {
         func_0040012C(1);

--- a/tests/end_to_end/nested_ifs4/irix-o2-out.c
+++ b/tests/end_to_end/nested_ifs4/irix-o2-out.c
@@ -1,3 +1,6 @@
+? func_00400114(?, s32); // static
+void test(s32 arg0); // static
+
 void test(s32 arg0) {
     s32 temp_a1;
 

--- a/tests/end_to_end/no-ifs-early-returns/irix-o2-out.c
+++ b/tests/end_to_end/no-ifs-early-returns/irix-o2-out.c
@@ -1,3 +1,5 @@
+void test(s32 *arg0, s32 *arg1); // static
+
 void test(s32 *arg0, s32 *arg1) {
     s32 temp_v1;
 

--- a/tests/end_to_end/nor/irix-g-out.c
+++ b/tests/end_to_end/nor/irix-g-out.c
@@ -1,3 +1,5 @@
+s32 test(s32 arg0, s32 arg1); // static
+
 s32 test(s32 arg0, s32 arg1) {
     return ~(arg0 | arg1);
 }

--- a/tests/end_to_end/nor/irix-o2-out.c
+++ b/tests/end_to_end/nor/irix-o2-out.c
@@ -1,3 +1,5 @@
+s32 test(s32 arg0, s32 arg1); // static
+
 s32 test(s32 arg0, s32 arg1) {
     return ~(arg0 | arg1);
 }

--- a/tests/end_to_end/phis-1/manual-out.c
+++ b/tests/end_to_end/phis-1/manual-out.c
@@ -1,3 +1,6 @@
+void *foo(); // extern
+void test(); // static
+
 void test(void) {
     void *sp10C;
     void *temp_ret;

--- a/tests/end_to_end/premature_returns_all/irix-g-out.c
+++ b/tests/end_to_end/premature_returns_all/irix-g-out.c
@@ -1,3 +1,5 @@
+? test(s32 arg0); // static
+
 ? test(s32 arg0) {
     if (arg0 != 0) {
         return 1;

--- a/tests/end_to_end/premature_returns_all/irix-o2-out.c
+++ b/tests/end_to_end/premature_returns_all/irix-o2-out.c
@@ -1,3 +1,5 @@
+? test(s32 arg0); // static
+
 ? test(s32 arg0) {
     if (arg0 != 0) {
         return 1;

--- a/tests/end_to_end/premature_returns_none/irix-g-out.c
+++ b/tests/end_to_end/premature_returns_none/irix-g-out.c
@@ -1,3 +1,5 @@
+?32 test(s32 arg0); // static
+
 ?32 test(s32 arg0) {
     ?32 sp4;
 

--- a/tests/end_to_end/premature_returns_none/irix-o2-out.c
+++ b/tests/end_to_end/premature_returns_none/irix-o2-out.c
@@ -1,3 +1,5 @@
+? test(s32 arg0); // static
+
 ? test(s32 arg0) {
     ? phi_v1;
 

--- a/tests/end_to_end/premature_returns_one/irix-g-out.c
+++ b/tests/end_to_end/premature_returns_one/irix-g-out.c
@@ -1,3 +1,5 @@
+? test(s32 arg0); // static
+
 ? test(s32 arg0) {
     if (arg0 != 0) {
         return 1;

--- a/tests/end_to_end/premature_returns_one/irix-o2-out.c
+++ b/tests/end_to_end/premature_returns_one/irix-o2-out.c
@@ -1,3 +1,5 @@
+? test(s32 arg0); // static
+
 ? test(s32 arg0) {
     if (arg0 != 0) {
         return 1;

--- a/tests/end_to_end/recursive-type/irix-g-out.c
+++ b/tests/end_to_end/recursive-type/irix-g-out.c
@@ -1,3 +1,6 @@
+? func_00400090(? *, ? *); // static
+void test(? *arg0, ? *arg1); // static
+
 void test(? *arg0, ? *arg1) {
     arg0 = &arg0;
     arg1 = &arg1;

--- a/tests/end_to_end/recursive-type/irix-o2-out.c
+++ b/tests/end_to_end/recursive-type/irix-o2-out.c
@@ -1,3 +1,6 @@
+? func_00400090(? *, ? *); // static
+void test(? *arg0, ? *arg1); // static
+
 void test(? *arg0, ? *arg1) {
     ? *temp_a0;
     ? *temp_a1;

--- a/tests/end_to_end/return-float/irix-g-out.c
+++ b/tests/end_to_end/return-float/irix-g-out.c
@@ -1,3 +1,5 @@
+f32 test(f32 arg0); // static
+
 f32 test(f32 arg0) {
     f32 phi_f14;
 

--- a/tests/end_to_end/return-float/irix-o2-out.c
+++ b/tests/end_to_end/return-float/irix-o2-out.c
@@ -1,3 +1,5 @@
+f32 test(f32 arg0); // static
+
 f32 test(f32 arg0) {
     if (arg0 != 0.0f) {
         return 15.0f;

--- a/tests/end_to_end/rodata-literals/irix-g-out.c
+++ b/tests/end_to_end/rodata-literals/irix-g-out.c
@@ -1,3 +1,9 @@
+void test(); // static
+extern f32 D_410130;
+extern f64 D_410138;
+extern f64 D_410140;
+extern ? *D_410148;
+
 void test(void) {
     D_410130 = 1.2f;
     D_410138 = 13.0;

--- a/tests/end_to_end/rodata-literals/irix-o2-out.c
+++ b/tests/end_to_end/rodata-literals/irix-o2-out.c
@@ -1,3 +1,9 @@
+void test(); // static
+extern f32 D_410120;
+extern f64 D_410128;
+extern f64 D_410130;
+extern ? *D_410138;
+
 void test(void) {
     D_410120 = 1.2f;
     D_410128 = 13.0;

--- a/tests/end_to_end/signed-conversion/irix-g-out.c
+++ b/tests/end_to_end/signed-conversion/irix-g-out.c
@@ -1,3 +1,6 @@
+void test(s8 arg0); // static
+extern ?32 D_410140;
+
 void test(s8 arg0) {
     D_410140 = (?32) arg0;
     D_410140 = (?32) (s8) (arg0 * 2);

--- a/tests/end_to_end/signed-conversion/irix-o2-out.c
+++ b/tests/end_to_end/signed-conversion/irix-o2-out.c
@@ -1,3 +1,6 @@
+s8 test(s8 arg0); // static
+extern ?32 D_410110;
+
 s8 test(s8 arg0) {
     s8 temp_v0;
 

--- a/tests/end_to_end/skip-casts/manual-out.c
+++ b/tests/end_to_end/skip-casts/manual-out.c
@@ -1,3 +1,5 @@
+void test(u32 arg0); // static
+
 void test(u32 arg0) {
     *NULL = arg0 >> 1;
     *NULL = 5;

--- a/tests/end_to_end/sqrt/irix-g-out.c
+++ b/tests/end_to_end/sqrt/irix-g-out.c
@@ -1,3 +1,5 @@
+f32 test(f32 arg0); // static
+
 f32 test(f32 arg0) {
     f32 spC;
     f32 sp8;

--- a/tests/end_to_end/sqrt/irix-o2-out.c
+++ b/tests/end_to_end/sqrt/irix-o2-out.c
@@ -1,3 +1,5 @@
+f32 test(f32 arg0); // static
+
 f32 test(f32 arg0) {
     f32 spC;
     f32 sp4;

--- a/tests/end_to_end/struct/irix-o2-out.c
+++ b/tests/end_to_end/struct/irix-o2-out.c
@@ -1,3 +1,5 @@
+void *test(void *arg0, void *arg1); // static
+
 void *test(void *arg0, void *arg1) {
     arg0->unk4 = (s32) (arg0->unk0 + arg0->unk4);
     arg1->unk0 = (s32) arg0->unk0;

--- a/tests/end_to_end/switch-with-if/irix-o2-out.c
+++ b/tests/end_to_end/switch-with-if/irix-o2-out.c
@@ -1,3 +1,8 @@
+void test(s32 arg0); // static
+extern ?32 D_4101D0;
+static ? jtbl_4001A0; // unable to generate initializer; const
+static ? jtbl_4001B8; // unable to generate initializer; const
+
 void test(s32 arg0) {
     u32 temp_t1;
     u32 temp_t6;

--- a/tests/end_to_end/switch/irix-g-out.c
+++ b/tests/end_to_end/switch/irix-g-out.c
@@ -1,3 +1,7 @@
+s32 test(s32 arg0); // static
+extern s32 D_410170;
+static ? jtbl_400150; // unable to generate initializer; const
+
 s32 test(s32 arg0) {
     u32 temp_t6;
     s32 phi_a0;

--- a/tests/end_to_end/switch/irix-o2-andor-out.c
+++ b/tests/end_to_end/switch/irix-o2-andor-out.c
@@ -1,3 +1,7 @@
+s32 test(s32 arg0); // static
+extern s32 D_410150;
+static ? jtbl_400130; // unable to generate initializer; const
+
 s32 test(s32 arg0) {
     u32 temp_t6;
     s32 phi_a0;

--- a/tests/end_to_end/switch/irix-o2-out.c
+++ b/tests/end_to_end/switch/irix-o2-out.c
@@ -1,3 +1,7 @@
+s32 test(s32 arg0); // static
+extern s32 D_410150;
+static ? jpt_400130; // unable to generate initializer; const
+
 s32 test(s32 arg0) {
     u32 temp_t6;
     s32 phi_a0;

--- a/tests/end_to_end/test/irix-g-out.c
+++ b/tests/end_to_end/test/irix-g-out.c
@@ -1,3 +1,7 @@
+? func_004000B0(); // static
+void test(); // static
+extern ?32 D_410100;
+
 void test(void) {
     func_004000B0();
     D_410100 = 4;

--- a/tests/end_to_end/test/irix-o2-out.c
+++ b/tests/end_to_end/test/irix-o2-out.c
@@ -1,3 +1,7 @@
+? func_004000B0(); // static
+void test(); // static
+extern ?32 D_4100E0;
+
 void test(void) {
     func_004000B0();
     D_4100E0 = 4;

--- a/tests/end_to_end/typedef/irix-g-out.c
+++ b/tests/end_to_end/typedef/irix-g-out.c
@@ -1,3 +1,5 @@
+void test(s32 arg0, s32 *arg1); // static
+
 void test(s32 arg0, s32 *arg1) {
     s32 temp_s0;
     s32 temp_s1;

--- a/tests/end_to_end/typedef/irix-o2-out.c
+++ b/tests/end_to_end/typedef/irix-o2-out.c
@@ -1,3 +1,5 @@
+void test(s32 arg0, s32 *arg1); // static
+
 void test(s32 arg0, s32 *arg1) {
     s32 sp1C;
     s32 sp18;

--- a/tests/end_to_end/unreachable-return/irix-g-out.c
+++ b/tests/end_to_end/unreachable-return/irix-g-out.c
@@ -1,3 +1,6 @@
+void test(); // static
+extern ?32 D_4100E0;
+
 void test(void) {
 loop_0:
     D_4100E0 = 1;

--- a/tests/end_to_end/unreachable-return/irix-o2-out.c
+++ b/tests/end_to_end/unreachable-return/irix-o2-out.c
@@ -1,3 +1,6 @@
+void test(); // static
+extern ?32 D_4100F0;
+
 void test(void) {
     D_4100F0 = 1;
 loop_1:

--- a/tests/end_to_end/unreachable-return2/irix-g-out.c
+++ b/tests/end_to_end/unreachable-return2/irix-g-out.c
@@ -1,3 +1,6 @@
+void test(); // static
+extern s32 D_4100F0;
+
 void test(void) {
 loop_0:
     if (D_4100F0 != 2) {

--- a/tests/end_to_end/unreachable-return2/irix-o2-out.c
+++ b/tests/end_to_end/unreachable-return2/irix-o2-out.c
@@ -1,3 +1,6 @@
+s32 test(); // static
+extern s32 D_4100E0;
+
 s32 test(void) {
 loop_1:
     if (D_4100E0 != 2) {

--- a/tests/end_to_end/unsized-pointers/manual-out.c
+++ b/tests/end_to_end/unsized-pointers/manual-out.c
@@ -1,3 +1,5 @@
+void *test(void *arg0, void *arg1); // static
+
 void *test(void *arg0, void *arg1) {
     return arg0->unk4 + 1 + arg1->unk4 + (arg1 + 1);
 }

--- a/tests/end_to_end/weird-asm/test-out.c
+++ b/tests/end_to_end/weird-asm/test-out.c
@@ -1,5 +1,7 @@
 Warning: missing "jr $ra" in last block (.label).
 
+? test(); // static
+
 ? test(void) {
     return 0x1233FFFF;
 }

--- a/website.py
+++ b/website.py
@@ -40,8 +40,8 @@ if "source" in form:
         cmd.append("--allman")
     if "leftptr" in form:
         cmd.extend(["--pointer-style", "left"])
-    if "globals" in form:
-        cmd.append("--emit-globals")
+    if "globals" not in form:
+        cmd.append("--no-emit-globals")
     if "visualize" in form:
         cmd.append("--visualize")
 


### PR DESCRIPTION
- Now that the default changed, all the end-to-end tests changed.
  - Removed `--emit-globals` from all test flags that had it
  - I made 1 new test that has `--no-emit-globals`, just to make sure the flag works
- I left `--emit-globals` supported for compatibility... but tbh given how new it is, it's probably fine to just delete it entirely?
- Update the website