### PR TITLE
Remove integer casts for Literals

### DIFF
--- a/src/translate.py
+++ b/src/translate.py
@@ -1156,11 +1156,7 @@ class Literal(Expression):
         suffix = ""
         if not fmt.skip_casts:
             if self.type.is_pointer():
-                prefix = "(void *)"
-            elif self.type.get_size_bits() == 8:
-                prefix = "(u8)"
-            elif self.type.get_size_bits() == 16:
-                prefix = "(u16)"
+                prefix = f"({self.type.format(fmt)})"
             if self.type.is_unsigned():
                 suffix = "U"
         mid = (

--- a/tests/end_to_end/branch-likely-b/manual-out.c
+++ b/tests/end_to_end/branch-likely-b/manual-out.c
@@ -2,5 +2,5 @@ void test(); // static
 
 void test(void) {
     *NULL = 0;
-    *(void *)1 = 0;
+    *(?32 *)1 = 0;
 }

--- a/tests/end_to_end/branch-likely-one-instruction/manual-out.c
+++ b/tests/end_to_end/branch-likely-one-instruction/manual-out.c
@@ -3,8 +3,8 @@ s32 test(); // static
 s32 test(void) {
     s32 phi_a0;
 
-    phi_a0 = *(void *)0x8009A600 == 3;
-    if (*(void *)0x800B0F15 == 5) {
+    phi_a0 = *(s32 *)0x8009A600 == 3;
+    if (*(s8 *)0x800B0F15 == 5) {
         phi_a0 = 1;
     }
     return phi_a0;

--- a/tests/end_to_end/global_decls/irix-o2-out.c
+++ b/tests/end_to_end/global_decls/irix-o2-out.c
@@ -2,7 +2,7 @@ MIPS2C_UNK extern_fn(struct A *); // extern
 MIPS2C_UNK static_fn(struct A *); // static
 extern f32 extern_float;
 struct A static_A = {
-    (u8)1,
+    1,
     {1, 2, 3, 4, 5},
     {
         {{1.0f, 2.0f, 3.0f, 4.0f}, {5.0f, 6.0f, 7.0f, 8.0f}, {9.0f, 0.0f, 1.0f, 2.0f}},

--- a/tests/end_to_end/loop/irix-g-out.c
+++ b/tests/end_to_end/loop/irix-g-out.c
@@ -7,7 +7,7 @@ void test(s32 arg0, s32 arg1) {
     sp4 = 0;
     if (arg1 > 0) {
         do {
-            *(arg0 + sp4) = (u8)0;
+            *(arg0 + sp4) = 0;
             temp_t9 = sp4 + 1;
             sp4 = temp_t9;
         } while ((temp_t9 < arg1) != 0);

--- a/tests/end_to_end/loop/irix-o2-out.c
+++ b/tests/end_to_end/loop/irix-o2-out.c
@@ -21,7 +21,7 @@ s32 test(s8 *arg0, s32 arg1) {
             phi_v0 = 0;
             do {
                 temp_v0 = phi_v0 + 1;
-                *phi_v1 = (u8)0;
+                *phi_v1 = 0;
                 phi_v1 += 1;
                 phi_v0 = temp_v0;
             } while (temp_a3 != temp_v0);
@@ -33,11 +33,11 @@ block_5:
                 phi_v0_2 = phi_v0_3;
                 do {
                     temp_v0_2 = phi_v0_2 + 4;
-                    phi_v1_2->unk1 = (u8)0;
-                    phi_v1_2->unk2 = (u8)0;
-                    phi_v1_2->unk3 = (u8)0;
+                    phi_v1_2->unk1 = 0;
+                    phi_v1_2->unk2 = 0;
+                    phi_v1_2->unk3 = 0;
                     temp_v1 = phi_v1_2 + 4;
-                    temp_v1->unk-4 = (u8)0;
+                    temp_v1->unk-4 = 0;
                     phi_v1_2 = temp_v1;
                     phi_v0_2 = temp_v0_2;
                     phi_return = temp_v0_2;

--- a/tests/end_to_end/misc1/irix-g-out.c
+++ b/tests/end_to_end/misc1/irix-g-out.c
@@ -16,6 +16,6 @@ s32 test(s32 arg0, ?32 arg1) {
         return 0;
     }
     func_0040019C(sp24, sp28, sp2C);
-    *(&D_4101C8 + arg0) = (u8)5;
+    *(&D_4101C8 + arg0) = 5;
     return sp28;
 }

--- a/tests/end_to_end/misc1/irix-o2-out.c
+++ b/tests/end_to_end/misc1/irix-o2-out.c
@@ -22,6 +22,6 @@ s32 test(s32 arg0, ? arg1) {
     }
     sp28 = temp_v0_2;
     func_00400158(sp24, temp_v0_2, temp_a2);
-    *(&D_410178 + arg0) = (u8)5;
+    *(&D_410178 + arg0) = 5;
     return sp28;
 }

--- a/tests/end_to_end/misc1/irix-o2-validsyntax-out.c
+++ b/tests/end_to_end/misc1/irix-o2-validsyntax-out.c
@@ -22,6 +22,6 @@ s32 test(s32 arg0, MIPS2C_UNK arg1) {
     }
     sp28 = temp_v0_2;
     func_00400158(sp24, temp_v0_2, temp_a2);
-    *(&D_410178 + arg0) = (u8)5;
+    *(&D_410178 + arg0) = 5;
     return sp28;
 }

--- a/tests/end_to_end/phis-1/manual-out.c
+++ b/tests/end_to_end/phis-1/manual-out.c
@@ -9,6 +9,6 @@ void test(void) {
     if (*NULL == 0) {
         sp10C = temp_ret;
     }
-    temp_ret->unk3 = (u8)0;
-    temp_ret->unk4 = (u8)0;
+    temp_ret->unk3 = 0;
+    temp_ret->unk4 = 0;
 }


### PR DESCRIPTION
(As discussed on Discord.)

Output from running tests against MM w/ context is [here](https://gist.github.com/zbanks/00b946953f767fa8c5a4af8a89abdf64).

One downside that we hadn't talked about yet is that all pointer casts used to be `(void *)`, regardless of pointer type. There are some places where we know it's a pointer, but we don't know the exact type, so it now shows up as `(? *)` or `(?32 *)`. 

I think this is still an improvement? I don't think `*(void *)0xA02FE1C0` is much better than `*(? *)0xA02FE1C0`: neither is valid C, and at least the latter is formatted as `*(MIPS2C_UNK32 *)...` with `--valid-syntax`.