### PR TITLE
Improve early return handling by swapping the order if/else blocks are built

### DIFF
--- a/tests/end_to_end/andor_assignment/irix-o2-noandor-out.c
+++ b/tests/end_to_end/andor_assignment/irix-o2-noandor-out.c
@@ -41,19 +41,17 @@ s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
             if (temp_v0 == 0) {
                 phi_t1 = temp_v0;
                 if (arg3 != 0) {
-block_4:
-                    phi_v1 = 1;
-                } else {
+                    goto block_4;
+                }
+                phi_t0 = temp_t0;
+                phi_t1 = temp_v0;
+                phi_v1 = -2;
+                phi_a2 = arg2;
+                if (arg0 != 0) {
                     phi_t0 = temp_t0;
                     phi_t1 = temp_v0;
-                    phi_v1 = -2;
+                    phi_v1 = -1;
                     phi_a2 = arg2;
-                    if (arg0 != 0) {
-                        phi_t0 = temp_t0;
-                        phi_t1 = temp_v0;
-                        phi_v1 = -1;
-                        phi_a2 = arg2;
-                    }
                 }
             } else {
                 goto block_4;
@@ -62,7 +60,8 @@ block_4:
             goto block_4;
         }
     } else {
-        goto block_4;
+block_4:
+        phi_v1 = 1;
     }
     temp_v1 = phi_v1 + phi_a2;
     phi_t1_2 = phi_t1;
@@ -114,8 +113,7 @@ block_4:
                     }
                     phi_v1_5 = phi_v1_7 + 5;
                 } else {
-block_21:
-                    phi_v1_5 = phi_v1_3 + 6;
+                    goto block_21;
                 }
             } else {
                 goto block_21;
@@ -124,7 +122,8 @@ block_21:
             goto block_21;
         }
     } else {
-        goto block_21;
+block_21:
+        phi_v1_5 = phi_v1_3 + 6;
     }
     return phi_v1_5;
 }

--- a/tests/end_to_end/andor_loops/irix-g-out.c
+++ b/tests/end_to_end/andor_loops/irix-g-out.c
@@ -27,25 +27,24 @@ loop_9:
 loop_13:
         sp0 += 1;
         if ((arg1 != 0) && ((arg2 != 0) || (arg3 != 0))) {
-block_30:
-            if (arg0 != 0) {
-                goto loop_13;
-            }
+            goto block_30;
+        }
+        sp0 += 1;
+        if ((arg1 != 0) || ((arg2 != 0) && (arg3 != 0))) {
+            goto block_30;
+        }
+        sp0 += 1;
+        if ((arg1 != 0) && ((arg2 != 0) || (arg3 != 0))) {
+
         } else {
             sp0 += 1;
             if ((arg1 != 0) || ((arg2 != 0) && (arg3 != 0))) {
-                goto block_30;
-            }
-            sp0 += 1;
-            if ((arg1 != 0) && ((arg2 != 0) || (arg3 != 0))) {
 
             } else {
                 sp0 += 1;
-                if ((arg1 != 0) || ((arg2 != 0) && (arg3 != 0))) {
-
-                } else {
-                    sp0 += 1;
-                    goto block_30;
+block_30:
+                if (arg0 != 0) {
+                    goto loop_13;
                 }
             }
         }

--- a/tests/end_to_end/andor_loops/irix-o2-out.c
+++ b/tests/end_to_end/andor_loops/irix-o2-out.c
@@ -59,16 +59,16 @@ loop_13:
                 phi_v1_2 = temp_v1_6;
                 if ((arg1 == 0) && ((arg2 == 0) || (phi_v1_2 = temp_v1_6, (arg3 == 0)))) {
                     phi_v1_6 = temp_v1_6 + 1;
-block_26:
-                    phi_v1_2 = phi_v1_6;
-                    phi_v1_5 = phi_v1_6;
-                    if (arg0 != 0) {
-                        goto loop_13;
-                    }
+                    goto block_26;
                 }
             }
         } else {
-            goto block_26;
+block_26:
+            phi_v1_2 = phi_v1_6;
+            phi_v1_5 = phi_v1_6;
+            if (arg0 != 0) {
+                goto loop_13;
+            }
         }
     }
     phi_v0 = 0;

--- a/tests/end_to_end/andor_mixed/irix-g-out.c
+++ b/tests/end_to_end/andor_mixed/irix-g-out.c
@@ -43,11 +43,11 @@ s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
             phi_t0_2 = arg3;
         }
         if ((phi_t0_2 == (arg0 + 1)) || ((arg1 + 1) != 0)) {
-block_53:
-            sp4 = 8;
+            goto block_53;
         }
     } else {
-        goto block_53;
+block_53:
+        sp4 = 8;
     }
     return sp4;
 }

--- a/tests/end_to_end/andor_mixed/irix-o2-out.c
+++ b/tests/end_to_end/andor_mixed/irix-o2-out.c
@@ -38,11 +38,11 @@
             phi_t0_2 = arg3;
         }
         if ((phi_t0_2 == (arg0 + 1)) || ((arg1 + 1) != 0)) {
-block_53:
-            phi_v1 = 8;
+            goto block_53;
         }
     } else {
-        goto block_53;
+block_53:
+        phi_v1 = 8;
     }
     return phi_v1;
 }

--- a/tests/end_to_end/break/irix-g-out.c
+++ b/tests/end_to_end/break/irix-g-out.c
@@ -10,23 +10,26 @@ loop_1:
         D_4101D0.unk0 = 1;
         if (D_4101D0.unk4 == 2) {
             D_4101D0.unk8 = 3;
-        } else if (D_4101D0.unk8 == 2) {
-            D_4101D0.unkC = 3;
-block_10:
-            temp_t7 = sp4 + 1;
-            sp4 = temp_t7;
-            if (temp_t7 < arg0) {
-                goto loop_1;
-            }
-        } else if (D_4101D0.unk10 == 2) {
-            D_4101D0.unk14 = 3;
         } else {
-            if (D_4101D0.unk14 == 2) {
-                D_4101D0.unk18 = 3;
-            } else {
-                D_4101D0.unkC = 4;
+            if (D_4101D0.unk8 == 2) {
+                D_4101D0.unkC = 3;
+                goto block_10;
             }
-            goto block_10;
+            if (D_4101D0.unk10 == 2) {
+                D_4101D0.unk14 = 3;
+            } else {
+                if (D_4101D0.unk14 == 2) {
+                    D_4101D0.unk18 = 3;
+                } else {
+                    D_4101D0.unkC = 4;
+                }
+block_10:
+                temp_t7 = sp4 + 1;
+                sp4 = temp_t7;
+                if (temp_t7 < arg0) {
+                    goto loop_1;
+                }
+            }
         }
     }
     D_4101D0.unk10 = 5;

--- a/tests/end_to_end/break/irix-o2-out.c
+++ b/tests/end_to_end/break/irix-o2-out.c
@@ -11,22 +11,25 @@ loop_2:
         D_410150.unk0 = 1;
         if (D_410150.unk4 == 2) {
             D_410150.unk8 = 3;
-        } else if (D_410150.unk8 == 2) {
-            D_410150.unkC = 3;
-block_11:
-            phi_v0 = temp_v0;
-            if (temp_v0 != arg0) {
-                goto loop_2;
-            }
-        } else if (D_410150.unk10 == 2) {
-            D_410150.unk14 = 3;
         } else {
-            if (D_410150.unk14 == 2) {
-                D_410150.unk18 = 3;
-            } else {
-                D_410150.unkC = 4;
+            if (D_410150.unk8 == 2) {
+                D_410150.unkC = 3;
+                goto block_11;
             }
-            goto block_11;
+            if (D_410150.unk10 == 2) {
+                D_410150.unk14 = 3;
+            } else {
+                if (D_410150.unk14 == 2) {
+                    D_410150.unk18 = 3;
+                } else {
+                    D_410150.unkC = 4;
+                }
+block_11:
+                phi_v0 = temp_v0;
+                if (temp_v0 != arg0) {
+                    goto loop_2;
+                }
+            }
         }
     }
     D_410150.unk10 = 5;

--- a/tests/end_to_end/doubles/irix-o2-mips1-out.c
+++ b/tests/end_to_end/doubles/irix-o2-mips1-out.c
@@ -6,10 +6,10 @@ f64 test(f64 arg0, s32 arg2, f64 arg4) {
     temp_f0 = (((f64) arg2 * arg0) + (arg0 / arg4)) - 7.0;
     if (!(temp_f0 < arg4)) {
         if ((temp_f0 == arg4) || (temp_f0 > 9.0)) {
-block_4:
+            goto block_4;
         }
     } else {
-        goto block_4;
+block_4:
     }
     D_410150 = 0.0;
     return 0.0;

--- a/tests/end_to_end/loop/irix-o2-out.c
+++ b/tests/end_to_end/loop/irix-o2-out.c
@@ -23,22 +23,22 @@ void test(s8 *arg0, s32 arg1) {
             } while (temp_a3 != temp_v0);
             phi_v0_3 = temp_v0;
             if (temp_v0 != arg1) {
-block_5:
-                phi_v1_2 = arg0 + phi_v0_3;
-                phi_v0_2 = phi_v0_3;
-                do {
-                    temp_v0_2 = phi_v0_2 + 4;
-                    phi_v1_2->unk1 = 0;
-                    phi_v1_2->unk2 = 0;
-                    phi_v1_2->unk3 = 0;
-                    temp_v1 = phi_v1_2 + 4;
-                    temp_v1->unk-4 = 0;
-                    phi_v1_2 = temp_v1;
-                    phi_v0_2 = temp_v0_2;
-                } while (temp_v0_2 != arg1);
+                goto block_5;
             }
         } else {
-            goto block_5;
+block_5:
+            phi_v1_2 = arg0 + phi_v0_3;
+            phi_v0_2 = phi_v0_3;
+            do {
+                temp_v0_2 = phi_v0_2 + 4;
+                phi_v1_2->unk1 = 0;
+                phi_v1_2->unk2 = 0;
+                phi_v1_2->unk3 = 0;
+                temp_v1 = phi_v1_2 + 4;
+                temp_v1->unk-4 = 0;
+                phi_v1_2 = temp_v1;
+                phi_v0_2 = temp_v0_2;
+            } while (temp_v0_2 != arg1);
         }
     }
 }

--- a/tests/end_to_end/loop_nested/irix-o2-out.c
+++ b/tests/end_to_end/loop_nested/irix-o2-out.c
@@ -43,26 +43,26 @@ s32 test(s32 arg0) {
                     phi_v1_2 = temp_v1;
                     phi_v1_5 = temp_v1;
                     if (phi_a3 != arg0) {
-block_6:
-                        phi_a1 = phi_a1_2;
-                        phi_a2_2 = phi_v0 * phi_a1_2;
-                        phi_a3_2 = phi_v0 * (phi_a1_2 + 1);
-                        phi_t0 = phi_v0 * (phi_a1_2 + 2);
-                        phi_t1 = phi_v0 * (phi_a1_2 + 3);
-                        do {
-                            temp_v1_2 = phi_v1_5 + phi_a2_2 + phi_a3_2 + phi_t0 + phi_t1;
-                            temp_a1 = phi_a1 + 4;
-                            phi_a1 = temp_a1;
-                            phi_v1_2 = temp_v1_2;
-                            phi_v1_5 = temp_v1_2;
-                            phi_a2_2 += phi_v0 * 4;
-                            phi_a3_2 += phi_v0 * 4;
-                            phi_t0 += phi_v0 * 4;
-                            phi_t1 += phi_v0 * 4;
-                        } while (temp_a1 != arg0);
+                        goto block_6;
                     }
                 } else {
-                    goto block_6;
+block_6:
+                    phi_a1 = phi_a1_2;
+                    phi_a2_2 = phi_v0 * phi_a1_2;
+                    phi_a3_2 = phi_v0 * (phi_a1_2 + 1);
+                    phi_t0 = phi_v0 * (phi_a1_2 + 2);
+                    phi_t1 = phi_v0 * (phi_a1_2 + 3);
+                    do {
+                        temp_v1_2 = phi_v1_5 + phi_a2_2 + phi_a3_2 + phi_t0 + phi_t1;
+                        temp_a1 = phi_a1 + 4;
+                        phi_a1 = temp_a1;
+                        phi_v1_2 = temp_v1_2;
+                        phi_v1_5 = temp_v1_2;
+                        phi_a2_2 += phi_v0 * 4;
+                        phi_a3_2 += phi_v0 * 4;
+                        phi_t0 += phi_v0 * 4;
+                        phi_t1 += phi_v0 * 4;
+                    } while (temp_a1 != arg0);
                 }
             }
             temp_v0 = phi_v0 + 1;

--- a/tests/end_to_end/multi-switch/irix-o2-out.c
+++ b/tests/end_to_end/multi-switch/irix-o2-out.c
@@ -12,15 +12,9 @@ s32 test(s32 arg0) {
             phi_a0_2 = arg0;
             if (arg0 != 0xC8) {
                 phi_a0_4 = arg0;
-            default: // switch 1
-            default: // switch 2
-block_23:
-                phi_a0 = phi_a0_4 / 2;
-                D_410210 = phi_a0;
-                return 2;
+                goto block_23;
             }
-        case 101: // switch 1
-        case 3: // switch 2
+            // Duplicate return node #16. Try simplifying control flow for better match
             return (phi_a0_2 + 1) ^ phi_a0_2;
         }
         phi_a0_4 = arg0;
@@ -31,21 +25,6 @@ block_23:
             switch (arg0) { // switch 1
             case 107: // switch 1
                 phi_a0 = arg0 + 1;
-                // Duplicate return node #24. Try simplifying control flow for better match
-                D_410210 = phi_a0;
-                return 2;
-            case 102: // switch 1
-block_21:
-                phi_a0 = phi_a0_3;
-                phi_a0_5 = phi_a0_3;
-                if (D_410210 == 0) {
-                case 103: // switch 1
-                case 104: // switch 1
-                case 105: // switch 1
-                case 106: // switch 1
-                    phi_a0_4 = phi_a0_5 - 1;
-                    goto block_23;
-                }
                 // Duplicate return node #24. Try simplifying control flow for better match
                 D_410210 = phi_a0;
                 return 2;
@@ -74,12 +53,27 @@ block_21:
                     return arg0 * arg0;
                 case 2: // switch 2
                     phi_a0_2 = arg0 - 1;
-                    // Duplicate return node #16. Try simplifying control flow for better match
+                    // fallthrough
+                case 3: // switch 2
+                case 101: // switch 1
                     return (phi_a0_2 + 1) ^ phi_a0_2;
                 case 6: // switch 2
                 case 7: // switch 2
                     phi_a0_3 = arg0 * 2;
-                    goto block_21;
+                case 102: // switch 1
+                    phi_a0 = phi_a0_3;
+                    phi_a0_5 = phi_a0_3;
+                    if (D_410210 == 0) {
+                    case 103: // switch 1
+                    case 104: // switch 1
+                    case 105: // switch 1
+                    case 106: // switch 1
+                        phi_a0_4 = phi_a0_5 - 1;
+                        goto block_23;
+                    }
+                    // Duplicate return node #24. Try simplifying control flow for better match
+                    D_410210 = phi_a0;
+                    return 2;
                 }
             } else {
                 goto block_23;
@@ -87,10 +81,13 @@ block_21:
         } else {
             if (arg0 != -0x32) {
                 phi_a0_4 = arg0;
-                goto block_23;
+            default: // switch 2
+            default: // switch 1
+block_23:
+                phi_a0 = phi_a0_4 / 2;
+            } else {
+                phi_a0 = arg0 - 1;
             }
-            phi_a0 = arg0 - 1;
-            // Duplicate return node #24. Try simplifying control flow for better match
             D_410210 = phi_a0;
             return 2;
         }

--- a/tests/end_to_end/switch-with-if/irix-o2-out.c
+++ b/tests/end_to_end/switch-with-if/irix-o2-out.c
@@ -26,7 +26,7 @@ void test(s32 arg0) {
                 D_4101D0 = 2;
                 return;
             }
-        default: // switch 2
+            // Duplicate return node #14. Try simplifying control flow for better match
             return;
         case 2: // switch 2
             if (arg0 == 1) {
@@ -38,6 +38,6 @@ void test(s32 arg0) {
             return;
         }
     } else {
-        // Duplicate return node #14. Try simplifying control flow for better match
+    default: // switch 2
     }
 }

--- a/tests/end_to_end/switch/irix-g-out.c
+++ b/tests/end_to_end/switch/irix-g-out.c
@@ -16,6 +16,7 @@ s32 test(s32 arg0) {
             return phi_a0_2 * 2;
         case 4:
             phi_a0 = arg0 + 1;
+            // Duplicate return node #8. Try simplifying control flow for better match
             D_410170 = phi_a0;
             return 2;
         case 6:
@@ -24,14 +25,11 @@ s32 test(s32 arg0) {
             // Duplicate return node #8. Try simplifying control flow for better match
             D_410170 = phi_a0;
             return 2;
-        default:
-block_7:
-            phi_a0 = arg0 / 2;
-            // Duplicate return node #8. Try simplifying control flow for better match
-            D_410170 = phi_a0;
-            return 2;
         }
     } else {
-        goto block_7;
+    default:
+        phi_a0 = arg0 / 2;
+        D_410170 = phi_a0;
+        return 2;
     }
 }

--- a/tests/end_to_end/switch/irix-o2-andor-out.c
+++ b/tests/end_to_end/switch/irix-o2-andor-out.c
@@ -16,6 +16,7 @@ s32 test(s32 arg0) {
             return phi_a0_2 * 2;
         case 4:
             phi_a0 = arg0 + 1;
+            // Duplicate return node #8. Try simplifying control flow for better match
             D_410150 = phi_a0;
             return 2;
         case 6:
@@ -24,14 +25,11 @@ s32 test(s32 arg0) {
             // Duplicate return node #8. Try simplifying control flow for better match
             D_410150 = phi_a0;
             return 2;
-        default:
-block_7:
-            phi_a0 = arg0 / 2;
-            // Duplicate return node #8. Try simplifying control flow for better match
-            D_410150 = phi_a0;
-            return 2;
         }
     } else {
-        goto block_7;
+    default:
+        phi_a0 = arg0 / 2;
+        D_410150 = phi_a0;
+        return 2;
     }
 }

--- a/tests/end_to_end/switch/irix-o2-out.c
+++ b/tests/end_to_end/switch/irix-o2-out.c
@@ -16,6 +16,7 @@ s32 test(s32 arg0) {
             return phi_a0_2 * 2;
         case 4:
             phi_a0 = arg0 + 1;
+            // Duplicate return node #8. Try simplifying control flow for better match
             D_410150 = phi_a0;
             return 2;
         case 6:
@@ -24,14 +25,11 @@ s32 test(s32 arg0) {
             // Duplicate return node #8. Try simplifying control flow for better match
             D_410150 = phi_a0;
             return 2;
-        default:
-block_7:
-            phi_a0 = arg0 / 2;
-            // Duplicate return node #8. Try simplifying control flow for better match
-            D_410150 = phi_a0;
-            return 2;
         }
     } else {
-        goto block_7;
+    default:
+        phi_a0 = arg0 / 2;
+        D_410150 = phi_a0;
+        return 2;
     }
 }


### PR DESCRIPTION
Mentioned in the Discord - but this seems like a weird trick that should smooth out some of the nesting that has been happening since my flowgraph refactor, particularly around switch statements. 

This works by making `goto`s in if/else blocks prefer jumping *forward* (from `if` to `else`), rather than *backwards*.
One potential downside is the way that loops are emitted: the previous version was biased towards `continue;`s (which jump backwards), and it seems this version emits better codes for `break;`s?

As a side effect, I also needed to precompute switch indexes so they wouldn't be reversed.

Example from MM: `EnZoraegg_Init`, which has two switch statements (not a multi switch) and the first has early returns: https://gist.github.com/zbanks/d26f7de31be4e3a85e57d93e9ec9ccf6