### PR TITLE
Improve phi assignment by picking an earlier/smaller set of nodes for SetPhiStmt

### DIFF
--- a/src/translate.py
+++ b/src/translate.py
@@ -1,12 +1,23 @@
 import abc
+from collections import defaultdict
+from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
 import math
 import struct
 import sys
 import traceback
-from contextlib import contextmanager
 import typing
-from typing import Callable, Dict, Iterator, List, Optional, Set, Tuple, Union
+from typing import (
+    Callable,
+    DefaultDict,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 from .c_types import TypeMap
 from .error import DecompFailure
@@ -3199,12 +3210,10 @@ def assign_phis(used_phis: List[PhiExpr], stack_info: StackInfo) -> None:
         assert len(phi.node.parents) >= 2
 
         # Group parent nodes by the value of their phi register
-        equivalent_nodes: Dict[Expression, List[Node]] = {}
+        equivalent_nodes: DefaultDict[Expression, List[Node]] = defaultdict(list)
         for node in phi.node.parents:
             expr = get_block_info(node).final_register_states[phi.reg]
             expr.type.unify(phi.type)
-            if expr not in equivalent_nodes:
-                equivalent_nodes[expr] = []
             equivalent_nodes[expr].append(node)
 
         exprs = list(equivalent_nodes.keys())

--- a/tests/end_to_end/andor_assignment/irix-o2-noandor-out.c
+++ b/tests/end_to_end/andor_assignment/irix-o2-noandor-out.c
@@ -31,27 +31,22 @@ s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
     temp_t7 = arg1 + arg2;
     sp2C = temp_t0;
     sp1C = temp_t7;
+    phi_t0 = temp_t0;
+    phi_a2 = arg2;
     phi_t1 = temp_t7;
     if (temp_t0 == 0) {
-        phi_t1 = temp_t7;
         if (temp_t7 == 0) {
             sp20 = temp_t0;
             temp_v0 = func_00400090(temp_t7);
             phi_t1 = temp_v0;
+            phi_t1 = temp_v0;
             if (temp_v0 == 0) {
-                phi_t1 = temp_v0;
                 if (arg3 != 0) {
                     goto block_4;
                 }
-                phi_t0 = temp_t0;
-                phi_t1 = temp_v0;
                 phi_v1 = -2;
-                phi_a2 = arg2;
                 if (arg0 != 0) {
-                    phi_t0 = temp_t0;
-                    phi_t1 = temp_v0;
                     phi_v1 = -1;
-                    phi_a2 = arg2;
                 }
             } else {
                 goto block_4;
@@ -64,24 +59,19 @@ block_4:
         phi_v1 = 1;
     }
     temp_v1 = phi_v1 + phi_a2;
+    phi_v1_2 = temp_v1;
     phi_t1_2 = phi_t1;
     phi_v1_3 = temp_v1;
+    phi_v1_6 = temp_v1;
     if (phi_t0 != 0) {
         temp_a0 = phi_t0 + phi_t1;
-        phi_t1_2 = phi_t1;
-        phi_v1_3 = temp_v1;
         if (phi_t1 != 0) {
             sp2C = temp_a0;
             sp24 = temp_v1;
             temp_v0_2 = func_00400090(temp_a0);
             phi_t1_2 = temp_v0_2;
-            phi_v1_3 = temp_v1;
             if (temp_v0_2 != 0) {
-                phi_t1_2 = temp_v0_2;
-                phi_v1_3 = temp_v1;
                 if (arg3 != 0) {
-                    phi_v1_2 = temp_v1;
-                    phi_v1_6 = temp_v1;
                     if (temp_v1 < 5) {
                         do {
                             temp_t5 = (phi_v1_2 + 1) * 2;
@@ -89,12 +79,13 @@ block_4:
                             phi_v1_6 = temp_t5;
                         } while ((temp_t5 < 5) != 0);
                     }
-                    phi_t1_2 = temp_v0_2;
                     phi_v1_3 = phi_v1_6 + 5;
                 }
             }
         }
     }
+    phi_v1_4 = phi_v1_3;
+    phi_v1_7 = phi_v1_3;
     if (sp2C != 0) {
         temp_a0_2 = sp2C + phi_t1_2;
         if (phi_t1_2 != 0) {
@@ -102,8 +93,6 @@ block_4:
             sp24 = phi_v1_3;
             if (func_00400090(temp_a0_2) != 0) {
                 if (arg3 != 0) {
-                    phi_v1_4 = phi_v1_3;
-                    phi_v1_7 = phi_v1_3;
                     if (phi_v1_3 < 5) {
                         do {
                             temp_t9 = (phi_v1_4 + 1) * 2;

--- a/tests/end_to_end/andor_assignment/irix-o2-noandor-out.c
+++ b/tests/end_to_end/andor_assignment/irix-o2-noandor-out.c
@@ -31,14 +31,14 @@ s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
     temp_t7 = arg1 + arg2;
     sp2C = temp_t0;
     sp1C = temp_t7;
-    phi_t0 = temp_t0;
-    phi_a2 = arg2;
     phi_t1 = temp_t7;
     if (temp_t0 == 0) {
         if (temp_t7 == 0) {
             sp20 = temp_t0;
             temp_v0 = func_00400090(temp_t7);
+            phi_t0 = temp_t0;
             phi_t1 = temp_v0;
+            phi_a2 = arg2;
             phi_t1 = temp_v0;
             if (temp_v0 == 0) {
                 if (arg3 != 0) {
@@ -59,17 +59,18 @@ block_4:
         phi_v1 = 1;
     }
     temp_v1 = phi_v1 + phi_a2;
-    phi_v1_2 = temp_v1;
     phi_t1_2 = phi_t1;
     phi_v1_3 = temp_v1;
-    phi_v1_6 = temp_v1;
     if (phi_t0 != 0) {
         temp_a0 = phi_t0 + phi_t1;
         if (phi_t1 != 0) {
             sp2C = temp_a0;
             sp24 = temp_v1;
             temp_v0_2 = func_00400090(temp_a0);
+            phi_v1_2 = temp_v1;
             phi_t1_2 = temp_v0_2;
+            phi_v1_3 = temp_v1;
+            phi_v1_6 = temp_v1;
             if (temp_v0_2 != 0) {
                 if (arg3 != 0) {
                     if (temp_v1 < 5) {
@@ -84,13 +85,13 @@ block_4:
             }
         }
     }
-    phi_v1_4 = phi_v1_3;
-    phi_v1_7 = phi_v1_3;
     if (sp2C != 0) {
         temp_a0_2 = sp2C + phi_t1_2;
         if (phi_t1_2 != 0) {
             sp2C = temp_a0_2;
             sp24 = phi_v1_3;
+            phi_v1_4 = phi_v1_3;
+            phi_v1_7 = phi_v1_3;
             if (func_00400090(temp_a0_2) != 0) {
                 if (arg3 != 0) {
                     if (phi_v1_3 < 5) {

--- a/tests/end_to_end/andor_assignment/irix-o2-out.c
+++ b/tests/end_to_end/andor_assignment/irix-o2-out.c
@@ -28,61 +28,43 @@ s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
     temp_s0 = arg0 + arg1;
     temp_t7 = arg1 + arg2;
     sp20 = temp_t7;
+    phi_a2 = arg2;
     phi_s0 = temp_s0;
     phi_t0 = temp_t7;
-    if ((temp_s0 != 0) || (phi_s0 = temp_s0, phi_t0 = temp_t7, (temp_t7 != 0)) || (temp_v0 = func_00400090(temp_t7), phi_s0 = temp_s0, phi_t0 = temp_v0, (temp_v0 != 0)) || (phi_s0 = 2, phi_t0 = temp_v0, (arg3 != 0))) {
+    if ((temp_s0 != 0) || (temp_t7 != 0) || (temp_v0 = func_00400090(temp_t7), phi_t0 = temp_v0, phi_t0 = temp_v0, (temp_v0 != 0)) || (phi_s0 = 2, phi_s0 = 2, (arg3 != 0))) {
         phi_v1 = 1;
     } else {
-        phi_s0 = 2;
-        phi_t0 = temp_v0;
         phi_v1 = -2;
-        phi_a2 = arg2;
         if (arg0 != 0) {
-            phi_s0 = 2;
-            phi_t0 = temp_v0;
             phi_v1 = -1;
-            phi_a2 = arg2;
         }
     }
     temp_v1 = phi_v1 + phi_a2;
+    phi_v1_2 = temp_v1;
     phi_s0_2 = phi_s0;
     phi_t0_2 = phi_t0;
     phi_v1_3 = temp_v1;
-    if (phi_s0 != 0) {
-        phi_s0_2 = phi_s0;
-        phi_t0_2 = phi_t0;
-        phi_v1_3 = temp_v1;
-        if (phi_t0 != 0) {
-            temp_s0_2 = phi_s0 + phi_t0;
-            sp24 = temp_v1;
-            temp_v0_2 = func_00400090(temp_s0_2);
-            phi_s0_2 = temp_s0_2;
-            phi_t0_2 = temp_v0_2;
-            phi_v1_3 = temp_v1;
-            if (temp_v0_2 != 0) {
-                phi_s0_2 = temp_s0_2;
-                phi_t0_2 = temp_v0_2;
-                phi_v1_3 = temp_v1;
-                if (arg3 != 0) {
-                    phi_v1_2 = temp_v1;
-                    phi_v1_6 = temp_v1;
-                    if (temp_v1 < 5) {
-                        do {
-                            temp_t3 = (phi_v1_2 + 1) * 2;
-                            phi_v1_2 = temp_t3;
-                            phi_v1_6 = temp_t3;
-                        } while ((temp_t3 < 5) != 0);
-                    }
-                    phi_s0_2 = temp_s0_2;
-                    phi_t0_2 = temp_v0_2;
-                    phi_v1_3 = phi_v1_6 + 5;
-                }
+    phi_v1_6 = temp_v1;
+    if ((phi_s0 != 0) && (phi_t0 != 0)) {
+        temp_s0_2 = phi_s0 + phi_t0;
+        sp24 = temp_v1;
+        temp_v0_2 = func_00400090(temp_s0_2);
+        phi_s0_2 = temp_s0_2;
+        phi_t0_2 = temp_v0_2;
+        if ((temp_v0_2 != 0) && (arg3 != 0)) {
+            if (temp_v1 < 5) {
+                do {
+                    temp_t3 = (phi_v1_2 + 1) * 2;
+                    phi_v1_2 = temp_t3;
+                    phi_v1_6 = temp_t3;
+                } while ((temp_t3 < 5) != 0);
             }
+            phi_v1_3 = phi_v1_6 + 5;
         }
     }
+    phi_v1_4 = phi_v1_3;
+    phi_v1_7 = phi_v1_3;
     if ((phi_s0_2 != 0) && (phi_t0_2 != 0) && (sp24 = phi_v1_3, (func_00400090(phi_s0_2 + phi_t0_2) != 0)) && (arg3 != 0)) {
-        phi_v1_4 = phi_v1_3;
-        phi_v1_7 = phi_v1_3;
         if (phi_v1_3 < 5) {
             do {
                 temp_t5 = (phi_v1_4 + 1) * 2;

--- a/tests/end_to_end/andor_assignment/irix-o2-out.c
+++ b/tests/end_to_end/andor_assignment/irix-o2-out.c
@@ -28,10 +28,9 @@ s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
     temp_s0 = arg0 + arg1;
     temp_t7 = arg1 + arg2;
     sp20 = temp_t7;
-    phi_a2 = arg2;
     phi_s0 = temp_s0;
     phi_t0 = temp_t7;
-    if ((temp_s0 != 0) || (temp_t7 != 0) || (temp_v0 = func_00400090(temp_t7), phi_t0 = temp_v0, phi_t0 = temp_v0, (temp_v0 != 0)) || (phi_s0 = 2, phi_s0 = 2, (arg3 != 0))) {
+    if ((temp_s0 != 0) || (temp_t7 != 0) || (temp_v0 = func_00400090(temp_t7), phi_t0 = temp_v0, phi_a2 = arg2, phi_t0 = temp_v0, (temp_v0 != 0)) || (phi_s0 = 2, phi_s0 = 2, (arg3 != 0))) {
         phi_v1 = 1;
     } else {
         phi_v1 = -2;
@@ -40,17 +39,18 @@ s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
         }
     }
     temp_v1 = phi_v1 + phi_a2;
-    phi_v1_2 = temp_v1;
     phi_s0_2 = phi_s0;
     phi_t0_2 = phi_t0;
     phi_v1_3 = temp_v1;
-    phi_v1_6 = temp_v1;
     if ((phi_s0 != 0) && (phi_t0 != 0)) {
         temp_s0_2 = phi_s0 + phi_t0;
         sp24 = temp_v1;
         temp_v0_2 = func_00400090(temp_s0_2);
+        phi_v1_2 = temp_v1;
         phi_s0_2 = temp_s0_2;
         phi_t0_2 = temp_v0_2;
+        phi_v1_3 = temp_v1;
+        phi_v1_6 = temp_v1;
         if ((temp_v0_2 != 0) && (arg3 != 0)) {
             if (temp_v1 < 5) {
                 do {
@@ -62,9 +62,7 @@ s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
             phi_v1_3 = phi_v1_6 + 5;
         }
     }
-    phi_v1_4 = phi_v1_3;
-    phi_v1_7 = phi_v1_3;
-    if ((phi_s0_2 != 0) && (phi_t0_2 != 0) && (sp24 = phi_v1_3, (func_00400090(phi_s0_2 + phi_t0_2) != 0)) && (arg3 != 0)) {
+    if ((phi_s0_2 != 0) && (phi_t0_2 != 0) && (sp24 = phi_v1_3, phi_v1_4 = phi_v1_3, phi_v1_7 = phi_v1_3, (func_00400090(phi_s0_2 + phi_t0_2) != 0)) && (arg3 != 0)) {
         if (phi_v1_3 < 5) {
             do {
                 temp_t5 = (phi_v1_4 + 1) * 2;

--- a/tests/end_to_end/andor_loops/irix-o2-out.c
+++ b/tests/end_to_end/andor_loops/irix-o2-out.c
@@ -19,32 +19,30 @@ s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
     s32 phi_v1_9;
 
     phi_v1_7 = 0;
-    if ((arg0 != 0) && ((phi_v1_9 = 0, (arg1 != 0)) || (phi_v1_7 = 0, phi_v1_9 = 0, (arg2 != 0)))) {
+    phi_v1_9 = 0;
+    if ((arg0 != 0) && ((arg1 != 0) || (arg2 != 0))) {
 loop_3:
         temp_v1 = phi_v1_9 + 1;
         phi_v1_7 = temp_v1;
+        phi_v1_9 = temp_v1;
         if (arg0 != 0) {
-            phi_v1_9 = temp_v1;
-            if ((arg1 != 0) || (phi_v1_7 = temp_v1, phi_v1_9 = temp_v1, (arg2 != 0))) {
+            if ((arg1 != 0) || (arg2 != 0)) {
                 goto loop_3;
             }
         }
     }
+    phi_v1_4 = phi_v1_7;
     phi_v1_8 = phi_v1_7;
-    if ((arg0 != 0) || ((phi_v1_4 = phi_v1_7, (arg1 != 0)) && (phi_v1_4 = phi_v1_7, phi_v1_8 = phi_v1_7, (arg2 != 0)))) {
+    if ((arg0 != 0) || ((arg1 != 0) && (arg2 != 0))) {
 loop_9:
         temp_v1_2 = phi_v1_8 + 1;
+        phi_v1_4 = temp_v1_2;
         phi_v1_8 = temp_v1_2;
         if (arg0 != 0) {
             goto loop_9;
         }
-        phi_v1_4 = temp_v1_2;
-        if (arg1 != 0) {
-            phi_v1_4 = temp_v1_2;
-            phi_v1_8 = temp_v1_2;
-            if (arg2 != 0) {
-                goto loop_9;
-            }
+        if ((arg1 != 0) && (arg2 != 0)) {
+            goto loop_9;
         }
     }
     phi_v1_2 = phi_v1_4;
@@ -52,12 +50,14 @@ loop_9:
     if (arg0 != 0) {
 loop_13:
         temp_v1_3 = phi_v1_5 + 1;
-        if (((arg1 == 0) || ((phi_v1_6 = temp_v1_3, (arg2 == 0)) && (phi_v1_6 = temp_v1_3, (arg3 == 0)))) && (temp_v1_4 = temp_v1_3 + 1, phi_v1_6 = temp_v1_4, (arg1 == 0)) && ((arg2 == 0) || (phi_v1_6 = temp_v1_4, (arg3 == 0)))) {
+        phi_v1_6 = temp_v1_3;
+        if (((arg1 == 0) || ((arg2 == 0) && (arg3 == 0))) && (temp_v1_4 = temp_v1_3 + 1, phi_v1_6 = temp_v1_4, (arg1 == 0)) && ((arg2 == 0) || (arg3 == 0))) {
             temp_v1_5 = temp_v1_4 + 1;
-            if ((arg1 == 0) || ((phi_v1_2 = temp_v1_5, (arg2 == 0)) && (phi_v1_2 = temp_v1_5, (arg3 == 0)))) {
+            phi_v1_2 = temp_v1_5;
+            if ((arg1 == 0) || ((arg2 == 0) && (arg3 == 0))) {
                 temp_v1_6 = temp_v1_5 + 1;
                 phi_v1_2 = temp_v1_6;
-                if ((arg1 == 0) && ((arg2 == 0) || (phi_v1_2 = temp_v1_6, (arg3 == 0)))) {
+                if ((arg1 == 0) && ((arg2 == 0) || (arg3 == 0))) {
                     phi_v1_6 = temp_v1_6 + 1;
                     goto block_26;
                 }
@@ -72,16 +72,17 @@ block_26:
         }
     }
     phi_v0 = 0;
+    phi_v1 = phi_v1_2;
     phi_v1_3 = phi_v1_2;
-    if ((arg0 != 0) || (phi_v0 = 0, phi_v1 = phi_v1_2, phi_v1_3 = phi_v1_2, (arg1 != 0))) {
+    if ((arg0 != 0) || (arg1 != 0)) {
 loop_29:
         temp_v0 = phi_v0 + arg2 + arg3;
         temp_v1_7 = phi_v1_3 + 1;
+        phi_v0 = temp_v0;
         phi_v1 = temp_v1_7;
+        phi_v1_3 = temp_v1_7;
         if (temp_v0 < 0xA) {
-            phi_v0 = temp_v0;
-            phi_v1_3 = temp_v1_7;
-            if ((arg0 != 0) || (phi_v0 = temp_v0, phi_v1 = temp_v1_7, phi_v1_3 = temp_v1_7, (arg1 != 0))) {
+            if ((arg0 != 0) || (arg1 != 0)) {
                 goto loop_29;
             }
         }

--- a/tests/end_to_end/andor_mixed/irix-o2-out.c
+++ b/tests/end_to_end/andor_mixed/irix-o2-out.c
@@ -3,7 +3,8 @@
     s32 phi_t0_2;
     ? phi_v1;
 
-    if (((arg0 + arg1) != 0) || (((arg1 + arg2) != 0) && ((arg0 * arg1) != 0)) || ((phi_v1 = 0, (arg3 != 0)) && (phi_v1 = 0, (arg0 != 0)))) {
+    phi_v1 = 0;
+    if (((arg0 + arg1) != 0) || (((arg1 + arg2) != 0) && ((arg0 * arg1) != 0)) || ((arg3 != 0) && (arg0 != 0))) {
         phi_v1 = 1;
     }
     if ((arg0 != 0) && ((arg1 != 0) || (arg2 != 0)) && ((arg3 != 0) || ((arg0 + 1) != 0))) {

--- a/tests/end_to_end/break/irix-o2-out.c
+++ b/tests/end_to_end/break/irix-o2-out.c
@@ -4,11 +4,12 @@ void test(s32 arg0) {
     s32 temp_v0;
     s32 phi_v0;
 
+    phi_v0 = 0;
     if (arg0 > 0) {
-        phi_v0 = 0;
 loop_2:
         temp_v0 = phi_v0 + 1;
         D_410150.unk0 = 1;
+        phi_v0 = temp_v0;
         if (D_410150.unk4 == 2) {
             D_410150.unk8 = 3;
         } else {
@@ -25,7 +26,6 @@ loop_2:
                     D_410150.unkC = 4;
                 }
 block_11:
-                phi_v0 = temp_v0;
                 if (temp_v0 != arg0) {
                     goto loop_2;
                 }

--- a/tests/end_to_end/loop/irix-o2-out.c
+++ b/tests/end_to_end/loop/irix-o2-out.c
@@ -9,19 +9,19 @@ void test(s8 *arg0, s32 arg1) {
     s32 phi_v0_2;
     s32 phi_v0_3;
 
+    phi_v0 = 0;
+    phi_v0_3 = 0;
     if (arg1 > 0) {
         temp_a3 = arg1 & 3;
-        phi_v0_3 = 0;
         if (temp_a3 != 0) {
             phi_v1 = arg0;
-            phi_v0 = 0;
             do {
                 temp_v0 = phi_v0 + 1;
                 *phi_v1 = 0;
                 phi_v1 += 1;
                 phi_v0 = temp_v0;
+                phi_v0_3 = temp_v0;
             } while (temp_a3 != temp_v0);
-            phi_v0_3 = temp_v0;
             if (temp_v0 != arg1) {
                 goto block_5;
             }

--- a/tests/end_to_end/loop_nested/irix-o2-out.c
+++ b/tests/end_to_end/loop_nested/irix-o2-out.c
@@ -24,24 +24,24 @@ s32 test(s32 arg0) {
     phi_v1_3 = 0;
     if (arg0 > 0) {
         do {
+            phi_a1_2 = 0;
             phi_v1_2 = phi_v1_3;
+            phi_v1_4 = phi_v1_3;
+            phi_v1_5 = phi_v1_3;
             if (arg0 > 0) {
                 temp_t1 = arg0 & 3;
-                phi_a1_2 = 0;
-                phi_v1_5 = phi_v1_3;
                 if (temp_t1 != 0) {
                     phi_a3 = 1;
-                    phi_v1_4 = phi_v1_3;
                     phi_a2 = phi_v0 * 0;
                     do {
                         temp_v1 = phi_v1_4 + phi_a2;
                         phi_a3 += 1;
+                        phi_a1_2 = phi_a3;
+                        phi_v1_2 = temp_v1;
                         phi_v1_4 = temp_v1;
                         phi_a2 += phi_v0;
+                        phi_v1_5 = temp_v1;
                     } while (temp_t1 != phi_a3);
-                    phi_a1_2 = phi_a3;
-                    phi_v1_2 = temp_v1;
-                    phi_v1_5 = temp_v1;
                     if (phi_a3 != arg0) {
                         goto block_6;
                     }

--- a/tests/end_to_end/loop_with_if/irix-o2-allman-out.c
+++ b/tests/end_to_end/loop_with_if/irix-o2-allman-out.c
@@ -4,10 +4,10 @@ s32 test(s32 arg0)
     s32 phi_v1_2;
     s32 phi_v1_3;
 
+    phi_v1 = 0;
     phi_v1_3 = 0;
     if (arg0 > 0)
     {
-        phi_v1 = 0;
         do
         {
             if (phi_v1 == 5)

--- a/tests/end_to_end/loop_with_if/irix-o2-out.c
+++ b/tests/end_to_end/loop_with_if/irix-o2-out.c
@@ -3,9 +3,9 @@ s32 test(s32 arg0) {
     s32 phi_v1_2;
     s32 phi_v1_3;
 
+    phi_v1 = 0;
     phi_v1_3 = 0;
     if (arg0 > 0) {
-        phi_v1 = 0;
         do {
             if (phi_v1 == 5) {
                 phi_v1_2 = phi_v1 * 2;

--- a/tests/end_to_end/multi-switch/irix-o2-out.c
+++ b/tests/end_to_end/multi-switch/irix-o2-out.c
@@ -7,21 +7,19 @@ s32 test(s32 arg0) {
     s32 phi_a0_4;
     s32 phi_a0_5;
 
+    phi_a0_2 = arg0;
+    phi_a0_3 = arg0;
+    phi_a0_4 = arg0;
+    phi_a0_5 = arg0;
     if (arg0 >= 0x33) {
         if (arg0 >= 0x6C) {
-            phi_a0_2 = arg0;
             if (arg0 != 0xC8) {
-                phi_a0_4 = arg0;
                 goto block_23;
             }
             // Duplicate return node #16. Try simplifying control flow for better match
             return (phi_a0_2 + 1) ^ phi_a0_2;
         }
-        phi_a0_4 = arg0;
         if ((u32) (arg0 - 0x65) < 7U) {
-            phi_a0_2 = arg0;
-            phi_a0_3 = arg0;
-            phi_a0_5 = arg0;
             switch (arg0) { // switch 1
             case 107: // switch 1
                 phi_a0 = arg0 + 1;
@@ -35,7 +33,6 @@ s32 test(s32 arg0) {
     } else {
         if (arg0 >= 8) {
             if (arg0 != 0x32) {
-                phi_a0_4 = arg0;
                 goto block_23;
             }
             phi_a0 = arg0 + 1;
@@ -44,10 +41,7 @@ s32 test(s32 arg0) {
             return 2;
         }
         if (arg0 >= -0x31) {
-            phi_a0_4 = arg0;
             if ((u32) (arg0 - 1) < 7U) {
-                phi_a0_2 = arg0;
-                phi_a0_4 = arg0;
                 switch (arg0) { // switch 2
                 case 1: // switch 2
                     return arg0 * arg0;
@@ -80,7 +74,6 @@ s32 test(s32 arg0) {
             }
         } else {
             if (arg0 != -0x32) {
-                phi_a0_4 = arg0;
             default: // switch 2
             default: // switch 1
 block_23:

--- a/tests/end_to_end/multiple-assigns/irix-o2-out.c
+++ b/tests/end_to_end/multiple-assigns/irix-o2-out.c
@@ -10,8 +10,8 @@ s32 test(s32 arg0) {
     s32 temp_a0_6;
     s32 phi_a0;
 
+    phi_a0 = arg0;
     if (arg0 == 5) {
-        phi_a0 = arg0;
         do {
             D_410120 = phi_a0;
             temp_a0 = phi_a0 + 1;

--- a/tests/end_to_end/switch/irix-g-out.c
+++ b/tests/end_to_end/switch/irix-g-out.c
@@ -4,8 +4,8 @@ s32 test(s32 arg0) {
     s32 phi_a0;
     s32 phi_a0_2;
 
+    phi_a0_2 = arg0;
     if ((u32) (arg0 - 1) < 7U) {
-        phi_a0_2 = arg0;
         switch (arg0) {
         case 1:
             return arg0 * arg0;

--- a/tests/end_to_end/switch/irix-o2-andor-out.c
+++ b/tests/end_to_end/switch/irix-o2-andor-out.c
@@ -4,8 +4,8 @@ s32 test(s32 arg0) {
     s32 phi_a0;
     s32 phi_a0_2;
 
+    phi_a0_2 = arg0;
     if ((u32) (arg0 - 1) < 7U) {
-        phi_a0_2 = arg0;
         switch (arg0) {
         case 1:
             return arg0 * arg0;

--- a/tests/end_to_end/switch/irix-o2-out.c
+++ b/tests/end_to_end/switch/irix-o2-out.c
@@ -4,8 +4,8 @@ s32 test(s32 arg0) {
     s32 phi_a0;
     s32 phi_a0_2;
 
+    phi_a0_2 = arg0;
     if ((u32) (arg0 - 1) < 7U) {
-        phi_a0_2 = arg0;
         switch (arg0) {
         case 1:
             return arg0 * arg0;


### PR DESCRIPTION
In `assign_phis()`, rather than emit the `SetPhiStmt` at the end of each of parents, try to find a different set of nodes that has equivalent behavior, but will likely produce nicer code.

- Prefer picking *earlier* nodes when possible. This helps avoid getting assignments inside complex conditionals (see `andor` tests), and can result in similar phi nodes "bunching up" in a way that's easier to refactor (see `phi_a0_2`-`5` in `multi-switch` test).
- If two or more of `phi.node.parents` share a dominator, we can do the assignment *once* in the dominator, as long as the value of the register at that node is the same. This reduces the number of statements.
- I originally thought loops would be tricky. I was worried we needed to avoid moving phi assignments out of loops, because that's not equivalent. I found some places where the phis got moved out of loops, but it turned out that moving the phi out made it *more* correct. ([`Mio0_Decompress`, in `mio0.c`](https://gist.github.com/zbanks/d628c6a4bfb3c9bfec8d4246ba6ac4bb)) I couldn't manage to reproduce this behavior in an end-to-end test.