### PR TITLE
Detect and combine "if guards" with switches

### DIFF
--- a/src/flow_graph.py
+++ b/src/flow_graph.py
@@ -924,10 +924,6 @@ class NaturalLoop:
     backedges: Set[Node] = field(default_factory=set)
 
 
-def symbol_name_is_jump_table(sym_name: str) -> bool:
-    return any(sym_name.startswith(prefix) for prefix in ("jtbl", "jpt_"))
-
-
 def build_graph_from_block(
     block: Block, blocks: List[Block], nodes: List[Node], asm_data: AsmData
 ) -> Node:
@@ -988,7 +984,10 @@ def build_graph_from_block(
                         and isinstance(arg.lhs, Macro)
                         and arg.lhs.macro_name == "lo"
                         and isinstance(arg.lhs.argument, AsmGlobalSymbol)
-                        and symbol_name_is_jump_table(arg.lhs.argument.symbol_name)
+                        and any(
+                            arg.lhs.argument.symbol_name.startswith(prefix)
+                            for prefix in ("jtbl", "jpt_")
+                        )
                     ):
                         jtbl_names.append(arg.lhs.argument.symbol_name)
             if len(jtbl_names) != 1:

--- a/src/if_statements.py
+++ b/src/if_statements.py
@@ -670,20 +670,23 @@ def build_switch_between(
     Output the subgraph between `switch` and `end`, but not including `end`.
     The returned SwitchStatement starts with the jump to the switch's value.
     """
+    switch_cases = switch.cases[:]
+    if default is end:
+        default = None
+    elif default is not None:
+        switch_cases.append(default)
+
     switch_index = add_labels_for_switch(context, switch, default)
 
     jump = get_block_info(switch).switch_control
     assert jump is not None
 
     switch_body = Body(print_node_comment=context.options.debug)
-    cases = switch.cases[:]
-    if default is not None and default is not end:
-        cases.append(default)
 
     # Order case blocks by their position in the asm, not by their order in the jump table
     # (but use the order in the jump table to break ties)
     sorted_cases = sorted(
-        set(cases), key=lambda node: (node.block.index, cases.index(node))
+        set(switch_cases), key=lambda node: (node.block.index, switch_cases.index(node))
     )
     next_sorted_cases: List[Optional[Node]] = []
     next_sorted_cases.extend(sorted_cases[1:])

--- a/src/if_statements.py
+++ b/src/if_statements.py
@@ -381,6 +381,28 @@ def emit_goto_or_early_return(context: Context, target: Node, body: Body) -> Non
         emit_goto(context, target, body)
 
 
+def is_switch_guard(node: Node) -> bool:
+    """Return True if `node` is a ConditionalNode for checking the bounds of a
+    SwitchNode's control expression. These can usually be combined in the output."""
+    if not isinstance(node, ConditionalNode):
+        return False
+    cond = get_block_info(node).branch_condition
+    assert cond is not None
+
+    switch_node = node.fallthrough_edge
+    if not isinstance(switch_node, SwitchNode):
+        return False
+    switch_block_info = get_block_info(switch_node)
+    assert switch_block_info.switch_control is not None
+
+    # The SwitchNode must have no statements, and the conditional
+    # from the ConditionalNode must properly check the jump table bounds.
+    return (
+        not switch_block_info.statements_to_write()
+        and switch_block_info.switch_control.matches_guard_condition(cond)
+    )
+
+
 def gather_any_comma_conditions(block_info: BlockInfo) -> Condition:
     branch_condition = block_info.branch_condition
     assert branch_condition is not None
@@ -591,6 +613,8 @@ def build_conditional_subgraph(
             and not curr_node.loop
             # Exclude nodes with incoming edges that are not part of the condition
             and all(p in chained_cond_nodes for p in curr_node.parents)
+            # Exclude guards for SwitchNodes (they may be elided)
+            and not is_switch_guard(curr_node)
         ):
             break
 
@@ -639,33 +663,27 @@ def emit_return(context: Context, node: ReturnNode, body: Body) -> None:
 def build_switch_between(
     context: Context,
     switch: SwitchNode,
+    default: Optional[Node],
     end: Node,
 ) -> SwitchStatement:
     """
     Output the subgraph between `switch` and `end`, but not including `end`.
     The returned SwitchStatement starts with the jump to the switch's value.
     """
-    # Try to detect the default node by looking at the switch's parent
-    default_node: Optional[Node] = None
-    if (
-        len(switch.parents) == 1
-        and isinstance(switch.parents[0], ConditionalNode)
-        and switch.parents[0].fallthrough_edge is switch
-        and switch.parents[0].conditional_edge is not end
-    ):
-        default_node = switch.parents[0].conditional_edge
-
-    switch_index = add_labels_for_switch(context, switch, default_node)
+    switch_index = add_labels_for_switch(context, switch, default)
 
     jump = get_block_info(switch).switch_control
     assert jump is not None
 
     switch_body = Body(print_node_comment=context.options.debug)
+    cases = switch.cases[:]
+    if default is not None and default is not end:
+        cases.append(default)
 
     # Order case blocks by their position in the asm, not by their order in the jump table
     # (but use the order in the jump table to break ties)
     sorted_cases = sorted(
-        set(switch.cases), key=lambda node: (node.block.index, switch.cases.index(node))
+        set(cases), key=lambda node: (node.block.index, cases.index(node))
     )
     next_sorted_cases: List[Optional[Node]] = []
     next_sorted_cases.extend(sorted_cases[1:])
@@ -788,10 +806,25 @@ def build_flowgraph_between(
         assert curr_end is not None
 
         # For nodes with branches, curr_end is not a direct successor of curr_start
-        if isinstance(curr_start, ConditionalNode):
+        if is_switch_guard(curr_start):
+            # curr_start is a ConditionalNode that falls through to a SwitchNode,
+            # where the condition checks that the switch's control expression is
+            # within the jump table bounds.
+            # We can combine the if+switch into just a single switch block.
+            assert isinstance(curr_start, ConditionalNode), "checked by is_switch_guard"
+            switch_node = curr_start.fallthrough_edge
+            assert isinstance(switch_node, SwitchNode), "checked by is_switch_guard"
+            default_node = curr_start.conditional_edge
+            # is_switch_guard checked that switch_node has no statements to write,
+            # so it is OK to mark it as emitted
+            context.emitted_nodes.add(switch_node)
+            body.add_switch(
+                build_switch_between(context, switch_node, default_node, curr_end)
+            )
+        elif isinstance(curr_start, ConditionalNode):
             body.add_if_else(build_conditional_subgraph(context, curr_start, curr_end))
         elif isinstance(curr_start, SwitchNode):
-            body.add_switch(build_switch_between(context, curr_start, curr_end))
+            body.add_switch(build_switch_between(context, curr_start, None, curr_end))
         else:
             # No branch, but double check that we didn't skip any nodes.
             # If the check fails, then the immediate_postdominator computation was wrong

--- a/src/if_statements.py
+++ b/src/if_statements.py
@@ -398,7 +398,8 @@ def is_switch_guard(node: Node) -> bool:
     # The SwitchNode must have no statements, and the conditional
     # from the ConditionalNode must properly check the jump table bounds.
     return (
-        not switch_block_info.statements_to_write()
+        switch_node.parents == [node]
+        and not switch_block_info.statements_to_write()
         and switch_block_info.switch_control.matches_guard_condition(cond)
     )
 
@@ -824,10 +825,10 @@ def build_flowgraph_between(
             body.add_switch(
                 build_switch_between(context, switch_node, default_node, curr_end)
             )
-        elif isinstance(curr_start, ConditionalNode):
-            body.add_if_else(build_conditional_subgraph(context, curr_start, curr_end))
         elif isinstance(curr_start, SwitchNode):
             body.add_switch(build_switch_between(context, curr_start, None, curr_end))
+        elif isinstance(curr_start, ConditionalNode):
+            body.add_if_else(build_conditional_subgraph(context, curr_start, curr_end))
         else:
             # No branch, but double check that we didn't skip any nodes.
             # If the check fails, then the immediate_postdominator computation was wrong

--- a/src/translate.py
+++ b/src/translate.py
@@ -29,7 +29,6 @@ from .flow_graph import (
     SwitchNode,
     TerminalNode,
     build_flowgraph,
-    symbol_name_is_jump_table,
 )
 from .options import Formatter, Options
 from .parse_file import AsmData, AsmDataEntry
@@ -1373,6 +1372,43 @@ class SwitchControl:
     jump_table: Optional[GlobalSymbol] = None
     offset: int = 0
 
+    def matches_guard_condition(self, cond: Condition) -> bool:
+        """
+        Return True if `cond` is one of:
+            - `((control_expr + (-offset)) >= len(jump_table))`, if `offset != 0`
+            - `(control_expr >= len(jump_table))`, if `offset == 0`
+        These are the appropriate bounds checks before using `jump_table`.
+        """
+        cmp_expr = simplify_condition(cond)
+        if not isinstance(cmp_expr, BinaryOp) or cmp_expr.op != ">=":
+            return False
+
+        # The LHS may have been wrapped in a u32 cast
+        left_expr = late_unwrap(cmp_expr.left)
+        if isinstance(left_expr, Cast):
+            left_expr = late_unwrap(left_expr.expr)
+
+        if self.offset != 0:
+            if (
+                not isinstance(left_expr, BinaryOp)
+                or late_unwrap(left_expr.left) != late_unwrap(self.control_expr)
+                or left_expr.op != "+"
+                or late_unwrap(left_expr.right) != Literal(-self.offset)
+            ):
+                return False
+        elif left_expr != late_unwrap(self.control_expr):
+            return False
+
+        right_expr = late_unwrap(cmp_expr.right)
+        return (
+            self.jump_table is not None
+            and self.jump_table.asm_data_entry is not None
+            and self.jump_table.asm_data_entry.is_jtbl
+            and isinstance(right_expr, Literal)
+            # Allow inexact matches, as long as it is less than the detected jump table length
+            and right_expr.value <= len(self.jump_table.asm_data_entry.data)
+        )
+
     @staticmethod
     def from_expr(expr: Expression) -> "SwitchControl":
         """
@@ -1418,7 +1454,7 @@ class SwitchControl:
                 offset = -offset_lit.value
 
         # Check that it is really a jump table
-        if not symbol_name_is_jump_table(jump_table.symbol_name):
+        if jump_table.asm_data_entry is None or not jump_table.asm_data_entry.is_jtbl:
             return error_expr
 
         return SwitchControl(control_expr, jump_table, offset)

--- a/tests/end_to_end/multi-switch/irix-o2-out.c
+++ b/tests/end_to_end/multi-switch/irix-o2-out.c
@@ -19,16 +19,12 @@ s32 test(s32 arg0) {
             // Duplicate return node #16. Try simplifying control flow for better match
             return (phi_a0_2 + 1) ^ phi_a0_2;
         }
-        if ((u32) (arg0 - 0x65) < 7U) {
-            switch (arg0) { // switch 1
-            case 107: // switch 1
-                phi_a0 = arg0 + 1;
-                // Duplicate return node #24. Try simplifying control flow for better match
-                D_410210 = phi_a0;
-                return 2;
-            }
-        } else {
-            goto block_23;
+        switch (arg0) { // switch 1
+        case 107: // switch 1
+            phi_a0 = arg0 + 1;
+            // Duplicate return node #24. Try simplifying control flow for better match
+            D_410210 = phi_a0;
+            return 2;
         }
     } else {
         if (arg0 >= 8) {
@@ -41,36 +37,32 @@ s32 test(s32 arg0) {
             return 2;
         }
         if (arg0 >= -0x31) {
-            if ((u32) (arg0 - 1) < 7U) {
-                switch (arg0) { // switch 2
-                case 1: // switch 2
-                    return arg0 * arg0;
-                case 2: // switch 2
-                    phi_a0_2 = arg0 - 1;
-                    // fallthrough
-                case 3: // switch 2
-                case 101: // switch 1
-                    return (phi_a0_2 + 1) ^ phi_a0_2;
-                case 6: // switch 2
-                case 7: // switch 2
-                    phi_a0_3 = arg0 * 2;
-                case 102: // switch 1
-                    phi_a0 = phi_a0_3;
-                    phi_a0_5 = phi_a0_3;
-                    if (D_410210 == 0) {
-                    case 103: // switch 1
-                    case 104: // switch 1
-                    case 105: // switch 1
-                    case 106: // switch 1
-                        phi_a0_4 = phi_a0_5 - 1;
-                        goto block_23;
-                    }
-                    // Duplicate return node #24. Try simplifying control flow for better match
-                    D_410210 = phi_a0;
-                    return 2;
+            switch (arg0) { // switch 2
+            case 1: // switch 2
+                return arg0 * arg0;
+            case 2: // switch 2
+                phi_a0_2 = arg0 - 1;
+                // fallthrough
+            case 3: // switch 2
+            case 101: // switch 1
+                return (phi_a0_2 + 1) ^ phi_a0_2;
+            case 6: // switch 2
+            case 7: // switch 2
+                phi_a0_3 = arg0 * 2;
+            case 102: // switch 1
+                phi_a0 = phi_a0_3;
+                phi_a0_5 = phi_a0_3;
+                if (D_410210 == 0) {
+                case 103: // switch 1
+                case 104: // switch 1
+                case 105: // switch 1
+                case 106: // switch 1
+                    phi_a0_4 = phi_a0_5 - 1;
+                    goto block_23;
                 }
-            } else {
-                goto block_23;
+                // Duplicate return node #24. Try simplifying control flow for better match
+                D_410210 = phi_a0;
+                return 2;
             }
         } else {
             if (arg0 != -0x32) {

--- a/tests/end_to_end/switch-with-if/irix-o2-out.c
+++ b/tests/end_to_end/switch-with-if/irix-o2-out.c
@@ -34,7 +34,6 @@ void test(s32 arg0) {
         return;
     case 5: // switch 2
     case 6: // switch 2
-    case 7: // switch 2
         if (arg0 == 1) {
             D_4101D0 = 1;
             return;

--- a/tests/end_to_end/switch-with-if/irix-o2-out.c
+++ b/tests/end_to_end/switch-with-if/irix-o2-out.c
@@ -20,7 +20,6 @@ void test(s32 arg0) {
         }
         break;
     }
-default: // switch 1
     switch (arg0) { // switch 2
     case 1: // switch 2
     case 2: // switch 2

--- a/tests/end_to_end/switch-with-if/irix-o2-out.c
+++ b/tests/end_to_end/switch-with-if/irix-o2-out.c
@@ -1,43 +1,47 @@
 extern s32 D_4101D0;
 
 void test(s32 arg0) {
-    if ((u32) (arg0 - 1) < 6U) {
-        switch (arg0) { // switch 1
-        case 1: // switch 1
-            D_4101D0 = 1;
-            if (arg0 == 1) {
-                D_4101D0 = 2;
-            }
-            break;
-        case 2: // switch 1
-            if (arg0 == 1) {
-                D_4101D0 = 1;
-            } else {
-                D_4101D0 = 2;
-            }
-            break;
-        }
-    }
-    if ((u32) (arg0 - 1) < 6U) {
-        switch (arg0) { // switch 2
-        case 1: // switch 2
-            D_4101D0 = 1;
-            if (arg0 == 1) {
-                D_4101D0 = 2;
-                return;
-            }
-            // Duplicate return node #14. Try simplifying control flow for better match
-            return;
-        case 2: // switch 2
-            if (arg0 == 1) {
-                D_4101D0 = 1;
-                return;
-            }
+    switch (arg0) { // switch 1
+    case 1: // switch 1
+    case 2: // switch 1
+    case 3: // switch 1
+    case 4: // switch 1
+        D_4101D0 = 1;
+        if (arg0 == 1) {
             D_4101D0 = 2;
-            // Duplicate return node #14. Try simplifying control flow for better match
+        }
+        break;
+    case 5: // switch 1
+    case 6: // switch 1
+        if (arg0 == 1) {
+            D_4101D0 = 1;
+        } else {
+            D_4101D0 = 2;
+        }
+        break;
+    }
+default: // switch 1
+    switch (arg0) { // switch 2
+    case 1: // switch 2
+    case 2: // switch 2
+    case 3: // switch 2
+    case 4: // switch 2
+        D_4101D0 = 1;
+        if (arg0 == 1) {
+            D_4101D0 = 2;
             return;
         }
-    } else {
     default: // switch 2
+        return;
+    case 5: // switch 2
+    case 6: // switch 2
+    case 7: // switch 2
+        if (arg0 == 1) {
+            D_4101D0 = 1;
+            return;
+        }
+        D_4101D0 = 2;
+        // Duplicate return node #14. Try simplifying control flow for better match
+        return;
     }
 }

--- a/tests/end_to_end/switch-with-if/irix-o2.s
+++ b/tests/end_to_end/switch-with-if/irix-o2.s
@@ -17,7 +17,6 @@ glabel jtbl_4001B8
 .word .case3
 .word .case4
 .word .case4
-.word .case4
 
 .text
 

--- a/tests/end_to_end/switch-with-if/irix-o2.s
+++ b/tests/end_to_end/switch-with-if/irix-o2.s
@@ -4,10 +4,19 @@
 .late_rodata
 glabel jtbl_4001A0
 .word .case1
+.word .case1
+.word .case1
+.word .case1
+.word .case2
 .word .case2
 
 glabel jtbl_4001B8
 .word .case3
+.word .case3
+.word .case3
+.word .case3
+.word .case4
+.word .case4
 .word .case4
 
 .text

--- a/tests/end_to_end/switch/irix-g-out.c
+++ b/tests/end_to_end/switch/irix-g-out.c
@@ -5,30 +5,27 @@ s32 test(s32 arg0) {
     s32 phi_a0_2;
 
     phi_a0_2 = arg0;
-    if ((u32) (arg0 - 1) < 7U) {
-        switch (arg0) {
-        case 1:
-            return arg0 * arg0;
-        case 2:
-            phi_a0_2 = arg0 - 1;
-            // fallthrough
-        case 3:
-            return phi_a0_2 * 2;
-        case 4:
-            phi_a0 = arg0 + 1;
-            // Duplicate return node #8. Try simplifying control flow for better match
-            D_410170 = phi_a0;
-            return 2;
-        case 6:
-        case 7:
-            phi_a0 = arg0 * 2;
-            // Duplicate return node #8. Try simplifying control flow for better match
-            D_410170 = phi_a0;
-            return 2;
-        }
-    } else {
+    switch (arg0) {
+    case 1:
+        return arg0 * arg0;
+    case 2:
+        phi_a0_2 = arg0 - 1;
+        // fallthrough
+    case 3:
+        return phi_a0_2 * 2;
+    case 4:
+        phi_a0 = arg0 + 1;
+        D_410170 = phi_a0;
+        return 2;
+    case 6:
+    case 7:
+        phi_a0 = arg0 * 2;
+        // Duplicate return node #8. Try simplifying control flow for better match
+        D_410170 = phi_a0;
+        return 2;
     default:
         phi_a0 = arg0 / 2;
+        // Duplicate return node #8. Try simplifying control flow for better match
         D_410170 = phi_a0;
         return 2;
     }

--- a/tests/end_to_end/switch/irix-o2-andor-out.c
+++ b/tests/end_to_end/switch/irix-o2-andor-out.c
@@ -5,30 +5,27 @@ s32 test(s32 arg0) {
     s32 phi_a0_2;
 
     phi_a0_2 = arg0;
-    if ((u32) (arg0 - 1) < 7U) {
-        switch (arg0) {
-        case 1:
-            return arg0 * arg0;
-        case 2:
-            phi_a0_2 = arg0 - 1;
-            // fallthrough
-        case 3:
-            return phi_a0_2 * 2;
-        case 4:
-            phi_a0 = arg0 + 1;
-            // Duplicate return node #8. Try simplifying control flow for better match
-            D_410150 = phi_a0;
-            return 2;
-        case 6:
-        case 7:
-            phi_a0 = arg0 * 2;
-            // Duplicate return node #8. Try simplifying control flow for better match
-            D_410150 = phi_a0;
-            return 2;
-        }
-    } else {
+    switch (arg0) {
+    case 1:
+        return arg0 * arg0;
+    case 2:
+        phi_a0_2 = arg0 - 1;
+        // fallthrough
+    case 3:
+        return phi_a0_2 * 2;
+    case 4:
+        phi_a0 = arg0 + 1;
+        D_410150 = phi_a0;
+        return 2;
+    case 6:
+    case 7:
+        phi_a0 = arg0 * 2;
+        // Duplicate return node #8. Try simplifying control flow for better match
+        D_410150 = phi_a0;
+        return 2;
     default:
         phi_a0 = arg0 / 2;
+        // Duplicate return node #8. Try simplifying control flow for better match
         D_410150 = phi_a0;
         return 2;
     }

--- a/tests/end_to_end/switch/irix-o2-out.c
+++ b/tests/end_to_end/switch/irix-o2-out.c
@@ -5,30 +5,27 @@ s32 test(s32 arg0) {
     s32 phi_a0_2;
 
     phi_a0_2 = arg0;
-    if ((u32) (arg0 - 1) < 7U) {
-        switch (arg0) {
-        case 1:
-            return arg0 * arg0;
-        case 2:
-            phi_a0_2 = arg0 - 1;
-            // fallthrough
-        case 3:
-            return phi_a0_2 * 2;
-        case 4:
-            phi_a0 = arg0 + 1;
-            // Duplicate return node #8. Try simplifying control flow for better match
-            D_410150 = phi_a0;
-            return 2;
-        case 6:
-        case 7:
-            phi_a0 = arg0 * 2;
-            // Duplicate return node #8. Try simplifying control flow for better match
-            D_410150 = phi_a0;
-            return 2;
-        }
-    } else {
+    switch (arg0) {
+    case 1:
+        return arg0 * arg0;
+    case 2:
+        phi_a0_2 = arg0 - 1;
+        // fallthrough
+    case 3:
+        return phi_a0_2 * 2;
+    case 4:
+        phi_a0 = arg0 + 1;
+        D_410150 = phi_a0;
+        return 2;
+    case 6:
+    case 7:
+        phi_a0 = arg0 * 2;
+        // Duplicate return node #8. Try simplifying control flow for better match
+        D_410150 = phi_a0;
+        return 2;
     default:
         phi_a0 = arg0 / 2;
+        // Duplicate return node #8. Try simplifying control flow for better match
         D_410150 = phi_a0;
         return 2;
     }


### PR DESCRIPTION
Most switches are proceeded by a `ConditionalNode` which performs a bounds check to ensure that the jump table access is valid. This check is pretty consistent across IDO/GCC. 

It's straightforward to combine this check with the `switch (...)` statement itself: if the conditional branch indicates the default case. (If the conditional branch is to `end`, that indicates that there is *no* default case).

This change was enabled by the earlier phi PR. There used to frequently be phi assignment expressions at the top of `SwitchNode`s, which makes it hard to combine the if+switch. Now those are almost entirely gone, so this heuristic is drastically more successful.

---

I tested this across OOT, MM, & PM (without context). It was able successfully combine 1045 instances, and only failed at 13. (Note: there ~180 functions which are non-reducible: these fall back to gotos-only mode, so they aren't tested here.) The issues were:
- 5 instances where the condition couldn't be parsed (e.g. the condition was partially turned into a temp)
- 4 instances where there were phi statements in the SwitchNode
- 3 instances like `switch (x & 7)`, which doesn't need a guard expression (cool!)
- 1 instance where the SwitchNode control expression wasn't parsed at all, and already had a "cannot parse jump table" comment