### PR TITLE
Add fake edges to the flow graph to break infinite loops and make the graph reducible

### DIFF
--- a/src/flow_graph.py
+++ b/src/flow_graph.py
@@ -797,9 +797,14 @@ class BaseNode(_BaseNode, abc.ABC):
 @dataclass(eq=False, repr=False)
 class BasicNode(BaseNode):
     successor: "Node"
+    # Optional link to the TerminalNode, used to make infinite loops reducible.
+    # Used by `compute_relations()`, but ignored when emitting code.
+    fake_successor: Optional["TerminalNode"] = None
 
     def children(self) -> List["Node"]:
         # TODO: Should we also include the fallthrough node if `emit_goto` is True?
+        if self.fake_successor is not None:
+            return [self.successor, self.fake_successor]
         return [self.successor]
 
     def __str__(self) -> str:
@@ -1280,6 +1285,37 @@ def compute_relations(nodes: List[Node]) -> None:
                     child.loop.nodes.add(parent)
 
 
+def terminate_infinite_loops(nodes: List[Node]) -> None:
+    terminal_node = nodes[-1]
+    assert isinstance(terminal_node, TerminalNode)
+
+    # Fixed-point iteration
+    while True:
+        # Find the set of nodes which are rechable from the TerminalNode, backwards
+        seen = set()
+        queue: Set[Node] = {terminal_node}
+        while queue:
+            n = queue.pop()
+            seen.add(n)
+            queue.update(set(n.parents) - seen)
+
+        # Find the BasicNodes which cannot reach the TerminalNode
+        # Although it's possible to design asm which has an infinite loop without
+        # BasicNodes, it doesn't seem to happen in practice. Keeping these fixups
+        # contained keeps the `build_flowgraph_between(...)` logic simpler.
+        unterminated_nodes = [
+            node for node in nodes if node not in seen and isinstance(node, BasicNode)
+        ]
+        if not unterminated_nodes:
+            # Nothing left to do!
+            return
+
+        # Add a "fake" edge from the final BasicNode to the TerminalNode,
+        # which is used by `compute_relations()` but is ignored in codegen.
+        unterminated_nodes[-1].fake_successor = terminal_node
+        compute_relations(nodes)
+
+
 @dataclass(frozen=True)
 class FlowGraph:
     nodes: List[Node]
@@ -1364,6 +1400,7 @@ def build_flowgraph(function: Function, asm_data: AsmData) -> FlowGraph:
     nodes = build_nodes(function, blocks, asm_data)
     nodes = duplicate_premature_returns(nodes)
     compute_relations(nodes)
+    terminate_infinite_loops(nodes)
     return FlowGraph(nodes)
 
 

--- a/src/if_statements.py
+++ b/src/if_statements.py
@@ -832,6 +832,9 @@ def build_flowgraph_between(
             body.add_switch(build_switch_between(context, curr_start, None, curr_end))
         elif isinstance(curr_start, ConditionalNode):
             body.add_if_else(build_conditional_subgraph(context, curr_start, curr_end))
+        elif isinstance(curr_start, BasicNode) and curr_start.fake_successor:
+            assert curr_start.fake_successor is curr_end
+            curr_end = curr_start.successor
         else:
             # No branch, but double check that we didn't skip any nodes.
             # If the check fails, then the immediate_postdominator computation was wrong
@@ -930,7 +933,6 @@ def build_body(context: Context, options: Options) -> Body:
         if options.ifs and not is_reducible:
             body.add_comment(
                 "Flowgraph is not reducible, falling back to gotos-only mode. "
-                "(Are there infinite loops?)"
             )
         body.extend(build_naive(context, context.flow_graph.nodes))
 

--- a/src/if_statements.py
+++ b/src/if_statements.py
@@ -832,8 +832,9 @@ def build_flowgraph_between(
             body.add_switch(build_switch_between(context, curr_start, None, curr_end))
         elif isinstance(curr_start, ConditionalNode):
             body.add_if_else(build_conditional_subgraph(context, curr_start, curr_end))
-        elif isinstance(curr_start, BasicNode) and curr_start.fake_successor:
-            assert curr_start.fake_successor is curr_end
+        elif (
+            isinstance(curr_start, BasicNode) and curr_start.fake_successor == curr_end
+        ):
             curr_end = curr_start.successor
         else:
             # No branch, but double check that we didn't skip any nodes.
@@ -932,7 +933,7 @@ def build_body(context: Context, options: Options) -> Body:
         body = Body(print_node_comment=context.options.debug)
         if options.ifs and not is_reducible:
             body.add_comment(
-                "Flowgraph is not reducible, falling back to gotos-only mode. "
+                "Flowgraph is not reducible, falling back to gotos-only mode."
             )
         body.extend(build_naive(context, context.flow_graph.nodes))
 

--- a/tests/end_to_end/known_called_function/irix-g-out.c
+++ b/tests/end_to_end/known_called_function/irix-g-out.c
@@ -1,7 +1,6 @@
 void test(s32 x, s16* y, s32 z, s8* r, s16* s, s32* t, s32* u) {
     s32* sp1C;
 
-    // Flowgraph is not reducible, falling back to gotos-only mode. (Are there infinite loops?)
     sp1C = NULL;
 loop_1:
     sp1C = foo(sp1C, y, t);

--- a/tests/end_to_end/known_called_function/irix-o2-out.c
+++ b/tests/end_to_end/known_called_function/irix-o2-out.c
@@ -1,7 +1,6 @@
 void test(s32 x, s16 *y, s32 z, s8 *r, s16 *s, s32 *t, s32 *u) {
     s32 *phi_s0;
 
-    // Flowgraph is not reducible, falling back to gotos-only mode. (Are there infinite loops?)
     phi_s0 = NULL;
 loop_1:
     phi_s0 = foo(phi_s0, y, t);

--- a/tests/end_to_end/loop-selfassign-phi/irix-g-out.c
+++ b/tests/end_to_end/loop-selfassign-phi/irix-g-out.c
@@ -2,12 +2,9 @@ s32 func_004000D8(s32); // static
 void test(s32 arg0); // static
 
 void test(s32 arg0) {
-    // Flowgraph is not reducible, falling back to gotos-only mode. (Are there infinite loops?)
 loop_1:
-    if (arg0 < 3) {
-        goto block_3;
+    if (arg0 >= 3) {
+        arg0 = func_004000D8(arg0);
     }
-    arg0 = func_004000D8(arg0);
-block_3:
     goto loop_1;
 }

--- a/tests/end_to_end/loop-selfassign-phi/irix-o2-out.c
+++ b/tests/end_to_end/loop-selfassign-phi/irix-o2-out.c
@@ -4,7 +4,6 @@ void test(s32 arg0); // static
 void test(s32 arg0) {
     s32 phi_s0;
 
-    // Flowgraph is not reducible, falling back to gotos-only mode. (Are there infinite loops?)
     phi_s0 = arg0;
 loop_1:
     if (phi_s0 < 3) {

--- a/tests/end_to_end/return-detection/floats-out.c
+++ b/tests/end_to_end/return-detection/floats-out.c
@@ -4,7 +4,7 @@ f32 test(void) {
     f32 temp_f0;
     f32 phi_f0;
 
-    // Flowgraph is not reducible, falling back to gotos-only mode. 
+    // Flowgraph is not reducible, falling back to gotos-only mode.
     temp_f0 = bar();
     phi_f0 = temp_f0;
     phi_f0 = temp_f0;

--- a/tests/end_to_end/return-detection/floats-out.c
+++ b/tests/end_to_end/return-detection/floats-out.c
@@ -4,7 +4,7 @@ f32 test(void) {
     f32 temp_f0;
     f32 phi_f0;
 
-    // Flowgraph is not reducible, falling back to gotos-only mode. (Are there infinite loops?)
+    // Flowgraph is not reducible, falling back to gotos-only mode. 
     temp_f0 = bar();
     phi_f0 = temp_f0;
     phi_f0 = temp_f0;

--- a/tests/end_to_end/return-detection/read-fncall-out.c
+++ b/tests/end_to_end/return-detection/read-fncall-out.c
@@ -1,7 +1,7 @@
 ? bar(); // extern
 
 void test(void) {
-    // Flowgraph is not reducible, falling back to gotos-only mode. (Are there infinite loops?)
+    // Flowgraph is not reducible, falling back to gotos-only mode. 
     bar();
     if (4 == 0) {
         goto block_3;

--- a/tests/end_to_end/return-detection/read-fncall-out.c
+++ b/tests/end_to_end/return-detection/read-fncall-out.c
@@ -1,7 +1,7 @@
 ? bar(); // extern
 
 void test(void) {
-    // Flowgraph is not reducible, falling back to gotos-only mode. 
+    // Flowgraph is not reducible, falling back to gotos-only mode.
     bar();
     if (4 == 0) {
         goto block_3;

--- a/tests/end_to_end/unreachable-return/irix-g-out.c
+++ b/tests/end_to_end/unreachable-return/irix-g-out.c
@@ -1,7 +1,6 @@
 extern s32 D_4100E0;
 
 void test(void) {
-    // Flowgraph is not reducible, falling back to gotos-only mode. (Are there infinite loops?)
 loop_0:
     D_4100E0 = 1;
     goto loop_0;

--- a/tests/end_to_end/unreachable-return/irix-o2-out.c
+++ b/tests/end_to_end/unreachable-return/irix-o2-out.c
@@ -1,7 +1,6 @@
 extern s32 D_4100F0;
 
 void test(void) {
-    // Flowgraph is not reducible, falling back to gotos-only mode. (Are there infinite loops?)
     D_4100F0 = 1;
 loop_1:
     goto loop_1;


### PR DESCRIPTION
This is sort of a hack? I definitely want feedback on this, maybe it's *too* hacky?

The idea is to find nodes which cannot reach the TerminalNode (i.e. infinite loops) and add a "fake" edge to the TerminalNode. This edge is used by `compute_relations(...)`, but then is ignored by `build_flowgraph_between(...)`. 

This change fixed 190 functions across OOT/MM/PM (183 of them from PM). 
There are only 4 functions left in PM, plus 2 end-to-end tests, which still have the "Flowgraph is not reducible..." warning. These functions cannot be made reducible by adding new edges (they would need to split nodes).