### PR TITLE
Remove extern text from forward-declared functions

### DIFF
--- a/src/translate.py
+++ b/src/translate.py
@@ -4153,7 +4153,8 @@ class GlobalInfo:
                     qualifier = "extern"
 
                 if sym.type.is_function():
-                    comments.append(qualifier)
+                    if not qualifier == "extern":
+                        comments.append(qualifier)
                     qualifier = ""
 
                 # Try to guess the symbol's `array_dim` if we have a data entry for it,

--- a/tests/end_to_end/function-pointer2/irix-o2-out.c
+++ b/tests/end_to_end/function-pointer2/irix-o2-out.c
@@ -1,4 +1,4 @@
-s32 bar(f32); // extern
+s32 bar(f32);
 extern s32 (*glob2)(f32);
 
 void test(void) {

--- a/tests/end_to_end/global_decls/irix-o2-out.c
+++ b/tests/end_to_end/global_decls/irix-o2-out.c
@@ -1,4 +1,4 @@
-MIPS2C_UNK extern_fn(struct A *); // extern
+MIPS2C_UNK extern_fn(struct A *);
 MIPS2C_UNK static_fn(struct A *); // static
 extern f32 extern_float;
 struct A static_A = {

--- a/tests/end_to_end/large-struct-member-address/manual-out.c
+++ b/tests/end_to_end/large-struct-member-address/manual-out.c
@@ -1,4 +1,4 @@
-? foo(s8 *); // extern
+? foo(s8 *);
 
 void test(struct A *a) {
     foo(&a->b);

--- a/tests/end_to_end/phis-1/manual-out.c
+++ b/tests/end_to_end/phis-1/manual-out.c
@@ -1,4 +1,4 @@
-void *foo(); // extern
+void *foo();
 
 void test(void) {
     void *sp10C;

--- a/tests/end_to_end/return-detection/circular-phis-ctx-out.c
+++ b/tests/end_to_end/return-detection/circular-phis-ctx-out.c
@@ -1,4 +1,4 @@
-? bar(); // extern
+? bar();
 
 s32 test(void) {
     s32 phi_v0;

--- a/tests/end_to_end/return-detection/circular-phis-out.c
+++ b/tests/end_to_end/return-detection/circular-phis-out.c
@@ -1,4 +1,4 @@
-? bar(); // extern
+? bar();
 
 void test(void) {
     s32 phi_v0;

--- a/tests/end_to_end/return-detection/circular-phis2-out.c
+++ b/tests/end_to_end/return-detection/circular-phis2-out.c
@@ -1,4 +1,4 @@
-? bar(); // extern
+? bar();
 
 void test(void) {
     bar();

--- a/tests/end_to_end/return-detection/conditional-use-out.c
+++ b/tests/end_to_end/return-detection/conditional-use-out.c
@@ -1,4 +1,4 @@
-? foo(?); // extern
+? foo(?);
 
 void test(void) {
     if ((1 != 0) && (1 != 0)) {

--- a/tests/end_to_end/return-detection/floats-out.c
+++ b/tests/end_to_end/return-detection/floats-out.c
@@ -1,4 +1,4 @@
-f32 bar(); // extern
+f32 bar();
 
 f32 test(void) {
     f32 temp_f0;

--- a/tests/end_to_end/return-detection/read-fncall-out.c
+++ b/tests/end_to_end/return-detection/read-fncall-out.c
@@ -1,4 +1,4 @@
-? bar(); // extern
+? bar();
 
 void test(void) {
     // Flowgraph is not reducible, falling back to gotos-only mode.


### PR DESCRIPTION
The list of symbols at the top of the output is already the extern'd list, it seems silly to mark every single function with extern in a comment. I don't think the comments here add anything, as if the function was in the given context, it's not shown in the list in the first place, these functions are specifically the ones that need a declaration.

The comments seem to be the equivalent of:
```
/* Functions */
func_111111(); // A function
func_111112(); // A function
func_111113(); // A function
AFunc(); // A function
func_6436(); // A function
```
At least for me, it ends up being a bit of unnecessary busy work to manually delete the comment from each one once copied in.

I'm leaving the static ones in as they're kinda weird, I'm not sure what makes a function get marked as static, all the ones I see in practice for decomp get marked as extern though.