### PR TITLE
Add an option to output switch case labels in hex

### DIFF
--- a/src/if_statements.py
+++ b/src/if_statements.py
@@ -154,7 +154,10 @@ class LabelStatement:
         lines = []
         if self.node in self.context.case_nodes:
             for (switch, case) in self.context.case_nodes[self.node]:
-                case_str = f"case {case}" if case is not None else "default"
+                case_num = None
+                if case is not None:
+                    case_num = f"0x{case:X}" if fmt.coding_style.hex_case else f"{case}"
+                case_str = f"case {case_num}" if case is not None else "default"
                 switch_str = f" // switch {switch}" if switch != 0 else ""
                 lines.append(fmt.indent(f"{case_str}:{switch_str}", -1))
         if self.node in self.context.goto_nodes:

--- a/src/main.py
+++ b/src/main.py
@@ -236,6 +236,12 @@ def parse_flags(flags: List[str]) -> Options:
         action="store_true",
     )
     group.add_argument(
+        "--hex-case",
+        dest="hex_case",
+        help="Display case labels in hex rather than decimal",
+        action="store_true",
+    )
+    group.add_argument(
         "--dump-typemap",
         dest="dump_typemap",
         action="store_true",
@@ -328,6 +334,7 @@ def parse_flags(flags: List[str]) -> Options:
         newline_before_else=args.allman,
         pointer_style_left=args.pointer_style == "left",
         unknown_underscore=args.unknown_underscore,
+        hex_case=args.hex_case,
     )
     filenames = args.filename
 

--- a/src/options.py
+++ b/src/options.py
@@ -10,6 +10,7 @@ class CodingStyle:
     newline_before_else: bool
     pointer_style_left: bool
     unknown_underscore: bool
+    hex_case: bool
 
 
 @dataclass
@@ -49,6 +50,7 @@ DEFAULT_CODING_STYLE: CodingStyle = CodingStyle(
     newline_before_else=False,
     pointer_style_left=False,
     unknown_underscore=False,
+    hex_case=False,
 )
 
 

--- a/tests/end_to_end/switch/irix-o2-flags.txt
+++ b/tests/end_to_end/switch/irix-o2-flags.txt
@@ -1,1 +1,2 @@
 --no-andor
+--hex-case

--- a/tests/end_to_end/switch/irix-o2-out.c
+++ b/tests/end_to_end/switch/irix-o2-out.c
@@ -6,19 +6,19 @@ s32 test(s32 arg0) {
 
     phi_a0_2 = arg0;
     switch (arg0) {
-    case 1:
+    case 0x1:
         return arg0 * arg0;
-    case 2:
+    case 0x2:
         phi_a0_2 = arg0 - 1;
         // fallthrough
-    case 3:
+    case 0x3:
         return phi_a0_2 * 2;
-    case 4:
+    case 0x4:
         phi_a0 = arg0 + 1;
         D_410150 = phi_a0;
         return 2;
-    case 6:
-    case 7:
+    case 0x6:
+    case 0x7:
         phi_a0 = arg0 * 2;
         // Duplicate return node #8. Try simplifying control flow for better match
         D_410150 = phi_a0;


### PR DESCRIPTION
Adds `--hex-case` to options. This is sometimes needed in decomp PRs, where some numbers make more sense in hex. 