### PR TITLE
Check `phi.replacement_expr` in `PhiExpr.propagates_to()`

### DIFF
--- a/src/translate.py
+++ b/src/translate.py
@@ -1348,7 +1348,7 @@ class PhiExpr(Expression):
         admittedly a bit sketchy, in case the phi is in scope here and used
         later on... but we have that problem with regular phi assignments as
         well."""
-        if self.used_by is None:
+        if self.used_by is None or self.replacement_expr is not None:
             return self
         return self.used_by.propagates_to()
 

--- a/tests/end_to_end/andor_assignment/irix-o2-noandor-out.c
+++ b/tests/end_to_end/andor_assignment/irix-o2-noandor-out.c
@@ -56,7 +56,9 @@ s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
         }
     } else {
 block_4:
+        phi_t0 = arg0 + arg1;
         phi_v1 = 1;
+        phi_a2 = arg2;
     }
     temp_v1 = phi_v1 + phi_a2;
     phi_t1_2 = phi_t1;

--- a/tests/end_to_end/andor_assignment/irix-o2-out.c
+++ b/tests/end_to_end/andor_assignment/irix-o2-out.c
@@ -32,6 +32,7 @@ s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
     phi_t0 = temp_t7;
     if ((temp_s0 != 0) || (temp_t7 != 0) || (temp_v0 = func_00400090(temp_t7), phi_t0 = temp_v0, phi_a2 = arg2, phi_t0 = temp_v0, (temp_v0 != 0)) || (phi_s0 = 2, phi_s0 = 2, (arg3 != 0))) {
         phi_v1 = 1;
+        phi_a2 = arg2;
     } else {
         phi_v1 = -2;
         if (arg0 != 0) {


### PR DESCRIPTION
This seems to fix the issue mzx was having in Discord with function `func_800CA22C` from MM, where `phi_a0_2` was uninitialized.

It looks like there was a similar bug in the e2e test for `andor_assignment` - so there's already test coverage for this fix.

I don't have a good enough understanding of the phi machinery to succinctly explain why this fixes the problem: but, I don't think this change invalidates any existing comments. If you have any suggestions for updating them to be more clear/explicit let me know. 
This problem predates my earlier PR #135 that changed where phi assignments were handled.