### PR TITLE
Add --passes/-P for running multiple passes over the input

### DIFF
--- a/src/flow_graph.py
+++ b/src/flow_graph.py
@@ -1398,6 +1398,10 @@ class FlowGraph:
             return False
         return True
 
+    def reset_block_info(self) -> None:
+        for node in self.nodes:
+            node.block.block_info = None
+
 
 def build_flowgraph(function: Function, asm_data: AsmData) -> FlowGraph:
     blocks = build_blocks(function, asm_data)

--- a/src/if_statements.py
+++ b/src/if_statements.py
@@ -963,6 +963,28 @@ def build_body(context: Context, options: Options) -> Body:
     return body
 
 
+def function_format_pass(function_info: "FunctionInfo") -> None:
+    """
+    Format every expression in the given function, but discard the output.
+    This is significantly faster than `get_function_text`, but does not
+    visit the Nodes in the same order.
+    """
+    # Use an arbitrary Formatter; the output will be discarded
+    fmt = Formatter()
+    for node in function_info.flow_graph.nodes:
+        if not node.block.block_info:
+            continue
+        block_info = get_block_info(node)
+        for statement in block_info.statements_to_write():
+            statement.format(fmt)
+        if block_info.return_value:
+            block_info.return_value.format(fmt)
+        if block_info.switch_control:
+            block_info.switch_control.control_expr.format(fmt)
+        if block_info.branch_condition:
+            block_info.branch_condition.format(fmt)
+
+
 def get_function_text(function_info: FunctionInfo, options: Options) -> str:
     fmt = options.formatter()
     context = Context(flow_graph=function_info.flow_graph, options=options, fmt=fmt)

--- a/src/if_statements.py
+++ b/src/if_statements.py
@@ -963,28 +963,6 @@ def build_body(context: Context, options: Options) -> Body:
     return body
 
 
-def function_format_pass(function_info: "FunctionInfo") -> None:
-    """
-    Format every expression in the given function, but discard the output.
-    This is significantly faster than `get_function_text`, but does not
-    visit the Nodes in the same order.
-    """
-    # Use an arbitrary Formatter; the output will be discarded
-    fmt = Formatter()
-    for node in function_info.flow_graph.nodes:
-        if not node.block.block_info:
-            continue
-        block_info = get_block_info(node)
-        for statement in block_info.statements_to_write():
-            statement.format(fmt)
-        if block_info.return_value:
-            block_info.return_value.format(fmt)
-        if block_info.switch_control:
-            block_info.switch_control.control_expr.format(fmt)
-        if block_info.branch_condition:
-            block_info.branch_condition.format(fmt)
-
-
 def get_function_text(function_info: FunctionInfo, options: Options) -> str:
     fmt = options.formatter()
     context = Context(flow_graph=function_info.flow_graph, options=options, fmt=fmt)

--- a/src/main.py
+++ b/src/main.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional, Union
 from .c_types import TypeMap, build_typemap, dump_typemap
 from .error import DecompFailure
 from .flow_graph import visualize_flowgraph
-from .if_statements import get_function_text, function_format_pass
+from .if_statements import get_function_text
 from .options import CodingStyle, Options
 from .parse_file import AsmData, Function, parse_file
 from .translate import (
@@ -110,78 +110,66 @@ def run(options: Options) -> int:
     )
     global_info = GlobalInfo(asm_data, function_names, typemap, typepool)
 
-    # Perform the preliminary passes to improve type resolution, but discard the results/exceptions
-    for i in range(options.passes - 1):
-        preliminary_infos = []
+    for pass_number in range(options.passes):
+        is_final_pass = pass_number == options.passes - 1
+
+        function_infos: List[Union[FunctionInfo, Exception]] = []
         for function in functions:
             try:
-                preliminary_infos.append(
-                    translate_to_ast(function, options, global_info)
+                info = translate_to_ast(function, options, global_info)
+                function_infos.append(info)
+            except Exception as e:
+                # Store the exception for later, to preserve the order in the output
+                function_infos.append(e)
+
+        return_code = 0
+        try:
+            if options.visualize_flowgraph:
+                fn_info = function_infos[0]
+                if isinstance(fn_info, Exception):
+                    raise fn_info
+                print(visualize_flowgraph(fn_info.flow_graph))
+                return 0
+
+            if options.structs:
+                type_decls = typepool.format_type_declarations(fmt)
+                if type_decls and is_final_pass:
+                    print(type_decls)
+
+            global_decls = global_info.global_decls(fmt, options.global_decls)
+            if global_decls and is_final_pass:
+                print(global_decls)
+        except Exception as e:
+            if is_final_pass:
+                print_exception_as_comment(
+                    e, context=None, sanitize=options.sanitize_tracebacks
                 )
-            except Exception as e:
-                pass
-        try:
-            global_info.global_decls(fmt, options.global_decls)
-        except Exception as e:
-            pass
-        for info in preliminary_infos:
-            try:
-                function_format_pass(info)
-            except Exception as e:
-                pass
-
-    function_infos: List[Union[FunctionInfo, Exception]] = []
-    for function in functions:
-        try:
-            info = translate_to_ast(function, options, global_info)
-            function_infos.append(info)
-        except Exception as e:
-            # Store the exception for later, to preserve the order in the output
-            function_infos.append(e)
-
-    return_code = 0
-    try:
-        if options.visualize_flowgraph:
-            fn_info = function_infos[0]
-            if isinstance(fn_info, Exception):
-                raise fn_info
-            print(visualize_flowgraph(fn_info.flow_graph))
-            return 0
-
-        if options.structs:
-            type_decls = typepool.format_type_declarations(fmt)
-            if type_decls:
-                print(type_decls)
-
-        global_decls = global_info.global_decls(fmt, options.global_decls)
-        if global_decls:
-            print(global_decls)
-    except Exception as e:
-        print_exception_as_comment(
-            e, context=None, sanitize=options.sanitize_tracebacks
-        )
-        return_code = 1
-
-    for index, (function, function_info) in enumerate(zip(functions, function_infos)):
-        if index != 0:
-            print()
-        try:
-            if options.print_assembly:
-                print(function)
-                print()
-
-            if isinstance(function_info, Exception):
-                raise function_info
-
-            function_text = get_function_text(function_info, options)
-            print(function_text)
-        except Exception as e:
-            print_exception_as_comment(
-                e,
-                context=f"function {function.name}",
-                sanitize=options.sanitize_tracebacks,
-            )
             return_code = 1
+
+        for index, (function, function_info) in enumerate(
+            zip(functions, function_infos)
+        ):
+            if is_final_pass:
+                if index != 0:
+                    print()
+                if options.print_assembly:
+                    print(function)
+                    print()
+            try:
+                if isinstance(function_info, Exception):
+                    raise function_info
+
+                function_text = get_function_text(function_info, options)
+                if is_final_pass:
+                    print(function_text)
+            except Exception as e:
+                if is_final_pass:
+                    print_exception_as_comment(
+                        e,
+                        context=f"function {function.name}",
+                        sanitize=options.sanitize_tracebacks,
+                    )
+                return_code = 1
 
     for warning in typepool.warnings:
         print(fmt.with_comments("", comments=[warning]))

--- a/src/main.py
+++ b/src/main.py
@@ -112,16 +112,23 @@ def run(options: Options) -> int:
 
     # Perform the preliminary passes to improve type resolution, but discard the results/exceptions
     for i in range(options.passes - 1):
+        preliminary_infos = []
         for function in functions:
             try:
-                info = translate_to_ast(function, options, global_info)
-                function_format_pass(info)
+                preliminary_infos.append(
+                    translate_to_ast(function, options, global_info)
+                )
             except Exception as e:
                 pass
         try:
             global_info.global_decls(fmt, options.global_decls)
         except Exception as e:
             pass
+        for info in preliminary_infos:
+            try:
+                function_format_pass(info)
+            except Exception as e:
+                pass
 
     function_infos: List[Union[FunctionInfo, Exception]] = []
     for function in functions:
@@ -362,7 +369,7 @@ def parse_flags(flags: List[str]) -> Options:
         type=int,
         default=2,
         help="Number of translation passes to perform. Each pass may improve type resolution and produce better "
-        "output, particularly when decompiling multiple funcitons. Default: 2",
+        "output, particularly when decompiling multiple functions. Default: 2",
     )
     group.add_argument(
         "--compiler",

--- a/src/options.py
+++ b/src/options.py
@@ -58,6 +58,7 @@ class Options:
     compiler: CompilerEnum
     structs: bool
     struct_field_inference: bool
+    passes: int
 
     def formatter(self) -> "Formatter":
         return Formatter(

--- a/tests/end_to_end/recursive-type/irix-g-out.c
+++ b/tests/end_to_end/recursive-type/irix-g-out.c
@@ -4,7 +4,7 @@ void test(? *arg0, ? *arg1);                        /* static */
 void test(? *arg0, ? *arg1) {
     arg0 = &arg0;
     arg1 = &arg1;
-    func_00400090(arg0, arg1);
+    func_00400090((? *) arg0, (? *) arg1);
     arg0 = (? *) arg1;
-    func_00400090(arg0, arg1);
+    func_00400090((? *) arg0, (? *) arg1);
 }

--- a/tests/end_to_end/recursive-type/irix-o2-out.c
+++ b/tests/end_to_end/recursive-type/irix-o2-out.c
@@ -9,7 +9,7 @@ void test(? *arg0, ? *arg1) {
     temp_a0 = &arg0;
     arg0 = temp_a0;
     arg1 = temp_a1;
-    func_00400090(temp_a0, temp_a1);
+    func_00400090((? *) temp_a0, (? *) temp_a1);
     arg0 = (? *) arg1;
-    func_00400090((? *) arg1, arg1);
+    func_00400090((? *) arg1, (? *) arg1);
 }


### PR DESCRIPTION
This generally improves type inference, but causes mips_to_c to run slower. More than 2 seems to not make a difference for single-function decomps.

`--passes=1` is the old behavior, `--passes=2` is the new default behavior and is about 50% slower than before (this trend is approximately linear afaict).

[Diffs from OOT, MM, PM](https://gist.github.com/zbanks/5f6fa0dfb278aa6674e684ba0e451504). Sorry that they are too large for github to display inline. There are a few that are worse where there was some incorrect struct type inference: this isn't great, but it should be relatively straightforward to identify & correct manually?