### PR TITLE
Only declare necessary functions

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -131,7 +131,7 @@ def run(options: Options) -> int:
             except:
                 pass
         try:
-            global_info.global_decls(fmt, options.global_decls)
+            global_info.global_decls(fmt, options.global_decls, [])
         except:
             pass
         for info in preliminary_infos:
@@ -166,7 +166,11 @@ def run(options: Options) -> int:
             if type_decls:
                 print(type_decls)
 
-        global_decls = global_info.global_decls(fmt, options.global_decls)
+        global_decls = global_info.global_decls(
+            fmt,
+            options.global_decls,
+            [fn for fn in function_infos if isinstance(fn, FunctionInfo)],
+        )
         if global_decls:
             print(global_decls)
     except Exception as e:

--- a/src/translate.py
+++ b/src/translate.py
@@ -4334,6 +4334,13 @@ def resolve_types_late(stack_info: StackInfo) -> None:
 
 
 @dataclass
+class FunctionInfo:
+    stack_info: StackInfo
+    flow_graph: FlowGraph
+    return_type: Type
+
+
+@dataclass
 class GlobalInfo:
     asm_data: AsmData
     local_functions: Set[str]
@@ -4450,10 +4457,44 @@ class GlobalInfo:
 
         return for_type(sym.type)
 
-    def global_decls(self, fmt: Formatter, decls: Options.GlobalDeclsEnum) -> str:
+    def find_forward_declares_needed(self, functions: List[FunctionInfo]) -> Set[str]:
+        funcs_seen = set()
+        forward_declares_needed = self.asm_data.mentioned_labels
+
+        for func in functions:
+            funcs_seen.add(func.stack_info.function.name)
+
+            for instr in func.stack_info.function.body:
+                if not isinstance(instr, Instruction):
+                    continue
+
+                for arg in instr.args:
+                    if isinstance(arg, AsmGlobalSymbol):
+                        func_name = arg.symbol_name
+                    elif isinstance(arg, Macro) and isinstance(
+                        arg.argument, AsmGlobalSymbol
+                    ):
+                        func_name = arg.argument.symbol_name
+                    else:
+                        continue
+
+                    if func_name in self.local_functions:
+                        if func_name not in funcs_seen:
+                            forward_declares_needed.add(func_name)
+
+        return forward_declares_needed
+
+    def global_decls(
+        self,
+        fmt: Formatter,
+        decls: Options.GlobalDeclsEnum,
+        functions: List[FunctionInfo],
+    ) -> str:
         # Format labels from symbol_type_map into global declarations.
         # As the initializers are formatted, this may cause more symbols
         # to be added to the global_symbol_map.
+        forward_declares_needed = self.find_forward_declares_needed(functions)
+
         lines = []
         processed_names: Set[str] = set()
         while True:
@@ -4582,6 +4623,14 @@ class GlobalInfo:
                 if decls != Options.GlobalDeclsEnum.ALL and sym.initializer_in_typemap:
                     continue
 
+                if (
+                    sym.type.is_function()
+                    and decls != Options.GlobalDeclsEnum.ALL
+                    and name in self.local_functions
+                    and name not in forward_declares_needed
+                ):
+                    continue
+
                 qualifier = f"{qualifier} " if qualifier else ""
                 value = f" = {value}" if value else ""
                 lines.append(
@@ -4596,13 +4645,6 @@ class GlobalInfo:
                 )
         lines.sort()
         return "".join(line for _, line in lines)
-
-
-@dataclass
-class FunctionInfo:
-    stack_info: StackInfo
-    flow_graph: FlowGraph
-    return_type: Type
 
 
 def translate_to_ast(

--- a/tests/end_to_end/andor_assignment/irix-g-out.c
+++ b/tests/end_to_end/andor_assignment/irix-g-out.c
@@ -1,5 +1,4 @@
 s32 func_00400090(s32);                             /* static */
-s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3);   /* static */
 
 s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
     s32 sp24;

--- a/tests/end_to_end/andor_assignment/irix-o2-noandor-out.c
+++ b/tests/end_to_end/andor_assignment/irix-o2-noandor-out.c
@@ -1,5 +1,4 @@
 s32 func_00400090(s32);                             /* static */
-s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3);   /* static */
 
 s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
     s32 sp2C;

--- a/tests/end_to_end/andor_assignment/irix-o2-out.c
+++ b/tests/end_to_end/andor_assignment/irix-o2-out.c
@@ -1,5 +1,4 @@
 s32 func_00400090(s32);                             /* static */
-s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3);   /* static */
 
 s32 test(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
     s32 sp24;

--- a/tests/end_to_end/custom-return/irix-g-out.c
+++ b/tests/end_to_end/custom-return/irix-g-out.c
@@ -1,5 +1,4 @@
 u16 func_0040012C(?);                               /* static */
-u16 test();                                         /* static */
 extern s32 D_410150;
 
 u16 test(void) {

--- a/tests/end_to_end/custom-return/irix-o2-out.c
+++ b/tests/end_to_end/custom-return/irix-o2-out.c
@@ -1,5 +1,4 @@
 s32 func_0040010C(?);                               /* static */
-s32 test();                                         /* static */
 extern s32 D_410120;
 
 s32 test(void) {

--- a/tests/end_to_end/custom_stack/irix-g-out.c
+++ b/tests/end_to_end/custom_stack/irix-g-out.c
@@ -14,7 +14,6 @@ struct _mips2c_stack_test {
 };                                                  /* size = 0x30 */
 
 ? func_00400090(s8 *);                              /* static */
-s32 test(void *arg0);                               /* static */
 
 s32 test(void *arg0) {
     s8 sp2F;

--- a/tests/end_to_end/float-fn/irix-g-out.c
+++ b/tests/end_to_end/float-fn/irix-g-out.c
@@ -1,6 +1,5 @@
 f32 func_004000DC(f32);                             /* static */
 f64 func_004000F4(f64);                             /* static */
-f32 test(f32 arg0);                                 /* static */
 
 f32 test(f32 arg0) {
     arg0 = func_004000DC(arg0);

--- a/tests/end_to_end/float-fn/irix-o2-out.c
+++ b/tests/end_to_end/float-fn/irix-o2-out.c
@@ -1,6 +1,5 @@
 f32 func_004000BC();                                /* static */
 f64 func_004000C4(f64);                             /* static */
-f32 test();                                         /* static */
 
 f32 test(void) {
     return (f32) func_004000C4((f64) func_004000BC());

--- a/tests/end_to_end/fn-write-reordering/irix-g-out.c
+++ b/tests/end_to_end/fn-write-reordering/irix-g-out.c
@@ -1,6 +1,5 @@
 s32 func_004000F0();                                /* static */
 ? func_00400108(s32);                               /* static */
-void test();                                        /* static */
 extern s32 D_410120;
 
 void test(void) {

--- a/tests/end_to_end/fn-write-reordering/irix-o2-out.c
+++ b/tests/end_to_end/fn-write-reordering/irix-o2-out.c
@@ -1,6 +1,5 @@
 s32 func_004000E4();                                /* static */
 ? func_004000EC(s32);                               /* static */
-void test();                                        /* static */
 extern s32 D_410100;
 
 void test(void) {

--- a/tests/end_to_end/jump-into-loop/irix-g-out.c
+++ b/tests/end_to_end/jump-into-loop/irix-g-out.c
@@ -1,5 +1,4 @@
 ? func_0040010C(s32);                               /* static */
-s32 test(s32 arg0);                                 /* static */
 
 s32 test(s32 arg0) {
 loop_3:

--- a/tests/end_to_end/jump-into-loop/irix-o2-out.c
+++ b/tests/end_to_end/jump-into-loop/irix-o2-out.c
@@ -1,5 +1,4 @@
 ? func_004000DC(s32);                               /* static */
-s32 test(s32 arg0);                                 /* static */
 
 s32 test(s32 arg0) {
     s32 temp_t6;

--- a/tests/end_to_end/loop-selfassign-phi/irix-g-out.c
+++ b/tests/end_to_end/loop-selfassign-phi/irix-g-out.c
@@ -1,5 +1,4 @@
 s32 func_004000D8(s32);                             /* static */
-void test(s32 arg0);                                /* static */
 
 void test(s32 arg0) {
 loop_1:

--- a/tests/end_to_end/loop-selfassign-phi/irix-o2-out.c
+++ b/tests/end_to_end/loop-selfassign-phi/irix-o2-out.c
@@ -1,5 +1,4 @@
 s32 func_004000F4(s32);                             /* static */
-void test(s32 arg0);                                /* static */
 
 void test(s32 arg0) {
     s32 phi_s0;

--- a/tests/end_to_end/lwl/irix-g-out.c
+++ b/tests/end_to_end/lwl/irix-g-out.c
@@ -1,5 +1,4 @@
 ? func_004000B0(? *);                               /* static */
-void test();                                        /* static */
 extern ? D_400170;
 extern ? D_400178;
 extern ? D_410180;

--- a/tests/end_to_end/lwl/irix-o2-out.c
+++ b/tests/end_to_end/lwl/irix-o2-out.c
@@ -1,5 +1,4 @@
 ? func_004000B0(? *);                               /* static */
-void test();                                        /* static */
 extern ? D_400150;
 extern ? D_400158;
 extern ? D_410160;

--- a/tests/end_to_end/misc1/irix-g-out.c
+++ b/tests/end_to_end/misc1/irix-g-out.c
@@ -1,6 +1,5 @@
 s32 func_00400174(?, ?, s32, s32, s32);             /* static */
 ? func_0040019C(s32, s32, s32);                     /* static */
-s32 test(s32 arg0, s32 arg1);                       /* static */
 extern s32 D_4101C0;
 extern ? D_4101C8;
 

--- a/tests/end_to_end/misc1/irix-o2-out.c
+++ b/tests/end_to_end/misc1/irix-o2-out.c
@@ -1,6 +1,5 @@
 s32 func_00400140(?, ?, s32, ?, s32);               /* static */
 ? func_00400158(s32, s32, s32);                     /* static */
-s32 test(s32 arg0, ? arg1);                         /* static */
 extern s32 D_410170;
 extern ? D_410178;
 

--- a/tests/end_to_end/misc1/irix-o2-stacklow-out.c
+++ b/tests/end_to_end/misc1/irix-o2-stacklow-out.c
@@ -1,6 +1,5 @@
 s32 func_00400140(?, ?, s32, ?, s32);               /* static */
 ? func_00400158(s32, s32, s32);                     /* static */
-s32 test(s32 arg0, ? arg1);                         /* static */
 extern s32 D_410170;
 extern ? D_410178;
 

--- a/tests/end_to_end/misc1/irix-o2-validsyntax-out.c
+++ b/tests/end_to_end/misc1/irix-o2-validsyntax-out.c
@@ -1,6 +1,5 @@
 s32 func_00400140(MIPS2C_UNK, MIPS2C_UNK, s32, MIPS2C_UNK, s32); /* static */
 MIPS2C_UNK func_00400158(s32, s32, s32);            /* static */
-s32 test(s32 arg0, MIPS2C_UNK arg1);                /* static */
 extern s32 D_410170;
 extern MIPS2C_UNK D_410178;
 

--- a/tests/end_to_end/nested_ifs/irix-g-out.c
+++ b/tests/end_to_end/nested_ifs/irix-g-out.c
@@ -1,5 +1,4 @@
 ? func_004000FC(?);                                 /* static */
-void test(s32 arg0);                                /* static */
 
 void test(s32 arg0) {
     if (arg0 == 7) {

--- a/tests/end_to_end/nested_ifs/irix-o2-out.c
+++ b/tests/end_to_end/nested_ifs/irix-o2-out.c
@@ -1,5 +1,4 @@
 ? func_004000F0(?, s32);                            /* static */
-void test(s32 arg0);                                /* static */
 
 void test(s32 arg0) {
     s32 temp_a1;

--- a/tests/end_to_end/nested_ifs2/irix-g-out.c
+++ b/tests/end_to_end/nested_ifs2/irix-g-out.c
@@ -1,5 +1,4 @@
 ? func_004000FC(?);                                 /* static */
-void test(s32 arg0);                                /* static */
 
 void test(s32 arg0) {
     if (arg0 == 7) {

--- a/tests/end_to_end/nested_ifs2/irix-o2-out.c
+++ b/tests/end_to_end/nested_ifs2/irix-o2-out.c
@@ -1,5 +1,4 @@
 ? func_004000F0(?, s32);                            /* static */
-void test(s32 arg0);                                /* static */
 
 void test(s32 arg0) {
     s32 temp_a1;

--- a/tests/end_to_end/nested_ifs3/irix-g-out.c
+++ b/tests/end_to_end/nested_ifs3/irix-g-out.c
@@ -1,5 +1,4 @@
 ? func_0040011C(?);                                 /* static */
-void test(s32 arg0);                                /* static */
 
 void test(s32 arg0) {
     if (arg0 == 7) {

--- a/tests/end_to_end/nested_ifs3/irix-o2-out.c
+++ b/tests/end_to_end/nested_ifs3/irix-o2-out.c
@@ -1,5 +1,4 @@
 ? func_00400114(?, s32);                            /* static */
-void test(s32 arg0);                                /* static */
 
 void test(s32 arg0) {
     s32 temp_a1;

--- a/tests/end_to_end/nested_ifs4/irix-g-out.c
+++ b/tests/end_to_end/nested_ifs4/irix-g-out.c
@@ -1,5 +1,4 @@
 ? func_0040012C(?);                                 /* static */
-void test(s32 arg0);                                /* static */
 
 void test(s32 arg0) {
     if (arg0 == 7) {

--- a/tests/end_to_end/nested_ifs4/irix-o2-out.c
+++ b/tests/end_to_end/nested_ifs4/irix-o2-out.c
@@ -1,5 +1,4 @@
 ? func_00400114(?, s32);                            /* static */
-void test(s32 arg0);                                /* static */
 
 void test(s32 arg0) {
     s32 temp_a1;

--- a/tests/end_to_end/recursive-type/irix-g-out.c
+++ b/tests/end_to_end/recursive-type/irix-g-out.c
@@ -1,5 +1,4 @@
 ? func_00400090(? *, ? *);                          /* static */
-void test(? *arg0, ? *arg1);                        /* static */
 
 void test(? *arg0, ? *arg1) {
     arg0 = &arg0;

--- a/tests/end_to_end/recursive-type/irix-o2-out.c
+++ b/tests/end_to_end/recursive-type/irix-o2-out.c
@@ -1,5 +1,4 @@
 ? func_00400090(? *, ? *);                          /* static */
-void test(? *arg0, ? *arg1);                        /* static */
 
 void test(? *arg0, ? *arg1) {
     ? *temp_a0;

--- a/tests/end_to_end/test/irix-g-out.c
+++ b/tests/end_to_end/test/irix-g-out.c
@@ -1,5 +1,4 @@
 ? func_004000B0();                                  /* static */
-void test();                                        /* static */
 extern s32 D_410100;
 
 void test(void) {

--- a/tests/end_to_end/test/irix-o2-out.c
+++ b/tests/end_to_end/test/irix-o2-out.c
@@ -1,5 +1,4 @@
 ? func_004000B0();                                  /* static */
-void test();                                        /* static */
 extern s32 D_4100E0;
 
 void test(void) {

--- a/tests/end_to_end/typedef/irix-g-out.c
+++ b/tests/end_to_end/typedef/irix-g-out.c
@@ -1,5 +1,3 @@
-void test(s32 arg0, s32 *arg1);                     /* static */
-
 void test(s32 arg0, s32 *arg1) {
     s32 temp_s0;
     s32 temp_s1;

--- a/tests/end_to_end/typedef/irix-o2-out.c
+++ b/tests/end_to_end/typedef/irix-o2-out.c
@@ -1,5 +1,3 @@
-void test(s32 arg0, s32 *arg1);                     /* static */
-
 void test(s32 arg0, s32 *arg1) {
     s32 sp1C;
     s32 sp18;

--- a/tests/end_to_end/weird-asm/test-out.c
+++ b/tests/end_to_end/weird-asm/test-out.c
@@ -1,7 +1,5 @@
 Warning: missing "jr $ra" in last block (.label).
 
-? test();                                           /* static */
-
 ? test(void) {
     return 0x1233FFFF;
 }


### PR DESCRIPTION
This PR seeks to only print functions which require a forward declaration when printing the global declarations. There's probably a better way to do this and I'm all ears if there's a simple way, but this was what I found.

There are some mypy errors with this, but they can't happen and I don't know how to surpress them.