### PR TITLE
Prune overlapping struct fields in preliminary passes

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -140,6 +140,10 @@ def run(options: Options) -> int:
             except:
                 pass
 
+        # This operation can change struct field paths, so it is only performed
+        # after discarding all of the translated Expressions.
+        typepool.prune_structs()
+
     function_infos: List[Union[FunctionInfo, Exception]] = []
     for function, flow_graph in zip(functions, flow_graphs):
         try:


### PR DESCRIPTION
This PR adds a pass that cleans up inferred fields in structs. This pass can change the paths used in `StructAccess`/`LocalVar` expressions, so it's only run when there are multiple passes. 

This primarily solves two problems:

1. Overlapping fields which are actually subfields of an earlier field. 
    - In `Vec3f unk0; f32 unk4; f32 unk8;`, `unk4` is really `unk0.y` and can be deleted.
    - This is an issue I had wanted to fix before allowing stack vars to be structs.
2. Incorrectly inferring large structs. 
    - It was really common to incorrectly infer `Actor unk_144;` in MM structs. This was brought up in #172. 
    - I think most of these errors are caused by missing arguments in function calls, but they're relatively easy to fix while fixing 1. This PR is more of a band-aid for these types of errors.

The strategy I use is a bit odd though, and I'm looking for feedback here. It depends on the new `--passes` feature and does the processing post-hoc (instead of incrementally). 
Is this a bad idea? My added code is relatively simple, but is it making `mips_to_c` too complicated? Is it weird to rely on performing the translation passes & discarding the output? I'm OK completely punting this PR.

[Diff in MM](https://gist.github.com/zbanks/5362785fe83253b50d86e27f71e84d88) & the [remaining overlapping fields](https://gist.github.com/zbanks/5362785fe83253b50d86e27f71e84d88#file-remaining_overlaps_mm). PM had no diffs (it doesn't have a lot of structs), and OOT only had two small diffs.
`En_Horse` in MM still outputs overlaps with the default `--passes=2`, and these don't go away until `--passes=4`. 