### PR TITLE
Use `&x + scale * index` expressions to determine `x`'s type

### DIFF
--- a/src/translate.py
+++ b/src/translate.py
@@ -3002,6 +3002,8 @@ def array_access_from_add(
             inner_type = Type.reg32(likely_float=False)
         elif typepool.struct_field_inference and isinstance(uw_base.expr, GlobalSymbol):
             # Make up a struct with a tag name based on the symbol & struct size.
+            # Although `scale = 8` could indicate an array of longs/doubles, it seems more
+            # common to be an array of structs.
             struct_name = f"_struct_{uw_base.expr.symbol_name}_0x{scale:X}"
             struct = typepool.get_struct_by_tag_name(
                 struct_name, stack_info.global_info.typemap

--- a/src/translate.py
+++ b/src/translate.py
@@ -1320,7 +1320,7 @@ class GlobalSymbol(Expression):
         Using the size of the symbol's `asm_data_entry` and a potential array element
         size, return the corresponding array dimension and number of "extra" bytes left
         at the end of the symbol's data.
-        If the extra bytes is nonzero, it's likely that `element_size` is incorrect.
+        If the extra bytes are nonzero, then it's likely that `element_size` is incorrect.
         """
         # If we don't have the .data/.rodata entry for this symbol, we can't guess
         # its array dimension. Jump tables are ignored and not treated as arrays.
@@ -2969,7 +2969,7 @@ def array_access_from_add(
 
     if scale < 0:
         scale = -scale
-        index = UnaryOp("-", index, type=index.type)
+        index = UnaryOp("-", as_s32(index), type=Type.s32())
 
     target_type = base.type.get_pointer_target()
     if target_type is None:
@@ -3014,7 +3014,7 @@ def array_access_from_add(
                 )
             elif struct.size != scale:
                 # This should only happen if there was already a struct with this name in the context
-                raise DecompFailure("sizeof(struct {struct_name}) != {scale:#x}")
+                raise DecompFailure(f"sizeof(struct {struct_name}) != {scale:#x}")
             inner_type = Type.struct(struct)
 
         if inner_type is not None:

--- a/src/types.py
+++ b/src/types.py
@@ -567,6 +567,10 @@ class Type:
                 if data.struct.is_union:
                     break
 
+            # This struct has a field that goes outside of the bounds of the struct
+            if position > data.struct.size:
+                return None
+
             add_padding(data.struct.size)
             return output
 


### PR DESCRIPTION
This is a relatively small change, but I think it improves the output a lot (at least on PM/MM). As I mentioned on discord, I know I have a lot of PRs open right now, but this change seems more useful than the others?

The "weird" part, IMO, is where I create a new struct when `x` is a `GlobalSymbol` and `scale` isn't 1, 2, or 4. This has the downside of potentially being wrong/noisy, because the new struct can't then unify with an existing struct. However, I think it has a net positive on the output? And it hopefully it's easy for the decomper to look at, and quickly identify "these look like the same struct" or "this looks like a `Vec3s`".

The output also has a lot more expressions like `(&sp30)[...]`, because stack variables are not yet allowed to be arrays. The element type is usually correct, but it requires the decomper to manually turn the variable into an array.

This change also seems to help reduce the number of temps, which is always a nice bonus.

The diffs highlight the fact that some "symbols" in MM are written in [`gSaveContext + 0x100` form](https://gist.github.com/zbanks/1ae3c38d1f9a7fd2dffe155fd131bbef#file-mm-diff-L5321), which mips2c assumes is the whole symbol name. [I have a commit to parse these into `StructAccess`es](https://github.com/matt-kempster/mips_to_c/commit/3bf77f6272f4a012ba894a846c03c8505399e2f6) but I'm not sure if I should include that in this PR.

The [diffs are pretty big](https://gist.github.com/zbanks/1ae3c38d1f9a7fd2dffe155fd131bbef), esp. on MM. There were changes on 37% of MM files and 5% of PM files. The diffs are large because there are many new global initializers added. MM's `ovl_Player_Actor` again posed some trouble, I think due to the fn arg issue. 