### PR TITLE
PPC: Support `mulli` and `lwzx`, `lhzx`, `lbzx` instructions

### DIFF
--- a/src/translate.py
+++ b/src/translate.py
@@ -3753,6 +3753,7 @@ CASES_DESTINATION_FIRST: InstrMap = {
     "add": lambda a: handle_add(a),
     "addis": lambda a: handle_addis(a),
     "subf": lambda a: BinaryOp.intptr(left=a.reg(1), op="-", right=a.reg(2)),
+    "mulli": lambda a: BinaryOp.s32(a.reg(1), "*", a.imm(2)),
     "lba": lambda a: handle_load(a, type=Type.s8()),
     "lbz": lambda a: handle_load(a, type=Type.u8()),
     "lha": lambda a: handle_load(a, type=Type.s16()),

--- a/src/translate.py
+++ b/src/translate.py
@@ -4691,7 +4691,7 @@ def translate_node_body(node: Node, regs: RegInfo, stack_info: StackInfo) -> Blo
 
             if mnemonic in ["lwzx", "lhzx", "lbzx"]:
                 if args.raw_arg(1) != Register('r0'):
-                    summed = BinaryOp.u32(args.reg(1), "+", args.reg(2))
+                    summed = BinaryOp.intptr(args.reg(1), "+", args.reg(2))
                     set_reg(args.raw_arg(0), summed)
 
             val = CASES_DESTINATION_FIRST[mnemonic.rstrip(".")](args)

--- a/src/translate.py
+++ b/src/translate.py
@@ -3253,6 +3253,21 @@ def handle_rlwinm(
 
     return BinaryOp.int(left=source, op="&", right=Literal(mask))
 
+def handle_loadx(source: Expression, type: Type) -> Expression:
+    size = type.get_size_bytes()
+    assert size is not None
+
+    # rD, rA, rB
+    if source.raw_arg(1) == Register('r0'):
+        # rA is 0, thus load from rB only
+        mem_addr = source.raw_arg(2)
+    else:
+        summed = BinaryOp.u32(source.reg(1), "+", source.reg(2))
+        source.regs[source.raw_arg(0)] = summed
+        mem_addr = source.raw_arg(0)
+
+    expr = deref(AddressMode(rhs=mem_addr, offset=0), source.regs, source.stack_info, size=size)
+    return as_type(expr, type, silent=True)
 
 def strip_macros(arg: Argument) -> Argument:
     """Replace %lo(...) by 0, and assert that there are no %hi(...). We assume that
@@ -3759,6 +3774,9 @@ CASES_DESTINATION_FIRST: InstrMap = {
     "lha": lambda a: handle_load(a, type=Type.s16()),
     "lhz": lambda a: handle_load(a, type=Type.u16()),
     "lwz": lambda a: handle_load(a, type=Type.reg32(likely_float=False)),
+    "lwzx": lambda a: handle_loadx(a, type=Type.reg32(likely_float=False)),
+    "lhzx": lambda a: handle_loadx(a, type=Type.u16()),
+    "lbzx": lambda a: handle_loadx(a, type=Type.u8()),
     "lis": lambda a: load_upper(a),
     "extsb": lambda a: handle_convert(a.reg(1), Type.s8(), Type.intish()),
     "extsh": lambda a: handle_convert(a.reg(1), Type.s16(), Type.intish()),

--- a/src/translate.py
+++ b/src/translate.py
@@ -3768,7 +3768,7 @@ CASES_DESTINATION_FIRST: InstrMap = {
     "add": lambda a: handle_add(a),
     "addis": lambda a: handle_addis(a),
     "subf": lambda a: BinaryOp.intptr(left=a.reg(1), op="-", right=a.reg(2)),
-    "mulli": lambda a: BinaryOp.s32(a.reg(1), "*", a.imm(2)),
+    "mulli": lambda a: BinaryOp.int(a.reg(1), "*", a.imm(2)),
     "lba": lambda a: handle_load(a, type=Type.s8()),
     "lbz": lambda a: handle_load(a, type=Type.u8()),
     "lha": lambda a: handle_load(a, type=Type.s16()),


### PR DESCRIPTION
This adds support for the following instructions:
 - `mulli`: 32-bit multiplication
 - `lwzx`, `lhzx`, `lbzx`: register-indexed load instructions

Example input:
```
.global ARCChangeDir
ARCChangeDir:
/* 80210EEC 00206C6C  94 21 FF F0 */	stwu r1, -0x10(r1)
/* 80210EF0 00206C70  7C 08 02 A6 */	mflr r0
/* 80210EF4 00206C74  90 01 00 14 */	stw r0, 0x14(r1)
/* 80210EF8 00206C78  93 E1 00 0C */	stw r31, 0xc(r1)
/* 80210EFC 00206C7C  7C 7F 1B 78 */	mr r31, r3
/* 80210F00 00206C80  4B FF FB 9D */	bl ARCConvertPathToEntrynum
/* 80210F04 00206C84  2C 03 00 00 */	cmpwi r3, 0
/* 80210F08 00206C88  80 9F 00 04 */	lwz r4, 4(r31)
/* 80210F0C 00206C8C  41 80 00 14 */	blt lbl_80210F20
/* 80210F10 00206C90  1C 03 00 0C */	mulli r0, r3, 0xc
/* 80210F14 00206C94  7C 04 00 2E */	lwzx r0, r4, r0
/* 80210F18 00206C98  54 00 00 0F */	rlwinm. r0, r0, 0, 0, 7
/* 80210F1C 00206C9C  40 82 00 0C */	bne lbl_80210F28
lbl_80210F20:
/* 80210F20 00206CA0  38 60 00 00 */	li r3, 0
/* 80210F24 00206CA4  48 00 00 0C */	b lbl_80210F30
lbl_80210F28:
/* 80210F28 00206CA8  90 7F 00 18 */	stw r3, 0x18(r31)
/* 80210F2C 00206CAC  38 60 00 01 */	li r3, 1
lbl_80210F30:
/* 80210F30 00206CB0  80 01 00 14 */	lwz r0, 0x14(r1)
/* 80210F34 00206CB4  83 E1 00 0C */	lwz r31, 0xc(r1)
/* 80210F38 00206CB8  7C 08 03 A6 */	mtlr r0
/* 80210F3C 00206CBC  38 21 00 10 */	addi r1, r1, 0x10
/* 80210F40 00206CC0  4E 80 00 20 */	blr 
```
Output before patch:
```c
s32 ARCConvertPathToEntrynum();                     /* extern */

? ARCChangeDir(void *arg0, s32 arg1) {
    s32 temp_r3;

    temp_r3 = ARCConvertPathToEntrynum();
    if ((temp_r3 < 0) || (MIPS2C_ERROR(unknown instruction: mulli $r0, $r3, 0xc), (((MIPS2C_ERROR(unknown instruction: lwzx $r0, $r4, $r0) & 0xFF000000) == 0) != 0))) {
        return 0;
    }
    arg0->unk18 = temp_r3;
    return 1;
}
```
Output after patch:
```c
s32 ARCConvertPathToEntrynum();                     /* extern */

? ARCChangeDir(void *arg0, s32 arg1) {
    s32 temp_r3;

    temp_r3 = ARCConvertPathToEntrynum();
    if ((temp_r3 < 0) || ((*((u32) arg0->unk4 + (u32) (temp_r3 * 0xC)) & 0xFF000000) == 0)) {
        return 0;
    }
    arg0->unk18 = temp_r3;
    return 1;
}
```