### PR TITLE
Cherry-pick changes to parse_file.py from ppc2cpp branch + cleanup

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -269,7 +269,7 @@ def parse_flags(flags: List[str]) -> Options:
         action="append",
         default=[],
         type=Path,
-        help="Search paths for loading .incbin directives in the input asm",
+        help="Add search path for loading .incbin directives in the input asm",
     )
 
     group = parser.add_argument_group("Output Options")

--- a/src/main.py
+++ b/src/main.py
@@ -263,6 +263,14 @@ def parse_flags(flags: List[str]) -> Options:
         default=[],
         help="Mark preprocessor constant as undefined",
     )
+    group.add_argument(
+        "-I",
+        "--incbin-dir",
+        dest="incbin_dir",
+        default=None,
+        type=Path,
+        help="Search path for loading .incbin directives",
+    )
 
     group = parser.add_argument_group("Output Options")
     group.add_argument(
@@ -554,6 +562,7 @@ def parse_flags(flags: List[str]) -> Options:
         print_stack_structs=args.print_stack_structs,
         unk_inference=args.unk_inference,
         passes=args.passes,
+        incbin_dir=args.incbin_dir,
     )
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -265,10 +265,11 @@ def parse_flags(flags: List[str]) -> Options:
     )
     group.add_argument(
         "--incbin-dir",
-        dest="incbin_dir",
-        default=None,
+        dest="incbin_dirs",
+        action="append",
+        default=[],
         type=Path,
-        help="Search path for loading .incbin directives in the input asm",
+        help="Search paths for loading .incbin directives in the input asm",
     )
 
     group = parser.add_argument_group("Output Options")
@@ -561,7 +562,7 @@ def parse_flags(flags: List[str]) -> Options:
         print_stack_structs=args.print_stack_structs,
         unk_inference=args.unk_inference,
         passes=args.passes,
-        incbin_dir=args.incbin_dir,
+        incbin_dirs=args.incbin_dirs,
     )
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -264,12 +264,11 @@ def parse_flags(flags: List[str]) -> Options:
         help="Mark preprocessor constant as undefined",
     )
     group.add_argument(
-        "-I",
         "--incbin-dir",
         dest="incbin_dir",
         default=None,
         type=Path,
-        help="Search path for loading .incbin directives",
+        help="Search path for loading .incbin directives in the input asm",
     )
 
     group = parser.add_argument_group("Output Options")

--- a/src/options.py
+++ b/src/options.py
@@ -66,7 +66,7 @@ class Options:
     print_stack_structs: bool
     unk_inference: bool
     passes: int
-    incbin_dir: Optional[Path]
+    incbin_dirs: List[Path]
 
     def formatter(self) -> "Formatter":
         return Formatter(

--- a/src/options.py
+++ b/src/options.py
@@ -66,6 +66,7 @@ class Options:
     print_stack_structs: bool
     unk_inference: bool
     passes: int
+    incbin_dir: Optional[Path]
 
     def formatter(self) -> "Formatter":
         return Formatter(

--- a/src/parse_file.py
+++ b/src/parse_file.py
@@ -204,6 +204,27 @@ def parse_ascii_directive(line: str, z: bool) -> bytes:
     return b"".join(ret)
 
 
+def parse_incbin(line: str, options: Options) -> Optional[bytes]:
+    if options.incbin_dir is None:
+        return None
+    try:
+        args = line.split(maxsplit=1)[1].split(",")
+        filename = args[0].strip("'\"")
+        offset = int(args[1].strip(), 0)
+        size = int(args[2].strip(), 0)
+    except ValueError:
+        raise DecompFailure(f"Could not parse asm_data .incbin directive: {line}")
+    try:
+        with (options.incbin_dir / filename).open("rb") as f:
+            f.seek(offset)
+            data = f.read(size)
+            if len(data) == size:
+                return data
+    except:
+        pass
+    return None
+
+
 def parse_file(f: typing.TextIO, options: Options) -> MIPSFile:
     filename = Path(f.name).name
     mips_file: MIPSFile = MIPSFile(filename)
@@ -223,8 +244,8 @@ def parse_file(f: typing.TextIO, options: Options) -> MIPSFile:
     re_comment_or_string = re.compile(r'#.*|/\*.*?\*/|"(?:\\.|[^\\"])*"')
     re_whitespace_or_string = re.compile(r'\s+|"(?:\\.|[^\\"])*"')
     re_local_glabel = re.compile("L(_U_)?[0-9A-F]{8}")
-    re_local_label = re.compile("loc_|locret_|def_")
-    re_label = re.compile(r"([a-zA-Z0-9_.]+):")
+    re_local_label = re.compile("loc_|locret_|def_|lbl_")
+    re_label = re.compile(r"([a-zA-Z0-9_.$]+):")
 
     T = TypeVar("T")
 
@@ -315,7 +336,7 @@ def parse_file(f: typing.TextIO, options: Options) -> MIPSFile:
             elif ifdef_level == 0:
                 if line.startswith(".section"):
                     curr_section = line.split(" ")[1].split(",")[0]
-                    if curr_section in (".rdata", ".late_rodata"):
+                    if curr_section in (".rdata", ".late_rodata", ".sdata2"):
                         curr_section = ".rodata"
                 elif (
                     line.startswith(".rdata")
@@ -329,27 +350,23 @@ def parse_file(f: typing.TextIO, options: Options) -> MIPSFile:
                     curr_section = ".bss"
                 elif line.startswith(".text"):
                     curr_section = ".text"
-                elif curr_section in (".rodata", ".data", ".bss"):
-                    if line.startswith(".word"):
-                        for w in line[5:].split(","):
+                elif curr_section in (".rodata", ".data", ".bss", ".sdata2"):
+                    if line.startswith(".word") or line.startswith(".4byte"):
+                        directive, args_str = line.split(maxsplit=1)
+                        for w in args_str.split(","):
                             w = w.strip()
                             if not w or w[0].isdigit() or w[0] == "-":
                                 ival = (
-                                    try_parse(lambda: int(w, 0), ".word") & 0xFFFFFFFF
+                                    try_parse(lambda: int(w, 0), directive) & 0xFFFFFFFF
                                 )
                                 mips_file.new_data_bytes(struct.pack(">I", ival))
                             else:
                                 mips_file.new_data_sym(w)
-                    elif line.startswith(".short"):
-                        for w in line[6:].split(","):
+                    elif any(line.startswith(d) for d in (".short", ".half", ".2byte")):
+                        directive, args_str = line.split(maxsplit=1)
+                        for w in args_str.split(","):
                             ival = (
-                                try_parse(lambda: int(w.strip(), 0), ".short") & 0xFFFF
-                            )
-                            mips_file.new_data_bytes(struct.pack(">H", ival))
-                    elif line.startswith(".half"):
-                        for w in line[5:].split(","):
-                            ival = (
-                                try_parse(lambda: int(w.strip(), 0), ".half") & 0xFFFF
+                                try_parse(lambda: int(w.strip(), 0), directive) & 0xFFFF
                             )
                             mips_file.new_data_bytes(struct.pack(">H", ival))
                     elif line.startswith(".byte"):
@@ -369,8 +386,8 @@ def parse_file(f: typing.TextIO, options: Options) -> MIPSFile:
                         mips_file.new_data_bytes(
                             parse_ascii_directive(line, z), is_string=True
                         )
-                    elif line.startswith(".space"):
-                        args = line[6:].split(",")
+                    elif line.startswith(".space") or line.startswith(".skip"):
+                        args = line.split(maxsplit=1)[1].split(",")
                         if len(args) == 2:
                             fill = (
                                 try_parse(lambda: int(args[1].strip(), 0), ".space")
@@ -384,6 +401,11 @@ def parse_file(f: typing.TextIO, options: Options) -> MIPSFile:
                             )
                         size = try_parse(lambda: int(args[0].strip(), 0), ".space")
                         mips_file.new_data_bytes(bytes([fill] * size))
+                    elif line.startswith(".incbin"):
+                        data = parse_incbin(line, options)
+                        if data is not None:
+                            mips_file.new_data_bytes(data)
+
         elif ifdef_level == 0:
             if line.startswith("glabel") or line.startswith("dlabel"):
                 process_label(line.split()[1], glabel=True)

--- a/src/parse_file.py
+++ b/src/parse_file.py
@@ -204,24 +204,25 @@ def parse_ascii_directive(line: str, z: bool) -> bytes:
     return b"".join(ret)
 
 
-def parse_incbin(line: str, options: Options) -> Optional[bytes]:
+def parse_incbin(args: List[str], options: Options) -> Optional[bytes]:
     if options.incbin_dir is None:
         return None
     try:
-        args = line.split(maxsplit=1)[1].split(",")
         filename = args[0].strip("'\"")
         offset = int(args[1].strip(), 0)
         size = int(args[2].strip(), 0)
     except ValueError:
-        raise DecompFailure(f"Could not parse asm_data .incbin directive: {line}")
+        raise DecompFailure(f"Could not parse asm_data .incbin directive: {args}")
+
     try:
         with (options.incbin_dir / filename).open("rb") as f:
             f.seek(offset)
             data = f.read(size)
             if len(data) == size:
                 return data
-    except:
+    except OSError:
         pass
+
     return None
 
 
@@ -338,6 +339,8 @@ def parse_file(f: typing.TextIO, options: Options) -> MIPSFile:
                     curr_section = line.split(" ")[1].split(",")[0]
                     if curr_section in (".rdata", ".late_rodata", ".sdata2"):
                         curr_section = ".rodata"
+                    if curr_section.startswith(".text"):
+                        curr_section = ".text"
                 elif (
                     line.startswith(".rdata")
                     or line.startswith(".rodata")
@@ -350,10 +353,11 @@ def parse_file(f: typing.TextIO, options: Options) -> MIPSFile:
                     curr_section = ".bss"
                 elif line.startswith(".text"):
                     curr_section = ".text"
-                elif curr_section in (".rodata", ".data", ".bss", ".sdata2"):
-                    if line.startswith(".word") or line.startswith(".4byte"):
-                        directive, args_str = line.split(maxsplit=1)
-                        for w in args_str.split(","):
+                elif curr_section in (".rodata", ".data", ".bss"):
+                    directive, _, args_str = line.partition(" ")
+                    args = args_str.split(",")
+                    if directive in (".word", ".4byte"):
+                        for w in args:
                             w = w.strip()
                             if not w or w[0].isdigit() or w[0] == "-":
                                 ival = (
@@ -362,35 +366,35 @@ def parse_file(f: typing.TextIO, options: Options) -> MIPSFile:
                                 mips_file.new_data_bytes(struct.pack(">I", ival))
                             else:
                                 mips_file.new_data_sym(w)
-                    elif any(line.startswith(d) for d in (".short", ".half", ".2byte")):
-                        directive, args_str = line.split(maxsplit=1)
-                        for w in args_str.split(","):
+                    elif directive in (".short", ".half", ".2byte"):
+                        for w in args:
                             ival = (
                                 try_parse(lambda: int(w.strip(), 0), directive) & 0xFFFF
                             )
                             mips_file.new_data_bytes(struct.pack(">H", ival))
-                    elif line.startswith(".byte"):
-                        for w in line[5:].split(","):
-                            ival = try_parse(lambda: int(w.strip(), 0), ".byte") & 0xFF
+                    elif directive == ".byte":
+                        for w in args:
+                            ival = (
+                                try_parse(lambda: int(w.strip(), 0), directive) & 0xFF
+                            )
                             mips_file.new_data_bytes(bytes([ival]))
-                    elif line.startswith(".float"):
-                        for w in line[6:].split(","):
-                            fval = try_parse(lambda: float(w.strip()), ".float")
+                    elif directive == ".float":
+                        for w in args:
+                            fval = try_parse(lambda: float(w.strip()), directive)
                             mips_file.new_data_bytes(struct.pack(">f", fval))
-                    elif line.startswith(".double"):
-                        for w in line[7:].split(","):
-                            fval = try_parse(lambda: float(w.strip()), ".double")
+                    elif directive == ".double":
+                        for w in args:
+                            fval = try_parse(lambda: float(w.strip()), directive)
                             mips_file.new_data_bytes(struct.pack(">d", fval))
-                    elif line.startswith(".asci"):
-                        z = line.startswith(".asciz") or line.startswith(".asciiz")
+                    elif directive in (".asci", ".asciz", ".ascii", ".asciiz"):
+                        z = directive.endswith("z")
                         mips_file.new_data_bytes(
                             parse_ascii_directive(line, z), is_string=True
                         )
-                    elif line.startswith(".space") or line.startswith(".skip"):
-                        args = line.split(maxsplit=1)[1].split(",")
+                    elif directive in (".space", ".skip"):
                         if len(args) == 2:
                             fill = (
-                                try_parse(lambda: int(args[1].strip(), 0), ".space")
+                                try_parse(lambda: int(args[1].strip(), 0), directive)
                                 & 0xFF
                             )
                         elif len(args) == 1:
@@ -399,10 +403,10 @@ def parse_file(f: typing.TextIO, options: Options) -> MIPSFile:
                             raise DecompFailure(
                                 f"Could not parse asm_data .space in {curr_section}: {line}"
                             )
-                        size = try_parse(lambda: int(args[0].strip(), 0), ".space")
+                        size = try_parse(lambda: int(args[0].strip(), 0), directive)
                         mips_file.new_data_bytes(bytes([fill] * size))
                     elif line.startswith(".incbin"):
-                        data = parse_incbin(line, options)
+                        data = parse_incbin(args, options)
                         if data is not None:
                             mips_file.new_data_bytes(data)
 


### PR DESCRIPTION
- Cherry-pick'd `069f226` from `ppc2cpp`
    - Removed the `-I` shortarg for `--incbin-dir`, not sure if we really want to use `-I` for that.
- Refactored directive parsing in `parse_file`to avoid manual string slicing.
- Checked that the new `parse_file.py` can be used on the `ppc2cpp` branch without additional modifications.
- All tests still run, no diffs in OOT, MM, or PM.