### PR TITLE
Move MIPS instruction handling to a new python file

### DIFF
--- a/src/arch_mips.py
+++ b/src/arch_mips.py
@@ -1,0 +1,480 @@
+from .types import Type
+from .parse_instruction import Register
+from .translate import (
+    Arch,
+    BinaryOp,
+    CmpInstrMap,
+    CommentStmt,
+    ErrorExpr,
+    Expression,
+    InstrMap,
+    InstrSet,
+    Literal,
+    PairInstrMap,
+    StmtInstrMap,
+    StoreInstrMap,
+    UnaryOp,
+    as_f32,
+    as_f64,
+    as_int64,
+    as_intish,
+    as_intptr,
+    as_ptr,
+    as_s32,
+    as_s64,
+    as_type,
+    as_u32,
+    as_u64,
+    fn_op,
+    fold_gcc_divmod,
+    fold_mul_chains,
+    handle_add,
+    handle_add_double,
+    handle_add_float,
+    handle_addi,
+    handle_bgez,
+    handle_conditional_move,
+    handle_convert,
+    handle_la,
+    handle_load,
+    handle_lwl,
+    handle_lwr,
+    handle_ori,
+    handle_sltiu,
+    handle_sltu,
+    handle_sra,
+    handle_swl,
+    handle_swr,
+    imm_add_32,
+    load_upper,
+    make_store,
+    void_fn_op,
+)
+
+
+class MipsArch(Arch):
+    stack_pointer_reg = Register("sp")
+    frame_pointer_reg = Register("fp")
+    return_address_reg = Register("ra")
+    temporary_reg = Register("at")
+
+    base_return_regs = [Register(r) for r in ["v0", "f0"]]
+    all_return_regs = [Register(r) for r in ["v0", "v1", "f0", "f1"]]
+    argument_regs = [Register(r) for r in ["a0", "a1", "a2", "a3", "f12", "f14"]]
+    simple_temp_regs = [
+        Register(r)
+        for r in [
+            "v0",
+            "v1",
+            "t0",
+            "t1",
+            "t2",
+            "t3",
+            "t4",
+            "t5",
+            "t6",
+            "t7",
+            "t8",
+            "t9",
+            "f0",
+            "f1",
+            "f2",
+            "f3",
+            "f4",
+            "f5",
+            "f6",
+            "f7",
+            "f8",
+            "f9",
+            "f10",
+            "f11",
+            "f13",
+            "f15",
+            "f16",
+            "f17",
+            "f18",
+            "f19",
+        ]
+    ]
+    temp_regs = (
+        argument_regs
+        + simple_temp_regs
+        + [
+            Register(r)
+            for r in [
+                "at",
+                "hi",
+                "lo",
+                "condition_bit",
+            ]
+        ]
+    )
+    saved_regs = [
+        Register(r)
+        for r in [
+            "s0",
+            "s1",
+            "s2",
+            "s3",
+            "s4",
+            "s5",
+            "s6",
+            "s7",
+            "f20",
+            "f21",
+            "f22",
+            "f23",
+            "f24",
+            "f25",
+            "f26",
+            "f27",
+            "f28",
+            "f29",
+            "f30",
+            "f31",
+            "ra",
+            "31",
+            "fp",
+            "gp",
+        ]
+    ]
+
+    instrs_ignore: InstrSet = {
+        # Ignore FCSR sets; they are leftovers from float->unsigned conversions.
+        # FCSR gets are as well, but it's fine to read MIPS2C_ERROR for those.
+        "ctc1",
+        "nop",
+        "b",
+        "j",
+    }
+    instrs_store: StoreInstrMap = {
+        # Storage instructions
+        "sb": lambda a: make_store(a, type=Type.int_of_size(8)),
+        "sh": lambda a: make_store(a, type=Type.int_of_size(16)),
+        "sw": lambda a: make_store(a, type=Type.reg32(likely_float=False)),
+        "sd": lambda a: make_store(a, type=Type.reg64(likely_float=False)),
+        # Unaligned stores
+        "swl": lambda a: handle_swl(a),
+        "swr": lambda a: handle_swr(a),
+        # Floating point storage/conversion
+        "swc1": lambda a: make_store(a, type=Type.reg32(likely_float=True)),
+        "sdc1": lambda a: make_store(a, type=Type.reg64(likely_float=True)),
+    }
+    instrs_branches: CmpInstrMap = {
+        # Branch instructions/pseudoinstructions
+        "beq": lambda a: BinaryOp.icmp(a.reg(0), "==", a.reg(1)),
+        "bne": lambda a: BinaryOp.icmp(a.reg(0), "!=", a.reg(1)),
+        "beqz": lambda a: BinaryOp.icmp(a.reg(0), "==", Literal(0)),
+        "bnez": lambda a: BinaryOp.icmp(a.reg(0), "!=", Literal(0)),
+        "blez": lambda a: BinaryOp.scmp(a.reg(0), "<=", Literal(0)),
+        "bgtz": lambda a: BinaryOp.scmp(a.reg(0), ">", Literal(0)),
+        "bltz": lambda a: BinaryOp.scmp(a.reg(0), "<", Literal(0)),
+        "bgez": lambda a: handle_bgez(a),
+    }
+    instrs_float_branches: InstrSet = {
+        # Floating-point branch instructions
+        "bc1t",
+        "bc1f",
+    }
+    instrs_jumps: InstrSet = {
+        # Unconditional jump
+        "jr"
+    }
+    instrs_fn_call: InstrSet = {
+        # Function call
+        "jal",
+        "jalr",
+    }
+    instrs_no_dest: StmtInstrMap = {
+        # Conditional traps (happen with Pascal code sometimes, might as well give a nicer
+        # output than MIPS2C_ERROR(...))
+        "teq": lambda a: void_fn_op(
+            "MIPS2C_TRAP_IF", [BinaryOp.icmp(a.reg(0), "==", a.reg(1))]
+        ),
+        "tne": lambda a: void_fn_op(
+            "MIPS2C_TRAP_IF", [BinaryOp.icmp(a.reg(0), "!=", a.reg(1))]
+        ),
+        "tlt": lambda a: void_fn_op(
+            "MIPS2C_TRAP_IF", [BinaryOp.scmp(a.reg(0), "<", a.reg(1))]
+        ),
+        "tltu": lambda a: void_fn_op(
+            "MIPS2C_TRAP_IF", [BinaryOp.ucmp(a.reg(0), "<", a.reg(1))]
+        ),
+        "tge": lambda a: void_fn_op(
+            "MIPS2C_TRAP_IF", [BinaryOp.scmp(a.reg(0), ">=", a.reg(1))]
+        ),
+        "tgeu": lambda a: void_fn_op(
+            "MIPS2C_TRAP_IF", [BinaryOp.ucmp(a.reg(0), ">=", a.reg(1))]
+        ),
+        "teqi": lambda a: void_fn_op(
+            "MIPS2C_TRAP_IF", [BinaryOp.icmp(a.reg(0), "==", a.imm(1))]
+        ),
+        "tnei": lambda a: void_fn_op(
+            "MIPS2C_TRAP_IF", [BinaryOp.icmp(a.reg(0), "!=", a.imm(1))]
+        ),
+        "tlti": lambda a: void_fn_op(
+            "MIPS2C_TRAP_IF", [BinaryOp.scmp(a.reg(0), "<", a.imm(1))]
+        ),
+        "tltiu": lambda a: void_fn_op(
+            "MIPS2C_TRAP_IF", [BinaryOp.ucmp(a.reg(0), "<", a.imm(1))]
+        ),
+        "tgei": lambda a: void_fn_op(
+            "MIPS2C_TRAP_IF", [BinaryOp.scmp(a.reg(0), ">=", a.imm(1))]
+        ),
+        "tgeiu": lambda a: void_fn_op(
+            "MIPS2C_TRAP_IF", [BinaryOp.ucmp(a.reg(0), ">=", a.imm(1))]
+        ),
+        "break": lambda a: void_fn_op(
+            "MIPS2C_BREAK", [a.imm(0)] if a.count() >= 1 else []
+        ),
+        "sync": lambda a: void_fn_op("MIPS2C_SYNC", []),
+        "trapuv.fictive": lambda a: CommentStmt("code compiled with -trapuv"),
+    }
+    instrs_float_comp: CmpInstrMap = {
+        # Float comparisons that don't raise exception on nan
+        "c.eq.s": lambda a: BinaryOp.fcmp(a.reg(0), "==", a.reg(1)),
+        "c.olt.s": lambda a: BinaryOp.fcmp(a.reg(0), "<", a.reg(1)),
+        "c.oge.s": lambda a: BinaryOp.fcmp(a.reg(0), ">=", a.reg(1)),
+        "c.ole.s": lambda a: BinaryOp.fcmp(a.reg(0), "<=", a.reg(1)),
+        "c.ogt.s": lambda a: BinaryOp.fcmp(a.reg(0), ">", a.reg(1)),
+        "c.neq.s": lambda a: BinaryOp.fcmp(a.reg(0), "==", a.reg(1)).negated(),
+        "c.uge.s": lambda a: BinaryOp.fcmp(a.reg(0), "<", a.reg(1)).negated(),
+        "c.ult.s": lambda a: BinaryOp.fcmp(a.reg(0), ">=", a.reg(1)).negated(),
+        "c.ugt.s": lambda a: BinaryOp.fcmp(a.reg(0), "<=", a.reg(1)).negated(),
+        "c.ule.s": lambda a: BinaryOp.fcmp(a.reg(0), ">", a.reg(1)).negated(),
+        # Float comparisons that may raise exception on nan
+        "c.seq.s": lambda a: BinaryOp.fcmp(a.reg(0), "==", a.reg(1)),
+        "c.lt.s": lambda a: BinaryOp.fcmp(a.reg(0), "<", a.reg(1)),
+        "c.ge.s": lambda a: BinaryOp.fcmp(a.reg(0), ">=", a.reg(1)),
+        "c.le.s": lambda a: BinaryOp.fcmp(a.reg(0), "<=", a.reg(1)),
+        "c.gt.s": lambda a: BinaryOp.fcmp(a.reg(0), ">", a.reg(1)),
+        "c.sne.s": lambda a: BinaryOp.fcmp(a.reg(0), "==", a.reg(1)).negated(),
+        "c.nle.s": lambda a: BinaryOp.fcmp(a.reg(0), "<=", a.reg(1)).negated(),
+        "c.nlt.s": lambda a: BinaryOp.fcmp(a.reg(0), "<", a.reg(1)).negated(),
+        "c.nge.s": lambda a: BinaryOp.fcmp(a.reg(0), ">=", a.reg(1)).negated(),
+        "c.ngt.s": lambda a: BinaryOp.fcmp(a.reg(0), ">", a.reg(1)).negated(),
+        # Double comparisons that don't raise exception on nan
+        "c.eq.d": lambda a: BinaryOp.dcmp(a.dreg(0), "==", a.dreg(1)),
+        "c.olt.d": lambda a: BinaryOp.dcmp(a.dreg(0), "<", a.dreg(1)),
+        "c.oge.d": lambda a: BinaryOp.dcmp(a.dreg(0), ">=", a.dreg(1)),
+        "c.ole.d": lambda a: BinaryOp.dcmp(a.dreg(0), "<=", a.dreg(1)),
+        "c.ogt.d": lambda a: BinaryOp.dcmp(a.dreg(0), ">", a.dreg(1)),
+        "c.neq.d": lambda a: BinaryOp.dcmp(a.dreg(0), "==", a.dreg(1)).negated(),
+        "c.uge.d": lambda a: BinaryOp.dcmp(a.dreg(0), "<", a.dreg(1)).negated(),
+        "c.ult.d": lambda a: BinaryOp.dcmp(a.dreg(0), ">=", a.dreg(1)).negated(),
+        "c.ugt.d": lambda a: BinaryOp.dcmp(a.dreg(0), "<=", a.dreg(1)).negated(),
+        "c.ule.d": lambda a: BinaryOp.dcmp(a.dreg(0), ">", a.dreg(1)).negated(),
+        # Double comparisons that may raise exception on nan
+        "c.seq.d": lambda a: BinaryOp.dcmp(a.dreg(0), "==", a.dreg(1)),
+        "c.lt.d": lambda a: BinaryOp.dcmp(a.dreg(0), "<", a.dreg(1)),
+        "c.ge.d": lambda a: BinaryOp.dcmp(a.dreg(0), ">=", a.dreg(1)),
+        "c.le.d": lambda a: BinaryOp.dcmp(a.dreg(0), "<=", a.dreg(1)),
+        "c.gt.d": lambda a: BinaryOp.dcmp(a.dreg(0), ">", a.dreg(1)),
+        "c.sne.d": lambda a: BinaryOp.dcmp(a.dreg(0), "==", a.dreg(1)).negated(),
+        "c.nle.d": lambda a: BinaryOp.dcmp(a.dreg(0), "<=", a.dreg(1)).negated(),
+        "c.nlt.d": lambda a: BinaryOp.dcmp(a.dreg(0), "<", a.dreg(1)).negated(),
+        "c.nge.d": lambda a: BinaryOp.dcmp(a.dreg(0), ">=", a.dreg(1)).negated(),
+        "c.ngt.d": lambda a: BinaryOp.dcmp(a.dreg(0), ">", a.dreg(1)).negated(),
+    }
+    instrs_hi_lo: PairInstrMap = {
+        # Div and mul output two results, to LO/HI registers. (Format: (hi, lo))
+        "div": lambda a: (
+            BinaryOp.s32(a.reg(0), "%", a.reg(1)),
+            BinaryOp.s32(a.reg(0), "/", a.reg(1)),
+        ),
+        "divu": lambda a: (
+            BinaryOp.u32(a.reg(0), "%", a.reg(1)),
+            BinaryOp.u32(a.reg(0), "/", a.reg(1)),
+        ),
+        "ddiv": lambda a: (
+            BinaryOp.s64(a.reg(0), "%", a.reg(1)),
+            BinaryOp.s64(a.reg(0), "/", a.reg(1)),
+        ),
+        "ddivu": lambda a: (
+            BinaryOp.u64(a.reg(0), "%", a.reg(1)),
+            BinaryOp.u64(a.reg(0), "/", a.reg(1)),
+        ),
+        "mult": lambda a: (
+            fold_gcc_divmod(BinaryOp.int(a.reg(0), "MULT_HI", a.reg(1))),
+            BinaryOp.int(a.reg(0), "*", a.reg(1)),
+        ),
+        "multu": lambda a: (
+            fold_gcc_divmod(BinaryOp.int(a.reg(0), "MULTU_HI", a.reg(1))),
+            BinaryOp.int(a.reg(0), "*", a.reg(1)),
+        ),
+        "dmult": lambda a: (
+            BinaryOp.int64(a.reg(0), "DMULT_HI", a.reg(1)),
+            BinaryOp.int64(a.reg(0), "*", a.reg(1)),
+        ),
+        "dmultu": lambda a: (
+            BinaryOp.int64(a.reg(0), "DMULTU_HI", a.reg(1)),
+            BinaryOp.int64(a.reg(0), "*", a.reg(1)),
+        ),
+    }
+    instrs_source_first: InstrMap = {
+        # Floating point moving instruction
+        "mtc1": lambda a: a.reg(0)
+    }
+    instrs_destination_first: InstrMap = {
+        # Flag-setting instructions
+        "slt": lambda a: BinaryOp.scmp(a.reg(1), "<", a.reg(2)),
+        "slti": lambda a: BinaryOp.scmp(a.reg(1), "<", a.imm(2)),
+        "sltu": lambda a: handle_sltu(a),
+        "sltiu": lambda a: handle_sltiu(a),
+        # Integer arithmetic
+        "addi": lambda a: handle_addi(a),
+        "addiu": lambda a: handle_addi(a),
+        "addu": lambda a: handle_add(a),
+        "subu": lambda a: (
+            fold_mul_chains(fold_gcc_divmod(BinaryOp.intptr(a.reg(1), "-", a.reg(2))))
+        ),
+        "negu": lambda a: fold_mul_chains(
+            UnaryOp(op="-", expr=as_s32(a.reg(1)), type=Type.s32())
+        ),
+        "neg": lambda a: fold_mul_chains(
+            UnaryOp(op="-", expr=as_s32(a.reg(1)), type=Type.s32())
+        ),
+        "div.fictive": lambda a: BinaryOp.s32(a.reg(1), "/", a.full_imm(2)),
+        "mod.fictive": lambda a: BinaryOp.s32(a.reg(1), "%", a.full_imm(2)),
+        # 64-bit integer arithmetic, treated mostly the same as 32-bit for now
+        "daddi": lambda a: handle_addi(a),
+        "daddiu": lambda a: handle_addi(a),
+        "daddu": lambda a: handle_add(a),
+        "dsubu": lambda a: fold_mul_chains(BinaryOp.intptr(a.reg(1), "-", a.reg(2))),
+        "dnegu": lambda a: fold_mul_chains(
+            UnaryOp(op="-", expr=as_s64(a.reg(1)), type=Type.s64())
+        ),
+        "dneg": lambda a: fold_mul_chains(
+            UnaryOp(op="-", expr=as_s64(a.reg(1)), type=Type.s64())
+        ),
+        # Hi/lo register uses (used after division/multiplication)
+        "mfhi": lambda a: a.regs[Register("hi")],
+        "mflo": lambda a: a.regs[Register("lo")],
+        # Floating point arithmetic
+        "add.s": lambda a: handle_add_float(a),
+        "sub.s": lambda a: BinaryOp.f32(a.reg(1), "-", a.reg(2)),
+        "neg.s": lambda a: UnaryOp("-", as_f32(a.reg(1)), type=Type.f32()),
+        "abs.s": lambda a: fn_op("fabsf", [as_f32(a.reg(1))], Type.f32()),
+        "sqrt.s": lambda a: fn_op("sqrtf", [as_f32(a.reg(1))], Type.f32()),
+        "div.s": lambda a: BinaryOp.f32(a.reg(1), "/", a.reg(2)),
+        "mul.s": lambda a: BinaryOp.f32(a.reg(1), "*", a.reg(2)),
+        # Double-precision arithmetic
+        "add.d": lambda a: handle_add_double(a),
+        "sub.d": lambda a: BinaryOp.f64(a.dreg(1), "-", a.dreg(2)),
+        "neg.d": lambda a: UnaryOp("-", as_f64(a.dreg(1)), type=Type.f64()),
+        "abs.d": lambda a: fn_op("fabs", [as_f64(a.dreg(1))], Type.f64()),
+        "sqrt.d": lambda a: fn_op("sqrt", [as_f64(a.dreg(1))], Type.f64()),
+        "div.d": lambda a: BinaryOp.f64(a.dreg(1), "/", a.dreg(2)),
+        "mul.d": lambda a: BinaryOp.f64(a.dreg(1), "*", a.dreg(2)),
+        # Floating point conversions
+        "cvt.d.s": lambda a: handle_convert(a.reg(1), Type.f64(), Type.f32()),
+        "cvt.d.w": lambda a: handle_convert(a.reg(1), Type.f64(), Type.intish()),
+        "cvt.s.d": lambda a: handle_convert(a.dreg(1), Type.f32(), Type.f64()),
+        "cvt.s.w": lambda a: handle_convert(a.reg(1), Type.f32(), Type.intish()),
+        "cvt.w.d": lambda a: handle_convert(a.dreg(1), Type.s32(), Type.f64()),
+        "cvt.w.s": lambda a: handle_convert(a.reg(1), Type.s32(), Type.f32()),
+        "cvt.s.u.fictive": lambda a: handle_convert(a.reg(1), Type.f32(), Type.u32()),
+        "cvt.u.d.fictive": lambda a: handle_convert(a.dreg(1), Type.u32(), Type.f64()),
+        "cvt.u.s.fictive": lambda a: handle_convert(a.reg(1), Type.u32(), Type.f32()),
+        "trunc.w.s": lambda a: handle_convert(a.reg(1), Type.s32(), Type.f32()),
+        "trunc.w.d": lambda a: handle_convert(a.dreg(1), Type.s32(), Type.f64()),
+        # Bit arithmetic
+        "ori": lambda a: handle_ori(a),
+        "and": lambda a: BinaryOp.int(left=a.reg(1), op="&", right=a.reg(2)),
+        "or": lambda a: BinaryOp.int(left=a.reg(1), op="|", right=a.reg(2)),
+        "not": lambda a: UnaryOp("~", a.reg(1), type=Type.intish()),
+        "nor": lambda a: UnaryOp(
+            "~", BinaryOp.int(left=a.reg(1), op="|", right=a.reg(2)), type=Type.intish()
+        ),
+        "xor": lambda a: BinaryOp.int(left=a.reg(1), op="^", right=a.reg(2)),
+        "andi": lambda a: BinaryOp.int(left=a.reg(1), op="&", right=a.unsigned_imm(2)),
+        "xori": lambda a: BinaryOp.int(left=a.reg(1), op="^", right=a.unsigned_imm(2)),
+        # Shifts
+        "sll": lambda a: fold_mul_chains(
+            BinaryOp.int(left=a.reg(1), op="<<", right=as_intish(a.imm(2)))
+        ),
+        "sllv": lambda a: fold_mul_chains(
+            BinaryOp.int(left=a.reg(1), op="<<", right=as_intish(a.reg(2)))
+        ),
+        "srl": lambda a: fold_gcc_divmod(
+            BinaryOp(
+                left=as_u32(a.reg(1)),
+                op=">>",
+                right=as_intish(a.imm(2)),
+                type=Type.u32(),
+            )
+        ),
+        "srlv": lambda a: fold_gcc_divmod(
+            BinaryOp(
+                left=as_u32(a.reg(1)),
+                op=">>",
+                right=as_intish(a.reg(2)),
+                type=Type.u32(),
+            )
+        ),
+        "sra": lambda a: handle_sra(a),
+        "srav": lambda a: fold_gcc_divmod(
+            BinaryOp(
+                left=as_s32(a.reg(1)),
+                op=">>",
+                right=as_intish(a.reg(2)),
+                type=Type.s32(),
+            )
+        ),
+        # 64-bit shifts
+        "dsll": lambda a: fold_mul_chains(
+            BinaryOp.int64(left=a.reg(1), op="<<", right=as_intish(a.imm(2)))
+        ),
+        "dsll32": lambda a: fold_mul_chains(
+            BinaryOp.int64(left=a.reg(1), op="<<", right=imm_add_32(a.imm(2)))
+        ),
+        "dsllv": lambda a: BinaryOp.int64(
+            left=a.reg(1), op="<<", right=as_intish(a.reg(2))
+        ),
+        "dsrl": lambda a: BinaryOp(
+            left=as_u64(a.reg(1)), op=">>", right=as_intish(a.imm(2)), type=Type.u64()
+        ),
+        "dsrl32": lambda a: BinaryOp(
+            left=as_u64(a.reg(1)), op=">>", right=imm_add_32(a.imm(2)), type=Type.u64()
+        ),
+        "dsrlv": lambda a: BinaryOp(
+            left=as_u64(a.reg(1)), op=">>", right=as_intish(a.reg(2)), type=Type.u64()
+        ),
+        "dsra": lambda a: BinaryOp(
+            left=as_s64(a.reg(1)), op=">>", right=as_intish(a.imm(2)), type=Type.s64()
+        ),
+        "dsra32": lambda a: BinaryOp(
+            left=as_s64(a.reg(1)), op=">>", right=imm_add_32(a.imm(2)), type=Type.s64()
+        ),
+        "dsrav": lambda a: BinaryOp(
+            left=as_s64(a.reg(1)), op=">>", right=as_intish(a.reg(2)), type=Type.s64()
+        ),
+        # Move pseudoinstruction
+        "move": lambda a: a.reg(1),
+        # Floating point moving instructions
+        "mfc1": lambda a: a.reg(1),
+        "mov.s": lambda a: a.reg(1),
+        "mov.d": lambda a: as_f64(a.dreg(1)),
+        # Conditional moves
+        "movn": lambda a: handle_conditional_move(a, True),
+        "movz": lambda a: handle_conditional_move(a, False),
+        # FCSR get
+        "cfc1": lambda a: ErrorExpr("cfc1"),
+        # Immediates
+        "li": lambda a: a.full_imm(1),
+        "lui": lambda a: load_upper(a),
+        "la": lambda a: handle_la(a),
+        # Loading instructions
+        "lb": lambda a: handle_load(a, type=Type.s8()),
+        "lbu": lambda a: handle_load(a, type=Type.u8()),
+        "lh": lambda a: handle_load(a, type=Type.s16()),
+        "lhu": lambda a: handle_load(a, type=Type.u16()),
+        "lw": lambda a: handle_load(a, type=Type.reg32(likely_float=False)),
+        "ld": lambda a: handle_load(a, type=Type.reg64(likely_float=False)),
+        "lwu": lambda a: handle_load(a, type=Type.u32()),
+        "lwc1": lambda a: handle_load(a, type=Type.reg32(likely_float=True)),
+        "ldc1": lambda a: handle_load(a, type=Type.reg64(likely_float=True)),
+        # Unaligned loads
+        "lwl": lambda a: handle_lwl(a),
+        "lwr": lambda a: handle_lwr(a),
+    }

--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,7 @@ from .translate import (
     translate_to_ast,
 )
 from .types import TypePool
+from .arch_mips import MipsArch
 
 
 def print_current_exception(sanitize: bool) -> None:
@@ -59,6 +60,7 @@ def print_exception_as_comment(
 
 
 def run(options: Options) -> int:
+    arch = MipsArch()
     all_functions: Dict[str, Function] = {}
     asm_data = AsmData()
     try:
@@ -108,7 +110,7 @@ def run(options: Options) -> int:
         unknown_field_prefix="unk_" if fmt.coding_style.unknown_underscore else "unk",
         unk_inference=options.unk_inference,
     )
-    global_info = GlobalInfo(asm_data, function_names, typemap, typepool)
+    global_info = GlobalInfo(asm_data, arch, function_names, typemap, typepool)
 
     flow_graphs: List[Union[FlowGraph, Exception]] = []
     for function in functions:

--- a/src/translate.py
+++ b/src/translate.py
@@ -51,99 +51,44 @@ from .types import (
     TypePool,
 )
 
+InstrSet = Set[str]
+InstrMap = Dict[str, Callable[["InstrArgs"], "Expression"]]
+StmtInstrMap = Dict[str, Callable[["InstrArgs"], "Statement"]]
+CmpInstrMap = Dict[str, Callable[["InstrArgs"], "Condition"]]
+StoreInstrMap = Dict[str, Callable[["InstrArgs"], Optional["StoreStmt"]]]
+MaybeInstrMap = Dict[str, Callable[["InstrArgs"], Optional["Expression"]]]
+PairInstrMap = Dict[str, Callable[["InstrArgs"], Tuple["Expression", "Expression"]]]
+
+
+class Arch(abc.ABC):
+    stack_pointer_reg: Register
+    frame_pointer_reg: Register
+    return_address_reg: Register
+    temporary_reg: Register
+
+    base_return_regs: List[Register]
+    all_return_regs: List[Register]
+    argument_regs: List[Register]
+    simple_temp_regs: List[Register]
+    temp_regs: List[Register]
+    saved_regs: List[Register]
+
+    instrs_ignore: InstrSet
+    instrs_store: StoreInstrMap
+    instrs_branches: CmpInstrMap
+    instrs_float_branches: InstrSet
+    instrs_jumps: InstrSet
+    instrs_fn_call: InstrSet
+    instrs_no_dest: StmtInstrMap
+    instrs_float_comp: CmpInstrMap
+    instrs_hi_lo: PairInstrMap
+    instrs_source_first: InstrMap
+    instrs_destination_first: InstrMap
+
+
 ASSOCIATIVE_OPS: Set[str] = {"+", "&&", "||", "&", "|", "^", "*"}
 COMPOUND_ASSIGNMENT_OPS: Set[str] = {"+", "-", "*", "/", "%", "&", "|", "^", "<<", ">>"}
 PSEUDO_FUNCTION_OPS: Set[str] = {"MULT_HI", "MULTU_HI", "DMULT_HI", "DMULTU_HI"}
-
-ARGUMENT_REGS: List[Register] = list(
-    map(Register, ["a0", "a1", "a2", "a3", "f12", "f14"])
-)
-
-SIMPLE_TEMP_REGS: List[Register] = list(
-    map(
-        Register,
-        [
-            "v0",
-            "v1",
-            "t0",
-            "t1",
-            "t2",
-            "t3",
-            "t4",
-            "t5",
-            "t6",
-            "t7",
-            "t8",
-            "t9",
-            "f0",
-            "f1",
-            "f2",
-            "f3",
-            "f4",
-            "f5",
-            "f6",
-            "f7",
-            "f8",
-            "f9",
-            "f10",
-            "f11",
-            "f13",
-            "f15",
-            "f16",
-            "f17",
-            "f18",
-            "f19",
-        ],
-    )
-)
-
-TEMP_REGS: List[Register] = (
-    ARGUMENT_REGS
-    + SIMPLE_TEMP_REGS
-    + list(
-        map(
-            Register,
-            [
-                "at",
-                "hi",
-                "lo",
-                "condition_bit",
-            ],
-        )
-    )
-)
-
-SAVED_REGS: List[Register] = list(
-    map(
-        Register,
-        [
-            "s0",
-            "s1",
-            "s2",
-            "s3",
-            "s4",
-            "s5",
-            "s6",
-            "s7",
-            "f20",
-            "f21",
-            "f22",
-            "f23",
-            "f24",
-            "f25",
-            "f26",
-            "f27",
-            "f28",
-            "f29",
-            "f30",
-            "f31",
-            "ra",
-            "31",
-            "fp",
-            "gp",
-        ],
-    )
-)
 
 
 @dataclass
@@ -443,9 +388,9 @@ class StackInfo:
         self.used_reg_vars.add(var.reg)
 
     def is_stack_reg(self, reg: Register) -> bool:
-        if reg.register_name == "sp":
+        if reg == self.global_info.arch.stack_pointer_reg:
             return True
-        if reg.register_name == "fp":
+        if reg == self.global_info.arch.frame_pointer_reg:
             return self.uses_framepointer
         return False
 
@@ -479,6 +424,7 @@ def get_stack_info(
     flow_graph: FlowGraph,
 ) -> StackInfo:
     info = StackInfo(function, global_info)
+    arch = global_info.arch
 
     # The goal here is to pick out special instructions that provide information
     # about this function's stack setup.
@@ -495,14 +441,14 @@ def get_stack_info(
     for inst in flow_graph.entry_node().block.instructions:
         if inst.mnemonic == "jal":
             break
-        elif inst.mnemonic == "addiu" and inst.args[0] == Register("sp"):
+        elif inst.mnemonic == "addiu" and inst.args[0] == arch.stack_pointer_reg:
             # Moving the stack pointer.
             assert isinstance(inst.args[2], AsmLiteral)
             info.allocated_stack_size = abs(inst.args[2].signed_value())
         elif (
             inst.mnemonic == "move"
-            and inst.args[0] == Register("fp")
-            and inst.args[1] == Register("sp")
+            and inst.args[0] == arch.frame_pointer_reg
+            and inst.args[1] == arch.stack_pointer_reg
         ):
             # "move fp, sp" very likely means the code is compiled with frame
             # pointers enabled; thus fp should be treated the same as sp.
@@ -510,13 +456,13 @@ def get_stack_info(
         elif (
             inst.mnemonic in ["sw", "swc1", "sdc1"]
             and isinstance(inst.args[0], Register)
-            and inst.args[0] in SAVED_REGS
+            and inst.args[0] in arch.saved_regs
             and isinstance(inst.args[1], AsmAddressMode)
-            and inst.args[1].rhs == Register("sp")
+            and inst.args[1].rhs == arch.stack_pointer_reg
             and inst.args[0] not in info.callee_save_reg_locations
         ):
             # Initial saving of callee-save register onto the stack.
-            if inst.args[0] == Register("ra"):
+            if inst.args[0] == arch.return_address_reg:
                 # Saving the return address on the stack.
                 info.is_leaf = False
             stack_offset = inst.args[1].lhs_as_literal()
@@ -534,7 +480,7 @@ def get_stack_info(
                 if (
                     inst.mnemonic in ["lw", "lwc1", "ldc1"]
                     and isinstance(inst.args[1], AsmAddressMode)
-                    and inst.args[1].rhs == Register("sp")
+                    and inst.args[1].rhs == arch.stack_pointer_reg
                     and inst.args[1].lhs_as_literal() >= 16
                 ):
                     info.subroutine_arg_top = min(
@@ -542,8 +488,8 @@ def get_stack_info(
                     )
                 elif (
                     inst.mnemonic == "addiu"
-                    and inst.args[0] != Register("sp")
-                    and inst.args[1] == Register("sp")
+                    and inst.args[0] != arch.stack_pointer_reg
+                    and inst.args[1] == arch.stack_pointer_reg
                     and isinstance(inst.args[2], AsmLiteral)
                     and inst.args[2].value < info.allocated_stack_size
                 ):
@@ -3260,344 +3206,6 @@ def function_abi(fn_sig: FunctionSignature, *, for_call: bool) -> Abi:
     )
 
 
-InstrSet = Set[str]
-InstrMap = Dict[str, Callable[[InstrArgs], Expression]]
-StmtInstrMap = Dict[str, Callable[[InstrArgs], Statement]]
-CmpInstrMap = Dict[str, Callable[[InstrArgs], Condition]]
-StoreInstrMap = Dict[str, Callable[[InstrArgs], Optional[StoreStmt]]]
-MaybeInstrMap = Dict[str, Callable[[InstrArgs], Optional[Expression]]]
-PairInstrMap = Dict[str, Callable[[InstrArgs], Tuple[Expression, Expression]]]
-
-CASES_IGNORE: InstrSet = {
-    # Ignore FCSR sets; they are leftovers from float->unsigned conversions.
-    # FCSR gets are as well, but it's fine to read MIPS2C_ERROR for those.
-    "ctc1",
-    "nop",
-    "b",
-    "j",
-}
-CASES_STORE: StoreInstrMap = {
-    # Storage instructions
-    "sb": lambda a: make_store(a, type=Type.int_of_size(8)),
-    "sh": lambda a: make_store(a, type=Type.int_of_size(16)),
-    "sw": lambda a: make_store(a, type=Type.reg32(likely_float=False)),
-    "sd": lambda a: make_store(a, type=Type.reg64(likely_float=False)),
-    # Unaligned stores
-    "swl": lambda a: handle_swl(a),
-    "swr": lambda a: handle_swr(a),
-    # Floating point storage/conversion
-    "swc1": lambda a: make_store(a, type=Type.reg32(likely_float=True)),
-    "sdc1": lambda a: make_store(a, type=Type.reg64(likely_float=True)),
-}
-CASES_BRANCHES: CmpInstrMap = {
-    # Branch instructions/pseudoinstructions
-    "beq": lambda a: BinaryOp.icmp(a.reg(0), "==", a.reg(1)),
-    "bne": lambda a: BinaryOp.icmp(a.reg(0), "!=", a.reg(1)),
-    "beqz": lambda a: BinaryOp.icmp(a.reg(0), "==", Literal(0)),
-    "bnez": lambda a: BinaryOp.icmp(a.reg(0), "!=", Literal(0)),
-    "blez": lambda a: BinaryOp.scmp(a.reg(0), "<=", Literal(0)),
-    "bgtz": lambda a: BinaryOp.scmp(a.reg(0), ">", Literal(0)),
-    "bltz": lambda a: BinaryOp.scmp(a.reg(0), "<", Literal(0)),
-    "bgez": lambda a: handle_bgez(a),
-}
-CASES_FLOAT_BRANCHES: InstrSet = {
-    # Floating-point branch instructions
-    "bc1t",
-    "bc1f",
-}
-CASES_JUMPS: InstrSet = {
-    # Unconditional jump
-    "jr"
-}
-CASES_FN_CALL: InstrSet = {
-    # Function call
-    "jal",
-    "jalr",
-}
-CASES_NO_DEST: StmtInstrMap = {
-    # Conditional traps (happen with Pascal code sometimes, might as well give a nicer
-    # output than MIPS2C_ERROR(...))
-    "teq": lambda a: void_fn_op(
-        "MIPS2C_TRAP_IF", [BinaryOp.icmp(a.reg(0), "==", a.reg(1))]
-    ),
-    "tne": lambda a: void_fn_op(
-        "MIPS2C_TRAP_IF", [BinaryOp.icmp(a.reg(0), "!=", a.reg(1))]
-    ),
-    "tlt": lambda a: void_fn_op(
-        "MIPS2C_TRAP_IF", [BinaryOp.scmp(a.reg(0), "<", a.reg(1))]
-    ),
-    "tltu": lambda a: void_fn_op(
-        "MIPS2C_TRAP_IF", [BinaryOp.ucmp(a.reg(0), "<", a.reg(1))]
-    ),
-    "tge": lambda a: void_fn_op(
-        "MIPS2C_TRAP_IF", [BinaryOp.scmp(a.reg(0), ">=", a.reg(1))]
-    ),
-    "tgeu": lambda a: void_fn_op(
-        "MIPS2C_TRAP_IF", [BinaryOp.ucmp(a.reg(0), ">=", a.reg(1))]
-    ),
-    "teqi": lambda a: void_fn_op(
-        "MIPS2C_TRAP_IF", [BinaryOp.icmp(a.reg(0), "==", a.imm(1))]
-    ),
-    "tnei": lambda a: void_fn_op(
-        "MIPS2C_TRAP_IF", [BinaryOp.icmp(a.reg(0), "!=", a.imm(1))]
-    ),
-    "tlti": lambda a: void_fn_op(
-        "MIPS2C_TRAP_IF", [BinaryOp.scmp(a.reg(0), "<", a.imm(1))]
-    ),
-    "tltiu": lambda a: void_fn_op(
-        "MIPS2C_TRAP_IF", [BinaryOp.ucmp(a.reg(0), "<", a.imm(1))]
-    ),
-    "tgei": lambda a: void_fn_op(
-        "MIPS2C_TRAP_IF", [BinaryOp.scmp(a.reg(0), ">=", a.imm(1))]
-    ),
-    "tgeiu": lambda a: void_fn_op(
-        "MIPS2C_TRAP_IF", [BinaryOp.ucmp(a.reg(0), ">=", a.imm(1))]
-    ),
-    "break": lambda a: void_fn_op("MIPS2C_BREAK", [a.imm(0)] if a.count() >= 1 else []),
-    "sync": lambda a: void_fn_op("MIPS2C_SYNC", []),
-    "trapuv.fictive": lambda a: CommentStmt("code compiled with -trapuv"),
-}
-CASES_FLOAT_COMP: CmpInstrMap = {
-    # Float comparisons that don't raise exception on nan
-    "c.eq.s": lambda a: BinaryOp.fcmp(a.reg(0), "==", a.reg(1)),
-    "c.olt.s": lambda a: BinaryOp.fcmp(a.reg(0), "<", a.reg(1)),
-    "c.oge.s": lambda a: BinaryOp.fcmp(a.reg(0), ">=", a.reg(1)),
-    "c.ole.s": lambda a: BinaryOp.fcmp(a.reg(0), "<=", a.reg(1)),
-    "c.ogt.s": lambda a: BinaryOp.fcmp(a.reg(0), ">", a.reg(1)),
-    "c.neq.s": lambda a: BinaryOp.fcmp(a.reg(0), "==", a.reg(1)).negated(),
-    "c.uge.s": lambda a: BinaryOp.fcmp(a.reg(0), "<", a.reg(1)).negated(),
-    "c.ult.s": lambda a: BinaryOp.fcmp(a.reg(0), ">=", a.reg(1)).negated(),
-    "c.ugt.s": lambda a: BinaryOp.fcmp(a.reg(0), "<=", a.reg(1)).negated(),
-    "c.ule.s": lambda a: BinaryOp.fcmp(a.reg(0), ">", a.reg(1)).negated(),
-    # Float comparisons that may raise exception on nan
-    "c.seq.s": lambda a: BinaryOp.fcmp(a.reg(0), "==", a.reg(1)),
-    "c.lt.s": lambda a: BinaryOp.fcmp(a.reg(0), "<", a.reg(1)),
-    "c.ge.s": lambda a: BinaryOp.fcmp(a.reg(0), ">=", a.reg(1)),
-    "c.le.s": lambda a: BinaryOp.fcmp(a.reg(0), "<=", a.reg(1)),
-    "c.gt.s": lambda a: BinaryOp.fcmp(a.reg(0), ">", a.reg(1)),
-    "c.sne.s": lambda a: BinaryOp.fcmp(a.reg(0), "==", a.reg(1)).negated(),
-    "c.nle.s": lambda a: BinaryOp.fcmp(a.reg(0), "<=", a.reg(1)).negated(),
-    "c.nlt.s": lambda a: BinaryOp.fcmp(a.reg(0), "<", a.reg(1)).negated(),
-    "c.nge.s": lambda a: BinaryOp.fcmp(a.reg(0), ">=", a.reg(1)).negated(),
-    "c.ngt.s": lambda a: BinaryOp.fcmp(a.reg(0), ">", a.reg(1)).negated(),
-    # Double comparisons that don't raise exception on nan
-    "c.eq.d": lambda a: BinaryOp.dcmp(a.dreg(0), "==", a.dreg(1)),
-    "c.olt.d": lambda a: BinaryOp.dcmp(a.dreg(0), "<", a.dreg(1)),
-    "c.oge.d": lambda a: BinaryOp.dcmp(a.dreg(0), ">=", a.dreg(1)),
-    "c.ole.d": lambda a: BinaryOp.dcmp(a.dreg(0), "<=", a.dreg(1)),
-    "c.ogt.d": lambda a: BinaryOp.dcmp(a.dreg(0), ">", a.dreg(1)),
-    "c.neq.d": lambda a: BinaryOp.dcmp(a.dreg(0), "==", a.dreg(1)).negated(),
-    "c.uge.d": lambda a: BinaryOp.dcmp(a.dreg(0), "<", a.dreg(1)).negated(),
-    "c.ult.d": lambda a: BinaryOp.dcmp(a.dreg(0), ">=", a.dreg(1)).negated(),
-    "c.ugt.d": lambda a: BinaryOp.dcmp(a.dreg(0), "<=", a.dreg(1)).negated(),
-    "c.ule.d": lambda a: BinaryOp.dcmp(a.dreg(0), ">", a.dreg(1)).negated(),
-    # Double comparisons that may raise exception on nan
-    "c.seq.d": lambda a: BinaryOp.dcmp(a.dreg(0), "==", a.dreg(1)),
-    "c.lt.d": lambda a: BinaryOp.dcmp(a.dreg(0), "<", a.dreg(1)),
-    "c.ge.d": lambda a: BinaryOp.dcmp(a.dreg(0), ">=", a.dreg(1)),
-    "c.le.d": lambda a: BinaryOp.dcmp(a.dreg(0), "<=", a.dreg(1)),
-    "c.gt.d": lambda a: BinaryOp.dcmp(a.dreg(0), ">", a.dreg(1)),
-    "c.sne.d": lambda a: BinaryOp.dcmp(a.dreg(0), "==", a.dreg(1)).negated(),
-    "c.nle.d": lambda a: BinaryOp.dcmp(a.dreg(0), "<=", a.dreg(1)).negated(),
-    "c.nlt.d": lambda a: BinaryOp.dcmp(a.dreg(0), "<", a.dreg(1)).negated(),
-    "c.nge.d": lambda a: BinaryOp.dcmp(a.dreg(0), ">=", a.dreg(1)).negated(),
-    "c.ngt.d": lambda a: BinaryOp.dcmp(a.dreg(0), ">", a.dreg(1)).negated(),
-}
-CASES_HI_LO: PairInstrMap = {
-    # Div and mul output two results, to LO/HI registers. (Format: (hi, lo))
-    "div": lambda a: (
-        BinaryOp.s32(a.reg(0), "%", a.reg(1)),
-        BinaryOp.s32(a.reg(0), "/", a.reg(1)),
-    ),
-    "divu": lambda a: (
-        BinaryOp.u32(a.reg(0), "%", a.reg(1)),
-        BinaryOp.u32(a.reg(0), "/", a.reg(1)),
-    ),
-    "ddiv": lambda a: (
-        BinaryOp.s64(a.reg(0), "%", a.reg(1)),
-        BinaryOp.s64(a.reg(0), "/", a.reg(1)),
-    ),
-    "ddivu": lambda a: (
-        BinaryOp.u64(a.reg(0), "%", a.reg(1)),
-        BinaryOp.u64(a.reg(0), "/", a.reg(1)),
-    ),
-    "mult": lambda a: (
-        fold_gcc_divmod(BinaryOp.int(a.reg(0), "MULT_HI", a.reg(1))),
-        BinaryOp.int(a.reg(0), "*", a.reg(1)),
-    ),
-    "multu": lambda a: (
-        fold_gcc_divmod(BinaryOp.int(a.reg(0), "MULTU_HI", a.reg(1))),
-        BinaryOp.int(a.reg(0), "*", a.reg(1)),
-    ),
-    "dmult": lambda a: (
-        BinaryOp.int64(a.reg(0), "DMULT_HI", a.reg(1)),
-        BinaryOp.int64(a.reg(0), "*", a.reg(1)),
-    ),
-    "dmultu": lambda a: (
-        BinaryOp.int64(a.reg(0), "DMULTU_HI", a.reg(1)),
-        BinaryOp.int64(a.reg(0), "*", a.reg(1)),
-    ),
-}
-CASES_SOURCE_FIRST: InstrMap = {
-    # Floating point moving instruction
-    "mtc1": lambda a: a.reg(0)
-}
-CASES_DESTINATION_FIRST: InstrMap = {
-    # Flag-setting instructions
-    "slt": lambda a: BinaryOp.scmp(a.reg(1), "<", a.reg(2)),
-    "slti": lambda a: BinaryOp.scmp(a.reg(1), "<", a.imm(2)),
-    "sltu": lambda a: handle_sltu(a),
-    "sltiu": lambda a: handle_sltiu(a),
-    # Integer arithmetic
-    "addi": lambda a: handle_addi(a),
-    "addiu": lambda a: handle_addi(a),
-    "addu": lambda a: handle_add(a),
-    "subu": lambda a: (
-        fold_mul_chains(fold_gcc_divmod(BinaryOp.intptr(a.reg(1), "-", a.reg(2))))
-    ),
-    "negu": lambda a: fold_mul_chains(
-        UnaryOp(op="-", expr=as_s32(a.reg(1)), type=Type.s32())
-    ),
-    "neg": lambda a: fold_mul_chains(
-        UnaryOp(op="-", expr=as_s32(a.reg(1)), type=Type.s32())
-    ),
-    "div.fictive": lambda a: BinaryOp.s32(a.reg(1), "/", a.full_imm(2)),
-    "mod.fictive": lambda a: BinaryOp.s32(a.reg(1), "%", a.full_imm(2)),
-    # 64-bit integer arithmetic, treated mostly the same as 32-bit for now
-    "daddi": lambda a: handle_addi(a),
-    "daddiu": lambda a: handle_addi(a),
-    "daddu": lambda a: handle_add(a),
-    "dsubu": lambda a: fold_mul_chains(BinaryOp.intptr(a.reg(1), "-", a.reg(2))),
-    "dnegu": lambda a: fold_mul_chains(
-        UnaryOp(op="-", expr=as_s64(a.reg(1)), type=Type.s64())
-    ),
-    "dneg": lambda a: fold_mul_chains(
-        UnaryOp(op="-", expr=as_s64(a.reg(1)), type=Type.s64())
-    ),
-    # Hi/lo register uses (used after division/multiplication)
-    "mfhi": lambda a: a.regs[Register("hi")],
-    "mflo": lambda a: a.regs[Register("lo")],
-    # Floating point arithmetic
-    "add.s": lambda a: handle_add_float(a),
-    "sub.s": lambda a: BinaryOp.f32(a.reg(1), "-", a.reg(2)),
-    "neg.s": lambda a: UnaryOp("-", as_f32(a.reg(1)), type=Type.f32()),
-    "abs.s": lambda a: fn_op("fabsf", [as_f32(a.reg(1))], Type.f32()),
-    "sqrt.s": lambda a: fn_op("sqrtf", [as_f32(a.reg(1))], Type.f32()),
-    "div.s": lambda a: BinaryOp.f32(a.reg(1), "/", a.reg(2)),
-    "mul.s": lambda a: BinaryOp.f32(a.reg(1), "*", a.reg(2)),
-    # Double-precision arithmetic
-    "add.d": lambda a: handle_add_double(a),
-    "sub.d": lambda a: BinaryOp.f64(a.dreg(1), "-", a.dreg(2)),
-    "neg.d": lambda a: UnaryOp("-", as_f64(a.dreg(1)), type=Type.f64()),
-    "abs.d": lambda a: fn_op("fabs", [as_f64(a.dreg(1))], Type.f64()),
-    "sqrt.d": lambda a: fn_op("sqrt", [as_f64(a.dreg(1))], Type.f64()),
-    "div.d": lambda a: BinaryOp.f64(a.dreg(1), "/", a.dreg(2)),
-    "mul.d": lambda a: BinaryOp.f64(a.dreg(1), "*", a.dreg(2)),
-    # Floating point conversions
-    "cvt.d.s": lambda a: handle_convert(a.reg(1), Type.f64(), Type.f32()),
-    "cvt.d.w": lambda a: handle_convert(a.reg(1), Type.f64(), Type.intish()),
-    "cvt.s.d": lambda a: handle_convert(a.dreg(1), Type.f32(), Type.f64()),
-    "cvt.s.w": lambda a: handle_convert(a.reg(1), Type.f32(), Type.intish()),
-    "cvt.w.d": lambda a: handle_convert(a.dreg(1), Type.s32(), Type.f64()),
-    "cvt.w.s": lambda a: handle_convert(a.reg(1), Type.s32(), Type.f32()),
-    "cvt.s.u.fictive": lambda a: handle_convert(a.reg(1), Type.f32(), Type.u32()),
-    "cvt.u.d.fictive": lambda a: handle_convert(a.dreg(1), Type.u32(), Type.f64()),
-    "cvt.u.s.fictive": lambda a: handle_convert(a.reg(1), Type.u32(), Type.f32()),
-    "trunc.w.s": lambda a: handle_convert(a.reg(1), Type.s32(), Type.f32()),
-    "trunc.w.d": lambda a: handle_convert(a.dreg(1), Type.s32(), Type.f64()),
-    # Bit arithmetic
-    "ori": lambda a: handle_ori(a),
-    "and": lambda a: BinaryOp.int(left=a.reg(1), op="&", right=a.reg(2)),
-    "or": lambda a: BinaryOp.int(left=a.reg(1), op="|", right=a.reg(2)),
-    "not": lambda a: UnaryOp("~", a.reg(1), type=Type.intish()),
-    "nor": lambda a: UnaryOp(
-        "~", BinaryOp.int(left=a.reg(1), op="|", right=a.reg(2)), type=Type.intish()
-    ),
-    "xor": lambda a: BinaryOp.int(left=a.reg(1), op="^", right=a.reg(2)),
-    "andi": lambda a: BinaryOp.int(left=a.reg(1), op="&", right=a.unsigned_imm(2)),
-    "xori": lambda a: BinaryOp.int(left=a.reg(1), op="^", right=a.unsigned_imm(2)),
-    # Shifts
-    "sll": lambda a: fold_mul_chains(
-        BinaryOp.int(left=a.reg(1), op="<<", right=as_intish(a.imm(2)))
-    ),
-    "sllv": lambda a: fold_mul_chains(
-        BinaryOp.int(left=a.reg(1), op="<<", right=as_intish(a.reg(2)))
-    ),
-    "srl": lambda a: fold_gcc_divmod(
-        BinaryOp(
-            left=as_u32(a.reg(1)), op=">>", right=as_intish(a.imm(2)), type=Type.u32()
-        )
-    ),
-    "srlv": lambda a: fold_gcc_divmod(
-        BinaryOp(
-            left=as_u32(a.reg(1)), op=">>", right=as_intish(a.reg(2)), type=Type.u32()
-        )
-    ),
-    "sra": lambda a: handle_sra(a),
-    "srav": lambda a: fold_gcc_divmod(
-        BinaryOp(
-            left=as_s32(a.reg(1)), op=">>", right=as_intish(a.reg(2)), type=Type.s32()
-        )
-    ),
-    # 64-bit shifts
-    "dsll": lambda a: fold_mul_chains(
-        BinaryOp.int64(left=a.reg(1), op="<<", right=as_intish(a.imm(2)))
-    ),
-    "dsll32": lambda a: fold_mul_chains(
-        BinaryOp.int64(left=a.reg(1), op="<<", right=imm_add_32(a.imm(2)))
-    ),
-    "dsllv": lambda a: BinaryOp.int64(
-        left=a.reg(1), op="<<", right=as_intish(a.reg(2))
-    ),
-    "dsrl": lambda a: BinaryOp(
-        left=as_u64(a.reg(1)), op=">>", right=as_intish(a.imm(2)), type=Type.u64()
-    ),
-    "dsrl32": lambda a: BinaryOp(
-        left=as_u64(a.reg(1)), op=">>", right=imm_add_32(a.imm(2)), type=Type.u64()
-    ),
-    "dsrlv": lambda a: BinaryOp(
-        left=as_u64(a.reg(1)), op=">>", right=as_intish(a.reg(2)), type=Type.u64()
-    ),
-    "dsra": lambda a: BinaryOp(
-        left=as_s64(a.reg(1)), op=">>", right=as_intish(a.imm(2)), type=Type.s64()
-    ),
-    "dsra32": lambda a: BinaryOp(
-        left=as_s64(a.reg(1)), op=">>", right=imm_add_32(a.imm(2)), type=Type.s64()
-    ),
-    "dsrav": lambda a: BinaryOp(
-        left=as_s64(a.reg(1)), op=">>", right=as_intish(a.reg(2)), type=Type.s64()
-    ),
-    # Move pseudoinstruction
-    "move": lambda a: a.reg(1),
-    # Floating point moving instructions
-    "mfc1": lambda a: a.reg(1),
-    "mov.s": lambda a: a.reg(1),
-    "mov.d": lambda a: as_f64(a.dreg(1)),
-    # Conditional moves
-    "movn": lambda a: handle_conditional_move(a, True),
-    "movz": lambda a: handle_conditional_move(a, False),
-    # FCSR get
-    "cfc1": lambda a: ErrorExpr("cfc1"),
-    # Immediates
-    "li": lambda a: a.full_imm(1),
-    "lui": lambda a: load_upper(a),
-    "la": lambda a: handle_la(a),
-    # Loading instructions
-    "lb": lambda a: handle_load(a, type=Type.s8()),
-    "lbu": lambda a: handle_load(a, type=Type.u8()),
-    "lh": lambda a: handle_load(a, type=Type.s16()),
-    "lhu": lambda a: handle_load(a, type=Type.u16()),
-    "lw": lambda a: handle_load(a, type=Type.reg32(likely_float=False)),
-    "ld": lambda a: handle_load(a, type=Type.reg64(likely_float=False)),
-    "lwu": lambda a: handle_load(a, type=Type.u32()),
-    "lwc1": lambda a: handle_load(a, type=Type.reg32(likely_float=True)),
-    "ldc1": lambda a: handle_load(a, type=Type.reg64(likely_float=True)),
-    # Unaligned loads
-    "lwl": lambda a: handle_lwl(a),
-    "lwr": lambda a: handle_lwr(a),
-}
-
-
 def output_regs_for_instr(
     instr: Instruction, global_info: "GlobalInfo"
 ) -> List[Register]:
@@ -3608,14 +3216,15 @@ def output_regs_for_instr(
             return []
         return [reg]
 
+    arch = global_info.arch
     mnemonic = instr.mnemonic
     if (
-        mnemonic in CASES_JUMPS
-        or mnemonic in CASES_STORE
-        or mnemonic in CASES_BRANCHES
-        or mnemonic in CASES_FLOAT_BRANCHES
-        or mnemonic in CASES_IGNORE
-        or mnemonic in CASES_NO_DEST
+        mnemonic in arch.instrs_jumps
+        or mnemonic in arch.instrs_store
+        or mnemonic in arch.instrs_branches
+        or mnemonic in arch.instrs_float_branches
+        or mnemonic in arch.instrs_ignore
+        or mnemonic in arch.instrs_no_dest
     ):
         return []
     if mnemonic == "jal":
@@ -3623,15 +3232,15 @@ def output_regs_for_instr(
         if isinstance(fn_target, AsmGlobalSymbol):
             if global_info.is_function_known_void(fn_target.symbol_name):
                 return []
-    if mnemonic in CASES_FN_CALL:
-        return list(map(Register, ["f0", "f1", "v0", "v1"]))
-    if mnemonic in CASES_SOURCE_FIRST:
+    if mnemonic in arch.instrs_fn_call:
+        return arch.all_return_regs
+    if mnemonic in arch.instrs_source_first:
         return reg_at(1)
-    if mnemonic in CASES_DESTINATION_FIRST:
+    if mnemonic in arch.instrs_destination_first:
         return reg_at(0)
-    if mnemonic in CASES_FLOAT_COMP:
+    if mnemonic in arch.instrs_float_comp:
         return [Register("condition_bit")]
-    if mnemonic in CASES_HI_LO:
+    if mnemonic in arch.instrs_hi_lo:
         return [Register("hi"), Register("lo")]
     if instr.args and isinstance(instr.args[0], Register):
         return reg_at(0)
@@ -3654,8 +3263,8 @@ def regs_clobbered_until_dominator(
         for instr in n.block.instructions:
             with current_instr(instr):
                 clobbered.update(output_regs_for_instr(instr, global_info))
-                if instr.mnemonic in CASES_FN_CALL:
-                    clobbered.update(TEMP_REGS)
+                if instr.mnemonic in global_info.arch.instrs_fn_call:
+                    clobbered.update(global_info.arch.temp_regs)
         stack.extend(n.parents)
     return clobbered
 
@@ -3677,7 +3286,10 @@ def reg_always_set(
         clobbered: Optional[bool] = None
         for instr in n.block.instructions:
             with current_instr(instr):
-                if instr.mnemonic in CASES_FN_CALL and reg in TEMP_REGS:
+                if (
+                    instr.mnemonic in global_info.arch.instrs_fn_call
+                    and reg in global_info.arch.temp_regs
+                ):
                     clobbered = True
                 if reg in output_regs_for_instr(instr, global_info):
                     clobbered = False
@@ -3836,7 +3448,7 @@ def propagate_register_meta(nodes: List[Node], reg: Register) -> None:
 
 
 def determine_return_register(
-    return_blocks: List[BlockInfo], fn_decl_provided: bool
+    return_blocks: List[BlockInfo], fn_decl_provided: bool, arch: Arch
 ) -> Optional[Register]:
     """Determine which of v0 and f0 is the most likely to contain the return
     value, or if the function is likely void."""
@@ -3856,7 +3468,7 @@ def determine_return_register(
 
     best_reg: Optional[Register] = None
     best_prio = -1
-    for reg in [Register("v0"), Register("f0")]:
+    for reg in arch.base_return_regs:
         prios = [priority(b, reg) for b in return_blocks]
         max_prio = max(prios)
         if max_prio == 3:
@@ -3886,6 +3498,7 @@ def translate_node_body(node: Node, regs: RegInfo, stack_info: StackInfo) -> Blo
     switch_expr: Optional[Expression] = None
     has_custom_return: bool = False
     has_function_call: bool = False
+    arch = stack_info.global_info.arch
 
     def eval_once(
         expr: Expression,
@@ -4007,18 +3620,18 @@ def translate_node_body(node: Node, regs: RegInfo, stack_info: StackInfo) -> Blo
             set_reg_maybe_return(reg, expr)
 
     def clear_caller_save_regs() -> None:
-        for reg in TEMP_REGS:
+        for reg in arch.temp_regs:
             if reg in regs:
                 del regs[reg]
 
     def overwrite_reg(reg: Register, expr: Expression) -> None:
         prev = regs.get_raw(reg)
-        at = regs.get_raw(Register("at"))
+        at = regs.get_raw(arch.temporary_reg)
         if (
             not isinstance(prev, EvalOnceExpr)
             or isinstance(expr, Literal)
-            or reg == Register("sp")
-            or reg == Register("at")
+            or reg == arch.stack_pointer_reg
+            or reg == arch.temporary_reg
             or not prev.type.unify(expr.type)
             or (at is not None and uses_expr(at, lambda e2: e2 == prev))
         ):
@@ -4053,12 +3666,12 @@ def translate_node_body(node: Node, regs: RegInfo, stack_info: StackInfo) -> Blo
         expr: Expression
 
         # Figure out what code to generate!
-        if mnemonic in CASES_IGNORE:
+        if mnemonic in arch.instrs_ignore:
             pass
 
-        elif mnemonic in CASES_STORE:
+        elif mnemonic in arch.instrs_store:
             # Store a value in a permanent place.
-            to_store = CASES_STORE[mnemonic](args)
+            to_store = arch.instrs_store[mnemonic](args)
             if to_store is None:
                 # Elided register preserval.
                 pass
@@ -4098,15 +3711,15 @@ def translate_node_body(node: Node, regs: RegInfo, stack_info: StackInfo) -> Blo
                 prevent_later_function_calls()
                 to_write.append(to_store)
 
-        elif mnemonic in CASES_SOURCE_FIRST:
+        elif mnemonic in arch.instrs_source_first:
             # Just 'mtc1'. It's reversed, so we have to specially handle it.
-            set_reg(args.reg_ref(1), CASES_SOURCE_FIRST[mnemonic](args))
+            set_reg(args.reg_ref(1), arch.instrs_source_first[mnemonic](args))
 
-        elif mnemonic in CASES_BRANCHES:
+        elif mnemonic in arch.instrs_branches:
             assert branch_condition is None
-            branch_condition = CASES_BRANCHES[mnemonic](args)
+            branch_condition = arch.instrs_branches[mnemonic](args)
 
-        elif mnemonic in CASES_FLOAT_BRANCHES:
+        elif mnemonic in arch.instrs_float_branches:
             assert branch_condition is None
             cond_bit = regs[Register("condition_bit")]
             if not isinstance(cond_bit, BinaryOp):
@@ -4116,9 +3729,9 @@ def translate_node_body(node: Node, regs: RegInfo, stack_info: StackInfo) -> Blo
             elif mnemonic == "bc1f":
                 branch_condition = cond_bit.negated()
 
-        elif mnemonic in CASES_JUMPS:
+        elif mnemonic in arch.instrs_jumps:
             assert mnemonic == "jr"
-            if args.reg_ref(0) == Register("ra"):
+            if args.reg_ref(0) == arch.return_address_reg:
                 # Return from the function.
                 assert isinstance(node, ReturnNode)
             else:
@@ -4126,7 +3739,7 @@ def translate_node_body(node: Node, regs: RegInfo, stack_info: StackInfo) -> Blo
                 assert isinstance(node, SwitchNode)
                 switch_expr = args.reg(0)
 
-        elif mnemonic in CASES_FN_CALL:
+        elif mnemonic in arch.instrs_fn_call:
             is_known_void = False
             if mnemonic == "jal":
                 fn_target = args.imm(0)
@@ -4145,7 +3758,7 @@ def translate_node_body(node: Node, regs: RegInfo, stack_info: StackInfo) -> Blo
                 if args.count() == 1:
                     fn_target = args.reg(0)
                 elif args.count() == 2:
-                    if args.reg_ref(0) != Register("ra"):
+                    if args.reg_ref(0) != arch.return_address_reg:
                         raise DecompFailure(
                             "Two-argument form of jalr is not supported."
                         )
@@ -4286,22 +3899,22 @@ def translate_node_body(node: Node, regs: RegInfo, stack_info: StackInfo) -> Blo
 
             has_function_call = True
 
-        elif mnemonic in CASES_FLOAT_COMP:
-            expr = CASES_FLOAT_COMP[mnemonic](args)
+        elif mnemonic in arch.instrs_float_comp:
+            expr = arch.instrs_float_comp[mnemonic](args)
             regs[Register("condition_bit")] = expr
 
-        elif mnemonic in CASES_HI_LO:
-            hi, lo = CASES_HI_LO[mnemonic](args)
+        elif mnemonic in arch.instrs_hi_lo:
+            hi, lo = arch.instrs_hi_lo[mnemonic](args)
             set_reg(Register("hi"), hi)
             set_reg(Register("lo"), lo)
 
-        elif mnemonic in CASES_NO_DEST:
-            stmt = CASES_NO_DEST[mnemonic](args)
+        elif mnemonic in arch.instrs_no_dest:
+            stmt = arch.instrs_no_dest[mnemonic](args)
             to_write.append(stmt)
 
-        elif mnemonic in CASES_DESTINATION_FIRST:
+        elif mnemonic in arch.instrs_destination_first:
             target = args.reg_ref(0)
-            val = CASES_DESTINATION_FIRST[mnemonic](args)
+            val = arch.instrs_destination_first[mnemonic](args)
             if False and target in args.raw_args[1:]:
                 # IDO tends to keep variables within single registers. Thus,
                 # if source = target, overwrite that variable instead of
@@ -4470,6 +4083,7 @@ class FunctionInfo:
 @dataclass
 class GlobalInfo:
     asm_data: AsmData
+    arch: Arch
     local_functions: Set[str]
     typemap: TypeMap
     typepool: TypePool
@@ -4783,8 +4397,9 @@ def translate_to_ast(
     stack_info = get_stack_info(function, global_info, flow_graph)
     start_regs: RegInfo = RegInfo(stack_info=stack_info)
 
-    start_regs[Register("sp")] = GlobalSymbol("sp", type=Type.ptr())
-    for reg in SAVED_REGS:
+    arch = global_info.arch
+    start_regs[arch.stack_pointer_reg] = GlobalSymbol("sp", type=Type.ptr())
+    for reg in arch.saved_regs:
         start_regs[reg] = stack_info.saved_reg_symbol(reg.register_name)
 
     def make_arg(offset: int, type: Type) -> PassedInArg:
@@ -4819,11 +4434,11 @@ def translate_to_ast(
         start_regs[Register("f14")] = make_arg(4, Type.floatish())
 
     if options.reg_vars == ["saved"]:
-        reg_vars = SAVED_REGS
+        reg_vars = arch.saved_regs
     elif options.reg_vars == ["most"]:
-        reg_vars = SAVED_REGS + SIMPLE_TEMP_REGS
+        reg_vars = arch.saved_regs + arch.simple_temp_regs
     elif options.reg_vars == ["all"]:
-        reg_vars = SAVED_REGS + SIMPLE_TEMP_REGS + ARGUMENT_REGS
+        reg_vars = arch.saved_regs + arch.simple_temp_regs + arch.argument_regs
     else:
         reg_vars = list(map(Register, options.reg_vars))
     for reg in reg_vars:
@@ -4844,13 +4459,15 @@ def translate_to_ast(
         options,
     )
 
-    for reg in [Register("v0"), Register("f0")]:
+    for reg in arch.base_return_regs:
         propagate_register_meta(flow_graph.nodes, reg)
 
     return_reg: Optional[Register] = None
 
     if not options.void and not return_type.is_void():
-        return_reg = determine_return_register(return_blocks, fn_sym.type_provided)
+        return_reg = determine_return_register(
+            return_blocks, fn_sym.type_provided, arch
+        )
 
     if return_reg is not None:
         for b in return_blocks:

--- a/src/translate.py
+++ b/src/translate.py
@@ -10,10 +10,12 @@ import typing
 from typing import (
     AbstractSet,
     Callable,
+    Collection,
     DefaultDict,
     Dict,
     Iterator,
     List,
+    Mapping,
     Optional,
     Set,
     Tuple,
@@ -51,13 +53,13 @@ from .types import (
     TypePool,
 )
 
-InstrSet = Set[str]
-InstrMap = Dict[str, Callable[["InstrArgs"], "Expression"]]
-StmtInstrMap = Dict[str, Callable[["InstrArgs"], "Statement"]]
-CmpInstrMap = Dict[str, Callable[["InstrArgs"], "Condition"]]
-StoreInstrMap = Dict[str, Callable[["InstrArgs"], Optional["StoreStmt"]]]
-MaybeInstrMap = Dict[str, Callable[["InstrArgs"], Optional["Expression"]]]
-PairInstrMap = Dict[str, Callable[["InstrArgs"], Tuple["Expression", "Expression"]]]
+InstrSet = Collection[str]
+InstrMap = Mapping[str, Callable[["InstrArgs"], "Expression"]]
+StmtInstrMap = Mapping[str, Callable[["InstrArgs"], "Statement"]]
+CmpInstrMap = Mapping[str, Callable[["InstrArgs"], "Condition"]]
+StoreInstrMap = Mapping[str, Callable[["InstrArgs"], Optional["StoreStmt"]]]
+MaybeInstrMap = Mapping[str, Callable[["InstrArgs"], Optional["Expression"]]]
+PairInstrMap = Mapping[str, Callable[["InstrArgs"], Tuple["Expression", "Expression"]]]
 
 
 class Arch(abc.ABC):


### PR DESCRIPTION
Happy to take any feedback here, now is a great time to make name changes or do any restructuring.

Potential weird things:
- I put the new `Arch` on `GlobalInfo`, but maybe it should also be in `Options`? Or only in `Options`? (Maybe `Options` should be available in more fns)
- I use a singleton instance of `MipsArch()`, instead of passing the class itself around. This *feels* like it would play better with the type system, but I'm not actually sure?