### PR TITLE
Move ABI-related functions into arch_mips.py

### DIFF
--- a/src/arch_mips.py
+++ b/src/arch_mips.py
@@ -1,8 +1,18 @@
-from .types import Type
+from typing import (
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+)
+from .types import FunctionSignature, Type
 from .parse_instruction import Register
 from .translate import (
+    Abi,
+    AbiArgSlot,
     Arch,
     BinaryOp,
+    Cast,
     CmpInstrMap,
     CommentStmt,
     ErrorExpr,
@@ -11,6 +21,7 @@ from .translate import (
     InstrSet,
     Literal,
     PairInstrMap,
+    SecondF64Half,
     StmtInstrMap,
     StoreInstrMap,
     UnaryOp,
@@ -477,3 +488,170 @@ class MipsArch(Arch):
         "lwl": lambda a: handle_lwl(a),
         "lwr": lambda a: handle_lwr(a),
     }
+
+    def function_abi(
+        self,
+        fn_sig: FunctionSignature,
+        likely_regs: Dict[Register, bool],
+        *,
+        for_call: bool,
+    ) -> Abi:
+        """Compute stack positions/registers used by a function according to the o32 ABI,
+        based on C type information. Additionally computes a list of registers that might
+        contain arguments, if the function is a varargs function. (Additional varargs
+        arguments may be passed on the stack; we could compute the offset at which that
+        would start but right now don't care -- we just slurp up everything.)"""
+
+        known_slots: List[AbiArgSlot] = []
+        candidate_slots: List[AbiArgSlot] = []
+        if fn_sig.params_known:
+            offset = 0
+            only_floats = True
+            if fn_sig.return_type.is_struct():
+                # The ABI for struct returns is to pass a pointer to where it should be written
+                # as the first argument.
+                known_slots.append(
+                    AbiArgSlot(
+                        offset=0,
+                        reg=Register("a0"),
+                        name="__return__",
+                        type=Type.ptr(fn_sig.return_type),
+                    )
+                )
+                offset = 4
+                only_floats = False
+
+            for ind, param in enumerate(fn_sig.params):
+                # Array parameters decay into pointers
+                param_type = param.type.decay()
+                size, align = param_type.get_parameter_size_align_bytes()
+                size = (size + 3) & ~3
+                only_floats = only_floats and param_type.is_float()
+                offset = (offset + align - 1) & -align
+                name = param.name
+                reg2: Optional[Register]
+                if ind < 2 and only_floats:
+                    reg = Register("f12" if ind == 0 else "f14")
+                    is_double = (
+                        param_type.is_float() and param_type.get_size_bits() == 64
+                    )
+                    known_slots.append(
+                        AbiArgSlot(offset=offset, reg=reg, name=name, type=param_type)
+                    )
+                    if is_double and not for_call:
+                        name2 = f"{name}_lo" if name else None
+                        reg2 = Register("f13" if ind == 0 else "f15")
+                        known_slots.append(
+                            AbiArgSlot(
+                                offset=offset + 4,
+                                reg=reg2,
+                                name=name2,
+                                type=Type.any_reg(),
+                            )
+                        )
+                else:
+                    for i in range(offset // 4, (offset + size) // 4):
+                        unk_offset = 4 * i - offset
+                        name2 = (
+                            f"{name}_unk{unk_offset:X}" if name and unk_offset else name
+                        )
+                        reg2 = Register(f"a{i}") if i < 4 else None
+                        known_slots.append(
+                            AbiArgSlot(
+                                offset=4 * i, reg=reg2, name=name2, type=param_type
+                            )
+                        )
+                offset += size
+
+            if fn_sig.is_variadic:
+                for i in range(offset // 4, 4):
+                    candidate_slots.append(
+                        AbiArgSlot(i * 4, Register(f"a{i}"), Type.any_reg())
+                    )
+
+        else:
+            candidate_slots = [
+                AbiArgSlot(0, Register("f12"), Type.floatish()),
+                AbiArgSlot(4, Register("f13"), Type.floatish()),
+                AbiArgSlot(4, Register("f14"), Type.floatish()),
+                AbiArgSlot(0, Register("a0"), Type.intptr()),
+                AbiArgSlot(4, Register("a1"), Type.any_reg()),
+                AbiArgSlot(8, Register("a2"), Type.any_reg()),
+                AbiArgSlot(12, Register("a3"), Type.any_reg()),
+            ]
+
+        valid_extra_regs: Set[Register] = {
+            slot.reg for slot in known_slots if slot.reg is not None
+        }
+        possible_slots: List[AbiArgSlot] = []
+        for slot in candidate_slots:
+            if slot.reg is None or slot.reg not in likely_regs:
+                continue
+
+            # Don't pass this register if lower numbered ones are undefined.
+            # Following the o32 ABI, register order can be a prefix of either:
+            # a0, a1, a2, a3
+            # f12, a1, a2, a3
+            # f12, f14, a2, a3
+            # f12, f13, a2, a3
+            # f12, f13, f14, f15
+            require: Optional[List[str]] = None
+            if slot == candidate_slots[0]:
+                # For varargs, a subset of a0 .. a3 may be used. Don't check
+                # earlier registers for the first member of that subset.
+                pass
+            elif slot.reg == Register("f13") or slot.reg == Register("f14"):
+                require = ["f12"]
+            elif slot.reg == Register("a1"):
+                require = ["a0", "f12"]
+            elif slot.reg == Register("a2"):
+                require = ["a1", "f13", "f14"]
+            elif slot.reg == Register("a3"):
+                require = ["a2"]
+            if require and not any(Register(r) in valid_extra_regs for r in require):
+                continue
+
+            valid_extra_regs.add(slot.reg)
+
+            if slot.reg == Register("f13"):
+                # We don't pass in f13 or f15 because they will often only
+                # contain SecondF64Half(), and otherwise would need to be
+                # merged with f12/f14 which we don't have logic for right
+                # now. However, f13 can still matter for whether a2 should
+                # be passed, and so is kept in possible_regs.
+                continue
+
+            # Skip registers that are untouched from the initial parameter
+            # list. This is sometimes wrong (can give both false positives
+            # and negatives), but having a heuristic here is unavoidable
+            # without access to function signatures, or when dealing with
+            # varargs functions. Decompiling multiple functions at once
+            # would help.
+            # TODO: don't do this in the middle of the argument list,
+            # except for f12 if a0 is passed and such.
+            if not likely_regs[slot.reg]:
+                continue
+
+            possible_slots.append(slot)
+
+        return Abi(
+            arg_slots=known_slots,
+            possible_slots=possible_slots,
+        )
+
+    def function_return(self, expr: Expression) -> List[Tuple[Register, Expression]]:
+        return [
+            (
+                Register("f0"),
+                Cast(expr, reinterpret=True, silent=True, type=Type.floatish()),
+            ),
+            (
+                Register("v0"),
+                Cast(expr, reinterpret=True, silent=True, type=Type.intptr()),
+            ),
+            (
+                Register("v1"),
+                as_u32(Cast(expr, reinterpret=True, silent=False, type=Type.u64())),
+            ),
+            (Register("f1"), SecondF64Half()),
+        ]

--- a/src/arch_mips.py
+++ b/src/arch_mips.py
@@ -640,6 +640,10 @@ class MipsArch(Arch):
         )
 
     def function_return(self, expr: Expression) -> List[Tuple[Register, Expression]]:
+        # We may not know what this function's return registers are --
+        # $f0, $v0 or ($v0,$v1) or $f0 -- but we don't really care,
+        # it's fine to be liberal here and put the return value in all
+        # of them. (It's not perfect for u64's, but that's rare anyway.)
         return [
             (
                 Register("f0"),

--- a/src/translate.py
+++ b/src/translate.py
@@ -110,7 +110,7 @@ class Arch(abc.ABC):
         of the function call `expr`.
         This must use all of the registers in `all_return_regs` in order to stay
         consistent with `output_regs_for_instr()`. This is why we can't use the
-        funciton's return type, even though it may be more accurate.
+        function's return type, even though it may be more accurate.
         """
         ...
 

--- a/src/translate.py
+++ b/src/translate.py
@@ -86,6 +86,22 @@ class Arch(abc.ABC):
     instrs_source_first: InstrMap
     instrs_destination_first: InstrMap
 
+    @abc.abstractmethod
+    def function_abi(
+        self,
+        fn_sig: FunctionSignature,
+        likely_regs: Dict[Register, bool],
+        *,
+        for_call: bool,
+    ) -> "Abi":
+        ...
+
+    @abc.abstractmethod
+    def function_return(
+        self, expr: "Expression"
+    ) -> List[Tuple[Register, "Expression"]]:
+        ...
+
 
 ASSOCIATIVE_OPS: Set[str] = {"+", "&&", "||", "&", "|", "^", "*"}
 COMPOUND_ASSIGNMENT_OPS: Set[str] = {"+", "-", "*", "/", "%", "&", "|", "^", "<<", ">>"}
@@ -3124,87 +3140,14 @@ def strip_macros(arg: Argument) -> Argument:
 class AbiArgSlot:
     offset: int
     reg: Optional[Register]
-    name: Optional[str]
     type: Type
+    name: Optional[str] = None
 
 
 @dataclass
 class Abi:
     arg_slots: List[AbiArgSlot]
-    possible_regs: List[Register]
-
-
-def function_abi(fn_sig: FunctionSignature, *, for_call: bool) -> Abi:
-    """Compute stack positions/registers used by a function according to the o32 ABI,
-    based on C type information. Additionally computes a list of registers that might
-    contain arguments, if the function is a varargs function. (Additional varargs
-    arguments may be passed on the stack; we could compute the offset at which that
-    would start but right now don't care -- we just slurp up everything.)"""
-    if not fn_sig.params_known:
-        return Abi(
-            arg_slots=[],
-            possible_regs=[
-                Register(r) for r in ["f12", "f13", "f14", "a0", "a1", "a2", "a3"]
-            ],
-        )
-
-    offset = 0
-    only_floats = True
-    slots: List[AbiArgSlot] = []
-    possible: List[Register] = []
-    if fn_sig.return_type.is_struct():
-        # The ABI for struct returns is to pass a pointer to where it should be written
-        # as the first argument.
-        slots.append(
-            AbiArgSlot(
-                offset=0,
-                reg=Register("a0"),
-                name="__return__",
-                type=Type.ptr(fn_sig.return_type),
-            )
-        )
-        offset = 4
-        only_floats = False
-
-    for ind, param in enumerate(fn_sig.params):
-        # Array parameters decay into pointers
-        param_type = param.type.decay()
-        size, align = param_type.get_parameter_size_align_bytes()
-        size = (size + 3) & ~3
-        only_floats = only_floats and param_type.is_float()
-        offset = (offset + align - 1) & -align
-        name = param.name
-        reg2: Optional[Register]
-        if ind < 2 and only_floats:
-            reg = Register("f12" if ind == 0 else "f14")
-            is_double = param_type.is_float() and param_type.get_size_bits() == 64
-            slots.append(AbiArgSlot(offset=offset, reg=reg, name=name, type=param_type))
-            if is_double and not for_call:
-                name2 = f"{name}_lo" if name else None
-                reg2 = Register("f13" if ind == 0 else "f15")
-                slots.append(
-                    AbiArgSlot(
-                        offset=offset + 4, reg=reg2, name=name2, type=Type.any_reg()
-                    )
-                )
-        else:
-            for i in range(offset // 4, (offset + size) // 4):
-                unk_offset = 4 * i - offset
-                name2 = f"{name}_unk{unk_offset:X}" if name and unk_offset else name
-                reg2 = Register(f"a{i}") if i < 4 else None
-                slots.append(
-                    AbiArgSlot(offset=4 * i, reg=reg2, name=name2, type=param_type)
-                )
-        offset += size
-
-    if fn_sig.is_variadic:
-        for i in range(offset // 4, 4):
-            possible.append(Register(f"a{i}"))
-
-    return Abi(
-        arg_slots=slots,
-        possible_regs=possible,
-    )
+    possible_slots: List[AbiArgSlot]
 
 
 def output_regs_for_instr(
@@ -3736,63 +3679,23 @@ def translate_node_body(node: Node, regs: RegInfo, stack_info: StackInfo) -> Blo
             fn_target = as_function_ptr(fn_target)
             fn_sig = fn_target.type.get_function_pointer_signature()
             assert fn_sig is not None, "known function pointers must have a signature"
-            abi = function_abi(fn_sig, for_call=True)
+
+            likely_regs: Dict[Register, bool] = {}
+            for reg, data in regs.contents.items():
+                likely_regs[reg] = (
+                    not isinstance(data.value, PassedInArg) or data.value.copied
+                )
+
+            abi = arch.function_abi(fn_sig, likely_regs, for_call=True)
 
             func_args: List[Expression] = []
             for slot in abi.arg_slots:
                 if slot.reg:
                     func_args.append(as_type(regs[slot.reg], slot.type, True))
 
-            valid_extra_regs: Set[str] = set()
-            for register in abi.possible_regs:
-                raw_expr = regs.get_raw(register)
-                if raw_expr is None:
-                    continue
-
-                # Don't pass this register if lower numbered ones are undefined.
-                # Following the o32 ABI, register order can be a prefix of either:
-                # a0, a1, a2, a3
-                # f12, a1, a2, a3
-                # f12, f14, a2, a3
-                # f12, f13, a2, a3
-                # f12, f13, f14, f15
-                require: Optional[List[str]] = None
-                if register == abi.possible_regs[0]:
-                    # For varargs, a subset of a0 .. a3 may be used. Don't check
-                    # earlier registers for the first member of that subset.
-                    pass
-                elif register == Register("f13") or register == Register("f14"):
-                    require = ["f12"]
-                elif register == Register("a1"):
-                    require = ["a0", "f12"]
-                elif register == Register("a2"):
-                    require = ["a1", "f13", "f14"]
-                elif register == Register("a3"):
-                    require = ["a2"]
-                if require and not any(r in valid_extra_regs for r in require):
-                    continue
-
-                valid_extra_regs.add(register.register_name)
-
-                if register == Register("f13"):
-                    # We don't pass in f13 or f15 because they will often only
-                    # contain SecondF64Half(), and otherwise would need to be
-                    # merged with f12/f14 which we don't have logic for right
-                    # now. However, f13 can still matter for whether a2 should
-                    # be passed, and so is kept in possible_regs.
-                    continue
-
-                # Skip registers that are untouched from our initial parameter
-                # list. This is sometimes wrong (can give both false positives
-                # and negatives), but having a heuristic here is unavoidable
-                # without access to function signatures, or when dealing with
-                # varargs functions. Decompiling multiple functions at once
-                # would help. TODO: don't do this in the middle of the argument
-                # list, except for f12 if a0 is passed and such.
-                if isinstance(raw_expr, PassedInArg) and not raw_expr.copied:
-                    continue
-
-                func_args.append(regs[register])
+            for slot in abi.possible_slots:
+                assert slot.reg is not None
+                func_args.append(regs[slot.reg])
 
             # Add the arguments after a3.
             # TODO: limit this and unify types based on abi.arg_slots
@@ -3836,33 +3739,16 @@ def translate_node_body(node: Node, regs: RegInfo, stack_info: StackInfo) -> Blo
             # needs to match exactly, which is why we can't look at
             # fn_sig.return_type even though it may be more accurate.
             if not is_known_void:
-
-                def set_return_reg(reg: Register, val: Expression) -> None:
-                    val = eval_once(
-                        val,
-                        emit_exactly_once=False,
-                        trivial=False,
-                        prefix=reg.register_name,
-                    )
+                for reg, val in arch.function_return(call):
+                    assert reg in arch.all_return_regs
+                    if not isinstance(val, SecondF64Half):
+                        val = eval_once(
+                            val,
+                            emit_exactly_once=False,
+                            trivial=False,
+                            prefix=reg.register_name,
+                        )
                     regs.set_with_meta(reg, val, RegMeta(function_return=True))
-
-                set_return_reg(
-                    Register("f0"),
-                    Cast(
-                        expr=call, reinterpret=True, silent=True, type=Type.floatish()
-                    ),
-                )
-                set_return_reg(
-                    Register("v0"),
-                    Cast(expr=call, reinterpret=True, silent=True, type=Type.intptr()),
-                )
-                set_return_reg(
-                    Register("v1"),
-                    as_u32(
-                        Cast(expr=call, reinterpret=True, silent=False, type=Type.u64())
-                    ),
-                )
-                regs[Register("f1")] = SecondF64Half()
 
             has_function_call = True
 
@@ -4362,10 +4248,6 @@ def translate_to_ast(
     for reg in arch.saved_regs:
         start_regs[reg] = stack_info.saved_reg_symbol(reg.register_name)
 
-    def make_arg(offset: int, type: Type) -> PassedInArg:
-        assert offset % 4 == 0
-        return PassedInArg(offset, copied=False, stack_info=stack_info, type=type)
-
     fn_sym = global_info.address_of_gsym(function.name).expr
     assert isinstance(fn_sym, GlobalSymbol)
 
@@ -4376,22 +4258,22 @@ def translate_to_ast(
     return_type = fn_sig.return_type
     stack_info.is_variadic = fn_sig.is_variadic
 
-    if fn_sig.params_known:
-        abi = function_abi(fn_sig, for_call=False)
-        for slot in abi.arg_slots:
-            stack_info.add_known_param(slot.offset, slot.name, slot.type)
-            if slot.reg is not None:
-                start_regs[slot.reg] = make_arg(slot.offset, slot.type)
-        for reg in abi.possible_regs:
-            offset = 4 * int(reg.register_name[1])
-            start_regs[reg] = make_arg(offset, Type.any_reg())
-    else:
-        start_regs[Register("a0")] = make_arg(0, Type.intptr())
-        start_regs[Register("a1")] = make_arg(4, Type.any_reg())
-        start_regs[Register("a2")] = make_arg(8, Type.any_reg())
-        start_regs[Register("a3")] = make_arg(12, Type.any_reg())
-        start_regs[Register("f12")] = make_arg(0, Type.floatish())
-        start_regs[Register("f14")] = make_arg(4, Type.floatish())
+    def make_arg(offset: int, type: Type) -> PassedInArg:
+        assert offset % 4 == 0
+        return PassedInArg(offset, copied=False, stack_info=stack_info, type=type)
+
+    abi = arch.function_abi(
+        fn_sig,
+        likely_regs={reg: True for reg in arch.argument_regs},
+        for_call=False,
+    )
+    for slot in abi.arg_slots:
+        stack_info.add_known_param(slot.offset, slot.name, slot.type)
+        if slot.reg is not None:
+            start_regs[slot.reg] = make_arg(slot.offset, slot.type)
+    for slot in abi.possible_slots:
+        if slot.reg is not None:
+            start_regs[slot.reg] = make_arg(slot.offset, slot.type)
 
     if options.reg_vars == ["saved"]:
         reg_vars = arch.saved_regs


### PR DESCRIPTION
- Move `function_abi(...)` into the new `Arch` class
   - Add `likely_regs` arg to move the `possible_regs` loop into this function -- the logic around `Register("f13")` is hard to abstract in a clean way otherwise, imo.
   - It'd be possible to also pass the function's `symbol_name`, the state of `subroutine_args`, or the state of `cr1_gt` (the PPC bit that is related to float varargs) -- but I'm just adding what's used for now.
- Use `function_abi(...)` to set initial register states at the start of `translate_to_ast(...)`
    - Minor difference: now includes both `$f13` and `$f14` at "offset 4", instead of just `$f14`. It's a little weird, I guess? It doesn't seem particularly better/worse than what we were guessing before?
- Moved setting the return registers into a new `function_return(...)` method on the `Arch` class.
   - Minor difference: now setting `$f1` is done with `regs.set_with_meta(..., RegMeta(function_return=True))` instead of `regs[...] = ...`.
- No diffs in e2e tests, OOT, MM, or PM.

----

Here were my notes, before moving this out of Draft. 
- Meta: what parts of the following should I sort out now, vs. addressing in future PRs? 
- Should I rename `MipsArch` to `MipsO32Arch`? (Should `Arch` also be renamed to `ArchAbi`/`AbiArch`?)
- Should `function_abi(...)` go in an ABI class, maybe with the `*_regs` members? 
    - Could this then be used by `parse_instruction.py`?
        - Should I be making changes to `parse_instruction.py` in this PR?
    - It doesn't really make sense to mix-n-match ISAs & ABIs though? 
    - The way I have it now, `MipsN32Arch` could easily inherit from `MipsO32Arch`?
