### PR TITLE
Add comments when args span multiple slots

### DIFF
--- a/tests/end_to_end/complicated_context/irix-g-out.c
+++ b/tests/end_to_end/complicated_context/irix-g-out.c
@@ -1,9 +1,9 @@
-s16 test(struct SomeStruct *arg, u8 should, f64 union_arg, ? union_arg_unk4, ...) {
+s16 test(struct SomeStruct *arg, u8 should, f64 union_arg_unk0, ? union_arg_unk4, ...) {
     f64 sp0;
     s8 temp_a1;
 
     temp_a1 = should & 0xFF;
-    sp0 = union_arg;
+    sp0 = union_arg_unk0;
     if (temp_a1 != 0) {
         globalf = arg->float_field;
         globali = arg->int_field;

--- a/tests/end_to_end/complicated_context/irix-o2-out.c
+++ b/tests/end_to_end/complicated_context/irix-o2-out.c
@@ -1,4 +1,4 @@
-s16 test(struct SomeStruct *arg, u8 should, ? union_arg, ? union_arg_unk4, ...) {
+s16 test(struct SomeStruct *arg, u8 should, ? union_arg_unk0, ? union_arg_unk4, ...) {
     s8 temp_t6;
 
     temp_t6 = should & 0xFF;

--- a/tests/end_to_end/gcc-division/gcc-o2-out.c
+++ b/tests/end_to_end/gcc-division/gcc-o2-out.c
@@ -15,7 +15,7 @@ void test(u32 a) {
 }
 
 void func_00400098(s8 arg0) {
-    func_00400090((u32) ((s32) ((s8) subroutine_arg4 + ((u32) (subroutine_arg4 << 0x18) >> 0x1F)) >> 1), arg0);
+    func_00400090((u32) ((s32) ((s8) subroutine_arg4 + ((u32) (subroutine_arg4 << 0x18) >> 0x1F)) >> 1), /* extra? */ arg0);
     func_00400090((u32) (s8) (subroutine_arg4 / 3));
     func_00400090((u32) (s8) (subroutine_arg4 / 5));
     func_00400090((u32) (s8) (subroutine_arg4 / 7));
@@ -32,7 +32,7 @@ void func_00400098(s8 arg0) {
 }
 
 void func_004003A8(s16 arg0) {
-    func_00400090((u32) ((s32) ((s16) subroutine_arg4 + ((u32) (subroutine_arg4 << 0x10) >> 0x1F)) >> 1), arg0);
+    func_00400090((u32) ((s32) ((s16) subroutine_arg4 + ((u32) (subroutine_arg4 << 0x10) >> 0x1F)) >> 1), /* extra? */ arg0);
     func_00400090((u32) (s16) (subroutine_arg4 / 3));
     func_00400090((u32) (s16) (subroutine_arg4 / 5));
     func_00400090((u32) (s16) (subroutine_arg4 / 7));


### PR DESCRIPTION
Follow-up to Simon's suggestion in #198.

For large arguments that span multiple `AbiArgSlot`s, add inline comments indicating their type & offset. This is done using a new `CommentExpr` wrapper. I also changed the argument names to add the `_unk0` if the argument does not fit in one slot, instead of starting with `_unk4`.

Warn when there are unused `subroutine_args` for functions with known parameters by including an `extra?` comment.

[Diffs](https://gist.github.com/zbanks/c26b1658f1050eaf3db48c0592214ce6)
- The `/* extra? */`s for `create_entity` in PM are false positives: the prototype in my context file does not have an ellipsis, unlike the `main` branch.
- I'm not sure how these arguments should interact with `StackInfo.add_known_param(...)` -- what type should be used when an argument spans multiple slots? [Example](https://gist.github.com/zbanks/c26b1658f1050eaf3db48c0592214ce6#file-all-diff-L188-L191): calling `right_unk0` a `u64` was probably more helpful than calling it a `s64`, but I don't know how best to generalize this?