### PR TITLE
Refactor `Arch` & `Instruction`, create `ArchAsm` ABC

### DIFF
--- a/src/arch_mips.py
+++ b/src/arch_mips.py
@@ -5,8 +5,15 @@ from typing import (
     Set,
     Tuple,
 )
+from .error import DecompFailure
 from .types import FunctionSignature, Type
-from .parse_instruction import Register
+from .parse_instruction import (
+    AsmGlobalSymbol,
+    AsmLiteral,
+    Instruction,
+    JumpTarget,
+    Register,
+)
 from .translate import (
     Abi,
     AbiArgSlot,
@@ -61,6 +68,74 @@ from .translate import (
     make_store,
     void_fn_op,
 )
+
+
+LENGTH_TWO: Set[str] = {
+    "neg",
+    "negu",
+    "not",
+    "neg.s",
+    "abs.s",
+    "sqrt.s",
+    "neg.d",
+    "abs.d",
+    "sqrt.d",
+}
+
+LENGTH_THREE: Set[str] = {
+    "slt",
+    "slti",
+    "sltu",
+    "sltiu",
+    "addi",
+    "addiu",
+    "addu",
+    "subu",
+    "daddi",
+    "daddiu",
+    "dsubu",
+    "add.s",
+    "sub.s",
+    "div.s",
+    "mul.s",
+    "add.d",
+    "sub.d",
+    "div.d",
+    "mul.d",
+    "ori",
+    "and",
+    "or",
+    "nor",
+    "xor",
+    "andi",
+    "xori",
+    "sll",
+    "sllv",
+    "srl",
+    "srlv",
+    "sra",
+    "srav",
+    "dsll",
+    "dsll32",
+    "dsllv",
+    "dsrl",
+    "dsrl32",
+    "dsrlv",
+    "dsra",
+    "dsra32",
+    "dsrav",
+}
+
+DIV_MULT_INSTRUCTIONS: Set[str] = {
+    "div",
+    "divu",
+    "ddiv",
+    "ddivu",
+    "mult",
+    "multu",
+    "dmult",
+    "dmultu",
+}
 
 
 class MipsArch(Arch):
@@ -148,6 +223,127 @@ class MipsArch(Arch):
             "gp",
         ]
     ]
+
+    @staticmethod
+    def is_branch_instruction(instr: Instruction) -> bool:
+        return (
+            instr.mnemonic
+            in [
+                "j",
+                "b",
+                "beq",
+                "bne",
+                "beqz",
+                "bnez",
+                "bgez",
+                "bgtz",
+                "blez",
+                "bltz",
+                "bc1t",
+                "bc1f",
+            ]
+            or MipsArch.is_branch_likely_instruction(instr)
+        )
+
+    @staticmethod
+    def is_branch_likely_instruction(instr: Instruction) -> bool:
+        return instr.mnemonic in [
+            "beql",
+            "bnel",
+            "beqzl",
+            "bnezl",
+            "bgezl",
+            "bgtzl",
+            "blezl",
+            "bltzl",
+            "bc1tl",
+            "bc1fl",
+        ]
+
+    @staticmethod
+    def get_branch_target(instr: Instruction) -> JumpTarget:
+        label = instr.args[-1]
+        if isinstance(label, AsmGlobalSymbol):
+            return JumpTarget(label.symbol_name)
+        if not isinstance(label, JumpTarget):
+            raise DecompFailure(
+                f'Couldn\'t parse instruction "{instr}": invalid branch target'
+            )
+        return label
+
+    @staticmethod
+    def is_jump_instruction(instr: Instruction) -> bool:
+        # (we don't treat jal/jalr as jumps, since control flow will return
+        # after the call)
+        return MipsArch.is_branch_instruction(instr) or instr.mnemonic == "jr"
+
+    @staticmethod
+    def is_delay_slot_instruction(instr: Instruction) -> bool:
+        return MipsArch.is_branch_instruction(instr) or instr.mnemonic in [
+            "jr",
+            "jal",
+            "jalr",
+        ]
+
+    @staticmethod
+    def normalize_instruction(instr: Instruction) -> Instruction:
+        args = instr.args
+        if len(args) == 3:
+            if instr.mnemonic == "sll" and args[0] == args[1] == Register("zero"):
+                return Instruction("nop", [], instr.meta)
+            if instr.mnemonic == "or" and args[2] == Register("zero"):
+                return Instruction("move", args[:2], instr.meta)
+            if instr.mnemonic == "addu" and args[2] == Register("zero"):
+                return Instruction("move", args[:2], instr.meta)
+            if instr.mnemonic == "daddu" and args[2] == Register("zero"):
+                return Instruction("move", args[:2], instr.meta)
+            if instr.mnemonic == "nor" and args[1] == Register("zero"):
+                return Instruction("not", [args[0], args[2]], instr.meta)
+            if instr.mnemonic == "nor" and args[2] == Register("zero"):
+                return Instruction("not", [args[0], args[1]], instr.meta)
+            if instr.mnemonic == "addiu" and args[2] == AsmLiteral(0):
+                return Instruction("move", args[:2], instr.meta)
+            if instr.mnemonic in DIV_MULT_INSTRUCTIONS:
+                if args[0] != Register("zero"):
+                    raise DecompFailure("first argument to div/mult must be $zero")
+                return Instruction(instr.mnemonic, args[1:], instr.meta)
+            if (
+                instr.mnemonic == "ori"
+                and args[1] == Register("zero")
+                and isinstance(args[2], AsmLiteral)
+            ):
+                lit = AsmLiteral(args[2].value & 0xFFFF)
+                return Instruction("li", [args[0], lit], instr.meta)
+            if (
+                instr.mnemonic == "addiu"
+                and args[1] == Register("zero")
+                and isinstance(args[2], AsmLiteral)
+            ):
+                lit = AsmLiteral(((args[2].value + 0x8000) & 0xFFFF) - 0x8000)
+                return Instruction("li", [args[0], lit], instr.meta)
+            if instr.mnemonic == "beq" and args[0] == args[1] == Register("zero"):
+                return Instruction("b", [args[2]], instr.meta)
+            if instr.mnemonic in ["bne", "beq", "beql", "bnel"] and args[1] == Register(
+                "zero"
+            ):
+                mn = instr.mnemonic[:3] + "z" + instr.mnemonic[3:]
+                return Instruction(mn, [args[0], args[2]], instr.meta)
+        if len(args) == 2:
+            if instr.mnemonic == "beqz" and args[0] == Register("zero"):
+                return Instruction("b", [args[1]], instr.meta)
+            if instr.mnemonic == "lui" and isinstance(args[1], AsmLiteral):
+                lit = AsmLiteral((args[1].value & 0xFFFF) << 16)
+                return Instruction("li", [args[0], lit], instr.meta)
+            if instr.mnemonic in LENGTH_THREE:
+                return MipsArch.normalize_instruction(
+                    Instruction(instr.mnemonic, [args[0]] + args, instr.meta)
+                )
+        if len(args) == 1:
+            if instr.mnemonic in LENGTH_TWO:
+                return MipsArch.normalize_instruction(
+                    Instruction(instr.mnemonic, [args[0]] + args, instr.meta)
+                )
+        return instr
 
     instrs_ignore: InstrSet = {
         # Ignore FCSR sets; they are leftovers from float->unsigned conversions.
@@ -489,8 +685,8 @@ class MipsArch(Arch):
         "lwr": lambda a: handle_lwr(a),
     }
 
+    @staticmethod
     def function_abi(
-        self,
         fn_sig: FunctionSignature,
         likely_regs: Dict[Register, bool],
         *,
@@ -650,7 +846,8 @@ class MipsArch(Arch):
             possible_slots=possible_slots,
         )
 
-    def function_return(self, expr: Expression) -> List[Tuple[Register, Expression]]:
+    @staticmethod
+    def function_return(expr: Expression) -> List[Tuple[Register, Expression]]:
         # We may not know what this function's return registers are --
         # $f0, $v0 or ($v0,$v1) or $f0 -- but we don't really care,
         # it's fine to be liberal here and put the return value in all

--- a/src/main.py
+++ b/src/main.py
@@ -66,10 +66,10 @@ def run(options: Options) -> int:
     try:
         for filename in options.filenames:
             if filename == "-":
-                mips_file = parse_file(sys.stdin, options)
+                mips_file = parse_file(sys.stdin, arch, options)
             else:
                 with open(filename, "r", encoding="utf-8-sig") as f:
-                    mips_file = parse_file(f, options)
+                    mips_file = parse_file(f, arch, options)
             all_functions.update((fn.name, fn) for fn in mips_file.functions)
             mips_file.asm_data.merge_into(asm_data)
 
@@ -115,7 +115,7 @@ def run(options: Options) -> int:
     flow_graphs: List[Union[FlowGraph, Exception]] = []
     for function in functions:
         try:
-            flow_graphs.append(build_flowgraph(function, global_info.asm_data))
+            flow_graphs.append(build_flowgraph(function, global_info.asm_data, arch))
         except Exception as e:
             # Store the exception for later, to preserve the order in the output
             flow_graphs.append(e)

--- a/src/parse_file.py
+++ b/src/parse_file.py
@@ -7,7 +7,7 @@ from typing import Callable, Dict, List, Match, Optional, Set, Tuple, TypeVar, U
 
 from .error import DecompFailure
 from .options import Options
-from .parse_instruction import Instruction, InstructionMeta, parse_instruction
+from .parse_instruction import ArchAsm, Instruction, InstructionMeta, parse_instruction
 
 
 @dataclass(frozen=True)
@@ -253,7 +253,7 @@ def parse_incbin(
     return None
 
 
-def parse_file(f: typing.TextIO, options: Options) -> MIPSFile:
+def parse_file(f: typing.TextIO, arch: ArchAsm, options: Options) -> MIPSFile:
     filename = Path(f.name).name
     mips_file: MIPSFile = MIPSFile(filename)
     defines: Dict[str, int] = options.preproc_defines
@@ -452,7 +452,7 @@ def parse_file(f: typing.TextIO, options: Options) -> MIPSFile:
                     lineno=lineno,
                     synthetic=False,
                 )
-                instr: Instruction = parse_instruction(line, meta)
+                instr: Instruction = parse_instruction(line, meta, arch)
                 mips_file.new_instruction(instr)
 
     if warnings:

--- a/src/parse_instruction.py
+++ b/src/parse_instruction.py
@@ -1,77 +1,11 @@
 """Functions and classes useful for parsing an arbitrary MIPS instruction.
 """
+import abc
 from dataclasses import dataclass, replace
 import string
 from typing import List, Optional, Set, Union
 
 from .error import DecompFailure
-
-LENGTH_TWO: Set[str] = {
-    "neg",
-    "negu",
-    "not",
-    "neg.s",
-    "abs.s",
-    "sqrt.s",
-    "neg.d",
-    "abs.d",
-    "sqrt.d",
-}
-
-LENGTH_THREE: Set[str] = {
-    "slt",
-    "slti",
-    "sltu",
-    "sltiu",
-    "addi",
-    "addiu",
-    "addu",
-    "subu",
-    "daddi",
-    "daddiu",
-    "dsubu",
-    "add.s",
-    "sub.s",
-    "div.s",
-    "mul.s",
-    "add.d",
-    "sub.d",
-    "div.d",
-    "mul.d",
-    "ori",
-    "and",
-    "or",
-    "nor",
-    "xor",
-    "andi",
-    "xori",
-    "sll",
-    "sllv",
-    "srl",
-    "srlv",
-    "sra",
-    "srav",
-    "dsll",
-    "dsll32",
-    "dsllv",
-    "dsrl",
-    "dsrl32",
-    "dsrlv",
-    "dsra",
-    "dsra32",
-    "dsrav",
-}
-
-DIV_MULT_INSTRUCTIONS: Set[str] = {
-    "div",
-    "divu",
-    "ddiv",
-    "ddivu",
-    "mult",
-    "multu",
-    "dmult",
-    "dmultu",
-}
 
 
 @dataclass(frozen=True)
@@ -352,128 +286,55 @@ class Instruction:
     ) -> "Instruction":
         return Instruction(mnemonic, args, replace(old.meta, synthetic=True))
 
-    def is_branch_instruction(self) -> bool:
-        return (
-            self.mnemonic
-            in [
-                "j",
-                "b",
-                "beq",
-                "bne",
-                "beqz",
-                "bnez",
-                "bgez",
-                "bgtz",
-                "blez",
-                "bltz",
-                "bc1t",
-                "bc1f",
-            ]
-            or self.is_branch_likely_instruction()
-        )
-
-    def is_branch_likely_instruction(self) -> bool:
-        return self.mnemonic in [
-            "beql",
-            "bnel",
-            "beqzl",
-            "bnezl",
-            "bgezl",
-            "bgtzl",
-            "blezl",
-            "bltzl",
-            "bc1tl",
-            "bc1fl",
-        ]
-
-    def get_branch_target(self) -> JumpTarget:
-        label = self.args[-1]
-        if isinstance(label, AsmGlobalSymbol):
-            return JumpTarget(label.symbol_name)
-        if not isinstance(label, JumpTarget):
-            raise DecompFailure(
-                f'Couldn\'t parse instruction "{self}": invalid branch target'
-            )
-        return label
-
-    def is_jump_instruction(self) -> bool:
-        # (we don't treat jal/jalr as jumps, since control flow will return
-        # after the call)
-        return self.is_branch_instruction() or self.mnemonic == "jr"
-
-    def is_delay_slot_instruction(self) -> bool:
-        return self.is_branch_instruction() or self.mnemonic in [
-            "jr",
-            "jal",
-            "jalr",
-        ]
-
     def __str__(self) -> str:
         args = ", ".join(str(arg) for arg in self.args)
         return f"{self.mnemonic} {args}"
 
 
-def normalize_instruction(instr: Instruction) -> Instruction:
-    args = instr.args
-    if len(args) == 3:
-        if instr.mnemonic == "sll" and args[0] == args[1] == Register("zero"):
-            return Instruction("nop", [], instr.meta)
-        if instr.mnemonic == "or" and args[2] == Register("zero"):
-            return Instruction("move", args[:2], instr.meta)
-        if instr.mnemonic == "addu" and args[2] == Register("zero"):
-            return Instruction("move", args[:2], instr.meta)
-        if instr.mnemonic == "daddu" and args[2] == Register("zero"):
-            return Instruction("move", args[:2], instr.meta)
-        if instr.mnemonic == "nor" and args[1] == Register("zero"):
-            return Instruction("not", [args[0], args[2]], instr.meta)
-        if instr.mnemonic == "nor" and args[2] == Register("zero"):
-            return Instruction("not", [args[0], args[1]], instr.meta)
-        if instr.mnemonic == "addiu" and args[2] == AsmLiteral(0):
-            return Instruction("move", args[:2], instr.meta)
-        if instr.mnemonic in DIV_MULT_INSTRUCTIONS:
-            if args[0] != Register("zero"):
-                raise DecompFailure("first argument to div/mult must be $zero")
-            return Instruction(instr.mnemonic, args[1:], instr.meta)
-        if (
-            instr.mnemonic == "ori"
-            and args[1] == Register("zero")
-            and isinstance(args[2], AsmLiteral)
-        ):
-            lit = AsmLiteral(args[2].value & 0xFFFF)
-            return Instruction("li", [args[0], lit], instr.meta)
-        if (
-            instr.mnemonic == "addiu"
-            and args[1] == Register("zero")
-            and isinstance(args[2], AsmLiteral)
-        ):
-            lit = AsmLiteral(((args[2].value + 0x8000) & 0xFFFF) - 0x8000)
-            return Instruction("li", [args[0], lit], instr.meta)
-        if instr.mnemonic == "beq" and args[0] == args[1] == Register("zero"):
-            return Instruction("b", [args[2]], instr.meta)
-        if instr.mnemonic in ["bne", "beq", "beql", "bnel"] and args[1] == Register(
-            "zero"
-        ):
-            mn = instr.mnemonic[:3] + "z" + instr.mnemonic[3:]
-            return Instruction(mn, [args[0], args[2]], instr.meta)
-    if len(args) == 2:
-        if instr.mnemonic == "beqz" and args[0] == Register("zero"):
-            return Instruction("b", [args[1]], instr.meta)
-        if instr.mnemonic == "lui" and isinstance(args[1], AsmLiteral):
-            lit = AsmLiteral((args[1].value & 0xFFFF) << 16)
-            return Instruction("li", [args[0], lit], instr.meta)
-        if instr.mnemonic in LENGTH_THREE:
-            return normalize_instruction(
-                Instruction(instr.mnemonic, [args[0]] + args, instr.meta)
-            )
-    if len(args) == 1:
-        if instr.mnemonic in LENGTH_TWO:
-            return normalize_instruction(
-                Instruction(instr.mnemonic, [args[0]] + args, instr.meta)
-            )
-    return instr
+class ArchAsm(abc.ABC):
+    stack_pointer_reg: Register
+    frame_pointer_reg: Register
+    return_address_reg: Register
+
+    base_return_regs: List[Register]
+    all_return_regs: List[Register]
+    argument_regs: List[Register]
+    simple_temp_regs: List[Register]
+    temp_regs: List[Register]
+    saved_regs: List[Register]
+
+    @staticmethod
+    @abc.abstractmethod
+    def is_branch_instruction(instr: Instruction) -> bool:
+        ...
+
+    @staticmethod
+    @abc.abstractmethod
+    def is_branch_likely_instruction(instr: Instruction) -> bool:
+        ...
+
+    @staticmethod
+    @abc.abstractmethod
+    def get_branch_target(instr: Instruction) -> JumpTarget:
+        ...
+
+    @staticmethod
+    @abc.abstractmethod
+    def is_jump_instruction(instr: Instruction) -> bool:
+        ...
+
+    @staticmethod
+    @abc.abstractmethod
+    def is_delay_slot_instruction(instr: Instruction) -> bool:
+        ...
+
+    @staticmethod
+    @abc.abstractmethod
+    def normalize_instruction(instr: Instruction) -> Instruction:
+        ...
 
 
-def parse_instruction(line: str, meta: InstructionMeta) -> Instruction:
+def parse_instruction(line: str, meta: InstructionMeta, arch: ArchAsm) -> Instruction:
     try:
         # First token is instruction name, rest is args.
         line = line.strip()
@@ -485,6 +346,6 @@ def parse_instruction(line: str, meta: InstructionMeta) -> Instruction:
             )
         )
         instr = Instruction(mnemonic, args, meta)
-        return normalize_instruction(instr)
+        return arch.normalize_instruction(instr)
     except Exception as e:
         raise DecompFailure(f"Failed to parse instruction {meta.loc_str()}: {line}")

--- a/src/parse_instruction.py
+++ b/src/parse_instruction.py
@@ -303,34 +303,28 @@ class ArchAsm(abc.ABC):
     temp_regs: List[Register]
     saved_regs: List[Register]
 
-    @staticmethod
     @abc.abstractmethod
-    def is_branch_instruction(instr: Instruction) -> bool:
+    def is_branch_instruction(self, instr: Instruction) -> bool:
         ...
 
-    @staticmethod
     @abc.abstractmethod
-    def is_branch_likely_instruction(instr: Instruction) -> bool:
+    def is_branch_likely_instruction(self, instr: Instruction) -> bool:
         ...
 
-    @staticmethod
     @abc.abstractmethod
-    def get_branch_target(instr: Instruction) -> JumpTarget:
+    def get_branch_target(self, instr: Instruction) -> JumpTarget:
         ...
 
-    @staticmethod
     @abc.abstractmethod
-    def is_jump_instruction(instr: Instruction) -> bool:
+    def is_jump_instruction(self, instr: Instruction) -> bool:
         ...
 
-    @staticmethod
     @abc.abstractmethod
-    def is_delay_slot_instruction(instr: Instruction) -> bool:
+    def is_delay_slot_instruction(self, instr: Instruction) -> bool:
         ...
 
-    @staticmethod
     @abc.abstractmethod
-    def normalize_instruction(instr: Instruction) -> Instruction:
+    def normalize_instruction(self, instr: Instruction) -> Instruction:
         ...
 
 

--- a/src/translate.py
+++ b/src/translate.py
@@ -35,6 +35,7 @@ from .flow_graph import (
 from .options import CodingStyle, Formatter, Options
 from .parse_file import AsmData, AsmDataEntry
 from .parse_instruction import (
+    ArchAsm,
     Argument,
     AsmAddressMode,
     AsmGlobalSymbol,
@@ -62,18 +63,7 @@ MaybeInstrMap = Mapping[str, Callable[["InstrArgs"], Optional["Expression"]]]
 PairInstrMap = Mapping[str, Callable[["InstrArgs"], Tuple["Expression", "Expression"]]]
 
 
-class Arch(abc.ABC):
-    stack_pointer_reg: Register
-    frame_pointer_reg: Register
-    return_address_reg: Register
-
-    base_return_regs: List[Register]
-    all_return_regs: List[Register]
-    argument_regs: List[Register]
-    simple_temp_regs: List[Register]
-    temp_regs: List[Register]
-    saved_regs: List[Register]
-
+class Arch(ArchAsm, abc.ABC):
     instrs_ignore: InstrSet
     instrs_store: StoreInstrMap
     instrs_branches: CmpInstrMap
@@ -86,9 +76,9 @@ class Arch(abc.ABC):
     instrs_source_first: InstrMap
     instrs_destination_first: InstrMap
 
+    @staticmethod
     @abc.abstractmethod
     def function_abi(
-        self,
         fn_sig: FunctionSignature,
         likely_regs: Dict[Register, bool],
         *,
@@ -101,10 +91,9 @@ class Arch(abc.ABC):
         """
         ...
 
+    @staticmethod
     @abc.abstractmethod
-    def function_return(
-        self, expr: "Expression"
-    ) -> List[Tuple[Register, "Expression"]]:
+    def function_return(expr: "Expression") -> List[Tuple[Register, "Expression"]]:
         """
         Compute register location(s) & values that will hold the return value
         of the function call `expr`.

--- a/src/translate.py
+++ b/src/translate.py
@@ -76,9 +76,9 @@ class Arch(ArchAsm, abc.ABC):
     instrs_source_first: InstrMap
     instrs_destination_first: InstrMap
 
-    @staticmethod
     @abc.abstractmethod
     def function_abi(
+        self,
         fn_sig: FunctionSignature,
         likely_regs: Dict[Register, bool],
         *,
@@ -91,9 +91,10 @@ class Arch(ArchAsm, abc.ABC):
         """
         ...
 
-    @staticmethod
     @abc.abstractmethod
-    def function_return(expr: "Expression") -> List[Tuple[Register, "Expression"]]:
+    def function_return(
+        self, expr: "Expression"
+    ) -> List[Tuple[Register, "Expression"]]:
         """
         Compute register location(s) & values that will hold the return value
         of the function call `expr`.


### PR DESCRIPTION
This PR has no (intentional!) functional changes; it is just moving the methods out of `Instruction` and into the new `ArchAsm` ABC. This is to prepare for incorporating PPC support from the `ppc2cpp` branch.

`Arch` is now a "super-interface" that also implements `ArchAsm`, so `MipsArch` implements *both* the translate-related behaviors *and* the instruction-related functions. 

I opted to pass `arch: ArchAsm` around to a lot of the functions in `flow_graph` -- the alternative would be to add it as a member to `Function`, but that felt inelegant? 