### PR TITLE
More preparation for `ppc2cpp` merge

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -157,6 +157,12 @@ def create_e2e_tests(
     return cases
 
 
+def find_tests_basic(asm_dir: Path) -> Iterator[List[Path]]:
+    # This has been tested with doldecomp projects for SMS, Melee, and SMB1
+    for asm_file in asm_dir.rglob("*.s"):
+        yield [asm_file]
+
+
 def find_tests_oot(asm_dir: Path) -> Iterator[List[Path]]:
     rodata_suffixes = [".rodata.s", ".rodata2.s"]
     for asm_file in asm_dir.rglob("*.s"):
@@ -225,6 +231,14 @@ def create_project_tests(
             "--stack-structs",
             "--unk-underscore",
             "--pointer-style=left",
+        ]
+    else:
+        file_iter = find_tests_basic(asm_dir)
+        base_flags = [
+            "--incbin-dir",
+            str(base_dir),
+            "--stack-structs",
+            "--unk-underscore",
         ]
 
     for file_list in file_iter:

--- a/src/arch_mips.py
+++ b/src/arch_mips.py
@@ -605,7 +605,7 @@ class MipsArch(Arch):
         "trunc.w.s": lambda a: handle_convert(a.reg(1), Type.s32(), Type.f32()),
         "trunc.w.d": lambda a: handle_convert(a.dreg(1), Type.s32(), Type.f64()),
         # Bit arithmetic
-        "ori": lambda a: handle_or(a, a.reg(1), a.unsigned_imm(2)),
+        "ori": lambda a: handle_or(a.reg(1), a.unsigned_imm(2)),
         "and": lambda a: BinaryOp.int(left=a.reg(1), op="&", right=a.reg(2)),
         "or": lambda a: BinaryOp.int(left=a.reg(1), op="|", right=a.reg(2)),
         "not": lambda a: UnaryOp("~", a.reg(1), type=Type.intish()),

--- a/src/if_statements.py
+++ b/src/if_statements.py
@@ -1360,11 +1360,14 @@ def build_body(context: Context, options: Options) -> Body:
 
     # Check no nodes were skipped: build_flowgraph_between should hit every node in
     # well-formed (reducible) graphs; and build_naive explicitly emits every node
-    unemitted_nodes = (
+    unemitted_nodes = list(
         set(context.flow_graph.nodes)
         - context.emitted_nodes
         - {context.flow_graph.terminal_node()}
     )
+    # NB: Sorting by name isn't perfectly correct ("100" comes before "2"), but this does
+    # create a reproducable output order because names are unique (unlike `n.block.index`).
+    unemitted_nodes.sort(key=lambda n: n.name())
     for node in unemitted_nodes:
         if isinstance(node, ReturnNode) and not node.is_real():
             continue

--- a/src/if_statements.py
+++ b/src/if_statements.py
@@ -1360,15 +1360,9 @@ def build_body(context: Context, options: Options) -> Body:
 
     # Check no nodes were skipped: build_flowgraph_between should hit every node in
     # well-formed (reducible) graphs; and build_naive explicitly emits every node
-    unemitted_nodes = list(
-        set(context.flow_graph.nodes)
-        - context.emitted_nodes
-        - {context.flow_graph.terminal_node()}
-    )
-    # NB: Sorting by name isn't perfectly correct ("100" comes before "2"), but this does
-    # create a reproducable output order because names are unique (unlike `n.block.index`).
-    unemitted_nodes.sort(key=lambda n: n.name())
-    for node in unemitted_nodes:
+    for node in context.flow_graph.nodes:
+        if node in context.emitted_nodes or isinstance(node, TerminalNode):
+            continue
         if isinstance(node, ReturnNode) and not node.is_real():
             continue
         body.add_comment(

--- a/src/parse_file.py
+++ b/src/parse_file.py
@@ -265,12 +265,12 @@ def parse_file(f: typing.TextIO, arch: ArchAsm, options: Options) -> MIPSFile:
     # https://stackoverflow.com/a/241506
     def re_comment_replacer(match: Match[str]) -> str:
         s = match.group(0)
-        if s[0] in "/# \t":
+        if s[0] in "/#; \t":
             return " "
         else:
             return s
 
-    re_comment_or_string = re.compile(r'#.*|/\*.*?\*/|"(?:\\.|[^\\"])*"')
+    re_comment_or_string = re.compile(r'[#;].*|/\*.*?\*/|"(?:\\.|[^\\"])*"')
     re_whitespace_or_string = re.compile(r'\s+|"(?:\\.|[^\\"])*"')
     re_local_glabel = re.compile("L(_U_)?[0-9A-F]{8}")
     re_local_label = re.compile("loc_|locret_|def_|lbl_")

--- a/src/translate.py
+++ b/src/translate.py
@@ -64,17 +64,17 @@ PairInstrMap = Mapping[str, Callable[["InstrArgs"], Tuple["Expression", "Express
 
 
 class Arch(ArchAsm, abc.ABC):
-    instrs_ignore: InstrSet
-    instrs_store: StoreInstrMap
-    instrs_branches: CmpInstrMap
-    instrs_float_branches: InstrSet
-    instrs_jumps: InstrSet
-    instrs_fn_call: InstrSet
-    instrs_no_dest: StmtInstrMap
-    instrs_float_comp: CmpInstrMap
-    instrs_hi_lo: PairInstrMap
-    instrs_source_first: InstrMap
-    instrs_destination_first: InstrMap
+    instrs_ignore: InstrSet = set()
+    instrs_store: StoreInstrMap = {}
+    instrs_branches: CmpInstrMap = {}
+    instrs_float_branches: InstrSet = set()
+    instrs_jumps: InstrSet = set()
+    instrs_fn_call: InstrSet = set()
+    instrs_no_dest: StmtInstrMap = {}
+    instrs_float_comp: CmpInstrMap = {}
+    instrs_hi_lo: PairInstrMap = {}
+    instrs_source_first: InstrMap = {}
+    instrs_destination_first: InstrMap = {}
 
     @abc.abstractmethod
     def function_abi(
@@ -2410,13 +2410,15 @@ def handle_la(args: InstrArgs) -> Expression:
     return add_imm(var, Literal(target.offset), stack_info)
 
 
-def handle_ori(args: InstrArgs) -> Expression:
-    imm = args.unsigned_imm(2)
-    r = args.reg(1)
-    if isinstance(r, Literal) and isinstance(imm, Literal) and (r.value & 0xFFFF) == 0:
-        return Literal(value=(r.value | imm.value))
+def handle_or(args: InstrArgs, left: Expression, right: Expression) -> Expression:
+    if (
+        isinstance(left, Literal)
+        and isinstance(right, Literal)
+        and (left.value & 0xFFFF) == 0
+    ):
+        return Literal(value=(left.value | right.value))
     # Regular bitwise OR.
-    return BinaryOp.int(left=r, op="|", right=imm)
+    return BinaryOp.int(left=left, op="|", right=right)
 
 
 def handle_sltu(args: InstrArgs) -> Expression:

--- a/src/translate.py
+++ b/src/translate.py
@@ -2410,7 +2410,7 @@ def handle_la(args: InstrArgs) -> Expression:
     return add_imm(var, Literal(target.offset), stack_info)
 
 
-def handle_or(args: InstrArgs, left: Expression, right: Expression) -> Expression:
+def handle_or(left: Expression, right: Expression) -> Expression:
     if (
         isinstance(left, Literal)
         and isinstance(right, Literal)


### PR DESCRIPTION
This is a bunch of small changes which have little-to-no effect on the existing behavior, but can bring the main branch closer to `ppc2cpp`.

- ArchAsm: add `all_regs` & `aliased_regs`
- ArchAsm: make `frame_pointer_reg` optional
- ArchAsm: add additional fns
- Arch: set defaults for `instrs_*`
- Refactor `handle_ori()` to `handle_or()`
- Change `Node` debug reps to prefer `.name()` over `.block.index`
- Emit skipped nodes in stable order
- Use `ArchAsm` for more instruction parsing (`.all_regs`)
- Allow `$` in symbol names
- Allow `;` as a comment separator, like `#`
- Remove trailing space from zero-argument `Instruction`s
- Add project support to `run_tests.py`

----

Only diffs are from `MIPS2C_ERROR`'s when the instruction has zero arguments, like the following:
```diff
[INFO] Output of ../oot/asm/osMapTLBRdb.s changed! Diff:
     MIPS2C_ERROR(unknown instruction: mtc0 $t1, $3);
-    MIPS2C_ERROR(unknown instruction: tlbwi );
+    MIPS2C_ERROR(unknown instruction: tlbwi);
     MIPS2C_ERROR(unknown instruction: mtc0 $t0, $10);
```