### PR TITLE
Mark args as inherited to improve return detection

### DIFF
--- a/src/translate.py
+++ b/src/translate.py
@@ -3730,8 +3730,8 @@ def propagate_register_meta(nodes: List[Node], reg: Register) -> None:
 def determine_return_register(
     return_blocks: List[BlockInfo], fn_decl_provided: bool, arch: Arch
 ) -> Optional[Register]:
-    """Determine which of v0 and f0 is the most likely to contain the return
-    value, or if the function is likely void."""
+    """Determine which of the arch's base_return_regs (i.e. v0, f0) is the most
+    likely to contain the return value, or if the function is likely void."""
 
     def priority(block_info: BlockInfo, reg: Register) -> int:
         meta = block_info.final_register_states.get_meta(reg)
@@ -4780,10 +4780,14 @@ def translate_to_ast(
     for slot in abi.arg_slots:
         stack_info.add_known_param(slot.offset, slot.name, slot.type)
         if slot.reg is not None:
-            start_regs[slot.reg] = make_arg(slot.offset, slot.type)
+            start_regs.set_with_meta(
+                slot.reg, make_arg(slot.offset, slot.type), RegMeta(inherited=True)
+            )
     for slot in abi.possible_slots:
         if slot.reg is not None:
-            start_regs[slot.reg] = make_arg(slot.offset, slot.type)
+            start_regs.set_with_meta(
+                slot.reg, make_arg(slot.offset, slot.type), RegMeta(inherited=True)
+            )
 
     if options.reg_vars == ["saved"]:
         reg_vars = arch.saved_regs

--- a/tests/end_to_end/break/mwcc-o4p-out.c
+++ b/tests/end_to_end/break/mwcc-o4p-out.c
@@ -1,6 +1,6 @@
 static ? globals;
 
-f32 test(s32 arg0, f32 arg8) {
+void test(s32 arg0) {
     s32 temp_ctr;
     s32 phi_ctr;
 
@@ -11,7 +11,7 @@ loop_1:
         if ((s32) globals.unk4 == 2) {
             globals.unk8 = 3;
             globals.unk10 = 5;
-            return arg8;
+            return;
         }
         if ((s32) globals.unk8 == 2) {
             globals.unkC = 3;
@@ -20,7 +20,7 @@ loop_1:
         if ((s32) globals.unk10 == 2) {
             globals.unk14 = 3;
             globals.unk10 = 5;
-            return arg8;
+            return;
         }
         if ((s32) globals.unk14 == 2) {
             globals.unk18 = 3;
@@ -33,10 +33,9 @@ block_10:
         if (temp_ctr == 0) {
             /* Duplicate return node #11. Try simplifying control flow for better match */
             globals.unk10 = 5;
-            return arg8;
+            return;
         }
         goto loop_1;
     }
     globals.unk10 = 5;
-    return arg8;
 }

--- a/tests/end_to_end/division-by-power-of-two/mwcc-o4p-out.c
+++ b/tests/end_to_end/division-by-power-of-two/mwcc-o4p-out.c
@@ -1,4 +1,3 @@
-f32 test(s32 *arg0, f32 arg8) {
+void test(s32 *arg0) {
     *arg0 = MIPS2C_ERROR(unknown instruction: addze $r0, $r0);
-    return arg8;
 }

--- a/tests/end_to_end/float-branch-evalonce/mwcc-o4p-out.c
+++ b/tests/end_to_end/float-branch-evalonce/mwcc-o4p-out.c
@@ -1,6 +1,6 @@
 extern f32 x;
 
-s32 test(s32 arg0) {
+void test(void) {
     s32 temp_cr0_lt;
     s32 temp_cr0_lt_2;
 
@@ -13,7 +13,5 @@ s32 test(s32 arg0) {
     x = 3.0f;
     if (temp_cr0_lt_2 == 0) {
         x = 7.0f;
-        return arg0;
     }
-    return arg0;
 }

--- a/tests/end_to_end/if-bitand/mwcc-o4p-out.c
+++ b/tests/end_to_end/if-bitand/mwcc-o4p-out.c
@@ -1,6 +1,6 @@
 extern s32 glob;
 
-s32 test(s32 arg0) {
+void test(void) {
     if ((glob & 1) != 0) {
         glob = 0;
     }
@@ -18,7 +18,5 @@ s32 test(s32 arg0) {
     }
     if ((glob & 0x80000000) != 0) {
         glob = 0;
-        return arg0;
     }
-    return arg0;
 }

--- a/tests/end_to_end/load-types/mwcc-o4p-out.c
+++ b/tests/end_to_end/load-types/mwcc-o4p-out.c
@@ -6,12 +6,11 @@ extern s32 e;
 extern s32 f;
 static ? ar;
 
-f32 test(f32 arg8) {
+void test(void) {
     ar.unk0 = (s32) (s8) a;
     ar.unk4 = (s32) b;
     ar.unk8 = (s32) c;
     ar.unkC = (s32) d;
     ar.unk10 = (s32) e;
     ar.unk14 = (s32) f;
-    return arg8;
 }

--- a/tests/end_to_end/loop/mwcc-o4p-out.c
+++ b/tests/end_to_end/loop/mwcc-o4p-out.c
@@ -1,4 +1,4 @@
-f32 test(s32 arg0, s32 arg1, f32 arg8) {
+void test(s32 arg0, s32 arg1) {
     s32 temp_ctr_2;
     s32 temp_r5;
     s32 temp_r6;
@@ -44,10 +44,6 @@ f32 test(s32 arg0, s32 arg1, f32 arg8) {
                 phi_r3 += 1;
                 phi_ctr_2 = temp_ctr_2;
             } while (temp_ctr_2 != 0);
-            return arg8;
         }
-        /* Duplicate return node #7. Try simplifying control flow for better match */
-        return arg8;
     }
-    return arg8;
 }

--- a/tests/end_to_end/modulo-by-power-of-two/mwcc-o4p-out.c
+++ b/tests/end_to_end/modulo-by-power-of-two/mwcc-o4p-out.c
@@ -1,5 +1,4 @@
-f32 test(s32 *arg0, f32 arg8) {
+void test(s32 *arg0) {
     MIPS2C_ERROR(unknown instruction: addze $r0, $r0);
     *arg0 = MIPS2C_ERROR(unknown instruction: subfc $r0, $r0, $r4);
-    return arg8;
 }

--- a/tests/end_to_end/mult-by-constant/mwcc-o4p-out.c
+++ b/tests/end_to_end/mult-by-constant/mwcc-o4p-out.c
@@ -1,6 +1,6 @@
 extern s32 y;
 
-f32 test(s32 arg0, f32 arg8) {
+void test(s32 arg0) {
     y = arg0;
     y = arg0 * 2;
     y = arg0 * 3;
@@ -23,5 +23,4 @@ f32 test(s32 arg0, f32 arg8) {
     y = arg0 * 0x14;
     y = arg0 * 0x15;
     y = arg0 * 0x16;
-    return arg8;
 }

--- a/tests/end_to_end/mult-by-two/mwcc-o4p-out.c
+++ b/tests/end_to_end/mult-by-two/mwcc-o4p-out.c
@@ -1,8 +1,7 @@
 extern f32 x;
 extern f64 y;
 
-s32 test(s32 arg0) {
+void test(void) {
     y *= 2.0;
     x *= 2.0f;
-    return arg0;
 }

--- a/tests/end_to_end/return-float/mwcc-o4p-out.c
+++ b/tests/end_to_end/return-float/mwcc-o4p-out.c
@@ -1,6 +1,6 @@
-s32 test(s32 arg0, f32 arg8) {
+f32 test(f32 arg8) {
     if (arg8 != 0.0f) {
-        return arg0;
+        return 15.0f;
     }
-    return arg0;
+    return arg8;
 }

--- a/tests/end_to_end/signed-conversion/mwcc-o4p-out.c
+++ b/tests/end_to_end/signed-conversion/mwcc-o4p-out.c
@@ -1,6 +1,6 @@
 extern s32 glob;
 
-f32 test(s8 arg0, f32 arg8) {
+void test(s8 arg0) {
     s8 temp_r5;
     s8 temp_r6;
 
@@ -12,5 +12,4 @@ f32 test(s8 arg0, f32 arg8) {
     glob = (s32) (s16) arg0;
     glob = (s32) (s16) temp_r5;
     glob = (s32) (s16) temp_r6;
-    return arg8;
 }

--- a/tests/end_to_end/struct/mwcc-o4p-out.c
+++ b/tests/end_to_end/struct/mwcc-o4p-out.c
@@ -1,6 +1,5 @@
-f32 test(void *arg0, void *arg1, f32 arg8) {
+void test(void *arg0, void *arg1) {
     arg0->unk_4 = (s32) (arg0->unk_0 + arg0->unk_4);
     arg1->unk_0 = (s32) arg0->unk_0;
     arg1->unk_4 = (s32) arg0->unk_4;
-    return arg8;
 }

--- a/tests/end_to_end/unreachable-return2/mwcc-o4p-out.c
+++ b/tests/end_to_end/unreachable-return2/mwcc-o4p-out.c
@@ -1,10 +1,9 @@
 extern s32 x;
 
-f32 test(f32 arg8) {
+void test(void) {
 loop_1:
     if ((s32) x != 2) {
         x = 1;
         goto loop_1;
     }
-    return arg8;
 }


### PR DESCRIPTION
[Original Comment](https://github.com/matt-kempster/mips_to_c/pull/205#discussion_r802457004)

> f32? (why does this argument even exist?)

I think it makes sense to mark *both* known args & possible args as `inherited=True`? But that's the part I'm least sure about here. 
