### PR TITLE
Implement PPC carry/extended ops, floating intriniscs, clz

### DIFF
--- a/mips2c_macros.h
+++ b/mips2c_macros.h
@@ -33,4 +33,8 @@ typedef s64 MIPS2C_UNK64;
 #define MIPS2C_BREAK() (0)
 #define MIPS2C_SYNC() (0)
 
+/* Floating-point intrinisics */
+#define MIPS2C_FRES(x) (1.0 / x)            /* PPC reciprocal estimator (fres) */
+#define MIPS2C_FRSQRTE(x) (1.0 / sqrtf(x)   /* PPC inverse square root estimator (frsqrte) */
+
 #endif

--- a/tests/end_to_end/comparison/mwcc-o4p-out.c
+++ b/tests/end_to_end/comparison/mwcc-o4p-out.c
@@ -1,14 +1,16 @@
-extern u32 global;
+extern s32 global;
 
 f32 test(s32 arg0, s32 arg1, s32 arg2, f32 arg8) {
-    global = (u32) MIPS2C_ERROR(unknown instruction: cntlzw $r0, $r0) >> 5U;
-    MIPS2C_ERROR(unknown instruction: eqv $r0, $r4, $r3);
-    global = MIPS2C_ERROR(unknown instruction: subfe $r5, $r0, $r5);
-    MIPS2C_ERROR(unknown instruction: subfc $r5, $r4, $r3);
-    global = MIPS2C_ERROR(unknown instruction: addze $r0, $r0) & 1;
-    MIPS2C_ERROR(unknown instruction: subfc $r3, $r3, $r4);
-    global = MIPS2C_ERROR(unknown instruction: adde $r5, $r5, $r6);
-    global = (u32) MIPS2C_ERROR(unknown instruction: cntlzw $r0, $r0) >> 5U;
-    global = MIPS2C_ERROR(unknown instruction: subfe $r0, $r0, $r3);
+    s32 temp_r3;
+    s32 temp_r5;
+
+    temp_r5 = arg2 - arg0;
+    global = (arg1 - arg0) == 0;
+    global = temp_r5 - (temp_r5 - 1);
+    global = ((u32) ~(arg1 ^ arg0) >> 0x1FU) & 1;
+    temp_r3 = -arg1;
+    global = (arg1 >> 0x1F) + ((u32) arg0 >> 0x1FU);
+    global = -arg0 == 0;
+    global = temp_r3 - (temp_r3 - 1);
     return arg8;
 }

--- a/tests/end_to_end/division-by-power-of-two/mwcc-o4p-out.c
+++ b/tests/end_to_end/division-by-power-of-two/mwcc-o4p-out.c
@@ -1,4 +1,4 @@
 f32 test(s32 *arg0, f32 arg8) {
-    *arg0 = MIPS2C_ERROR(unknown instruction: addze $r0, $r0);
+    *arg0 = (s32) *arg0 >> 1;
     return arg8;
 }

--- a/tests/end_to_end/gcc-division/mwcc-o4p-out.c
+++ b/tests/end_to_end/gcc-division/mwcc-o4p-out.c
@@ -20,7 +20,7 @@ void test_s8(s8 c) {
     s8 temp_r4_3;
 
     sp8 = c;
-    func_00400090(MIPS2C_ERROR(unknown instruction: addze $r3, $r3));
+    func_00400090((u32) ((s32) (s8) (u8) sp8 >> 1));
     func_00400090(MULT_HI(0x55555556, (s8) (u8) sp8) + ((s8) (u8) sp8 / 6442450941));
     func_00400090((s8) (u8) sp8 / 5);
     temp_r0 = (s8) (u8) sp8;
@@ -31,8 +31,7 @@ void test_s8(s8 c) {
     temp_r0_3 = (s8) (u8) sp8;
     temp_r0_4 = (s32) (MULT_HI(0x80808081, temp_r0_3) + temp_r0_3) >> 7;
     func_00400090(temp_r0_4 + ((u32) temp_r0_4 >> 0x1FU));
-    MIPS2C_ERROR(unknown instruction: addze $r3, $r3);
-    func_00400090(MIPS2C_ERROR(unknown instruction: subfc $r3, $r3, $r0));
+    func_00400090((s8) (u8) sp8 % 2);
     temp_r4 = (s8) (u8) sp8;
     func_00400090(temp_r4 - ((MULT_HI(0x55555556, temp_r4) + ((s8) (u8) sp8 / 6442450941)) * 3));
     func_00400090((s8) (u8) sp8 % 5);
@@ -58,7 +57,7 @@ void test_s16(s16 h) {
     s32 temp_r3;
 
     sp8 = h;
-    func_00400090(MIPS2C_ERROR(unknown instruction: addze $r3, $r3));
+    func_00400090((u32) ((s32) sp8 >> 1));
     func_00400090(MULT_HI(0x55555556, sp8) + (sp8 / 6442450941));
     func_00400090(sp8 / 5);
     temp_r0 = (s32) (MULT_HI(0x92492493, sp8) + sp8) >> 2;
@@ -71,8 +70,7 @@ void test_s16(s16 h) {
     func_00400090(temp_r0_3 + ((u32) temp_r0_3 >> 0x1FU));
     temp_r0_4 = (s32) (MULT_HI(0x80010003, sp8) + sp8) >> 0xF;
     func_00400090(temp_r0_4 + ((u32) temp_r0_4 >> 0x1FU));
-    MIPS2C_ERROR(unknown instruction: addze $r3, $r3);
-    func_00400090(MIPS2C_ERROR(unknown instruction: subfc $r3, $r3, $r0));
+    func_00400090(sp8 % 2);
     func_00400090(sp8 - ((MULT_HI(0x55555556, sp8) + (sp8 / 6442450941)) * 3));
     func_00400090(sp8 % 5);
     temp_r0_5 = (s32) (MULT_HI(0x92492493, sp8) + sp8) >> 2;
@@ -110,14 +108,14 @@ void test_s32_div(s32 d) {
 
     sp8 = d;
     func_00400090((u32) d);
-    func_00400090(MIPS2C_ERROR(unknown instruction: addze $r3, $r3));
+    func_00400090((u32) (sp8 >> 1));
     func_00400090(MULT_HI(0x55555556, sp8) + (sp8 / 6442450941));
-    func_00400090(MIPS2C_ERROR(unknown instruction: addze $r3, $r3));
+    func_00400090((u32) (sp8 >> 2));
     func_00400090(sp8 / 5);
     func_00400090(MULT_HI(0x2AAAAAAB, sp8) + (sp8 / 12884901882));
     temp_r0 = (s32) (MULT_HI(0x92492493, sp8) + sp8) >> 2;
     func_00400090(temp_r0 + ((u32) temp_r0 >> 0x1FU));
-    func_00400090(MIPS2C_ERROR(unknown instruction: addze $r3, $r3));
+    func_00400090((u32) (sp8 >> 3));
     func_00400090(sp8 / 9);
     func_00400090(sp8 / 10);
     func_00400090(sp8 / 11);
@@ -127,7 +125,7 @@ void test_s32_div(s32 d) {
     func_00400090(temp_r0_2 + ((u32) temp_r0_2 >> 0x1FU));
     temp_r0_3 = (s32) (MULT_HI(0x88888889, sp8) + sp8) >> 3;
     func_00400090(temp_r0_3 + ((u32) temp_r0_3 >> 0x1FU));
-    func_00400090(MIPS2C_ERROR(unknown instruction: addze $r3, $r3));
+    func_00400090((u32) (sp8 >> 4));
     func_00400090(sp8 / 17);
     func_00400090(sp8 / 18);
     func_00400090(sp8 / 19);
@@ -148,7 +146,7 @@ void test_s32_div(s32 d) {
     func_00400090(temp_r0_7 + ((u32) temp_r0_7 >> 0x1FU));
     temp_r0_8 = (s32) (MULT_HI(0x84210843, sp8) + sp8) >> 4;
     func_00400090(temp_r0_8 + ((u32) temp_r0_8 >> 0x1FU));
-    func_00400090(MIPS2C_ERROR(unknown instruction: addze $r3, $r3));
+    func_00400090((u32) (sp8 >> 5));
     func_00400090(sp8 / 33);
     func_00400090(sp8 / 100);
     temp_r0_9 = (s32) (MULT_HI(0x80808081, sp8) + sp8) >> 7;
@@ -165,7 +163,7 @@ void test_s32_div(s32 d) {
     func_00400090(temp_r0_11 + ((u32) temp_r0_11 >> 0x1FU));
     temp_r0_12 = (s32) (MULT_HI(0x80000003, sp8) + sp8) >> 0x1D;
     func_00400090(temp_r0_12 + ((u32) temp_r0_12 >> 0x1FU));
-    func_00400090(MIPS2C_ERROR(unknown instruction: addze $r3, $r3));
+    func_00400090((u32) (sp8 >> 0x1E));
     func_00400090(sp8 / 1073741824);
     func_00400090(sp8 / 2147483644);
     temp_r0_13 = (s32) (MULT_HI(0x80000003, sp8) + sp8) >> 0x1E;
@@ -181,10 +179,10 @@ void test_s32_div(s32 d) {
     func_00400090(temp_r0_16 + ((u32) temp_r0_16 >> 0x1FU));
     temp_r0_17 = (s32) MULT_HI(0x99999999, sp8) >> 1;
     func_00400090(temp_r0_17 + ((u32) temp_r0_17 >> 0x1FU));
-    func_00400090((u32) -(s32) MIPS2C_ERROR(unknown instruction: addze $r3, $r3));
+    func_00400090((u32) -(s32) (sp8 >> 2));
     temp_r0_18 = (s32) (MULT_HI(0x55555555, sp8) - sp8) >> 1;
     func_00400090(temp_r0_18 + ((u32) temp_r0_18 >> 0x1FU));
-    func_00400090((u32) -(s32) MIPS2C_ERROR(unknown instruction: addze $r3, $r3));
+    func_00400090((u32) -(s32) (sp8 >> 1));
     func_00400090((u32) (d / -1));
 }
 
@@ -213,17 +211,14 @@ void test_s32_mod(s32 d) {
 
     sp8 = d;
     func_00400090(0U);
-    MIPS2C_ERROR(unknown instruction: addze $r3, $r3);
-    func_00400090(MIPS2C_ERROR(unknown instruction: subfc $r3, $r3, $r0));
+    func_00400090(sp8 % 2);
     func_00400090(sp8 - ((MULT_HI(0x55555556, sp8) + (sp8 / 6442450941)) * 3));
-    MIPS2C_ERROR(unknown instruction: addze $r3, $r3);
-    func_00400090(MIPS2C_ERROR(unknown instruction: subfc $r3, $r3, $r0));
+    func_00400090(sp8 % 4);
     func_00400090(sp8 % 5);
     func_00400090(sp8 - ((MULT_HI(0x2AAAAAAB, sp8) + (sp8 / 12884901882)) * 6));
     temp_r0 = (s32) (MULT_HI(0x92492493, sp8) + sp8) >> 2;
     func_00400090(sp8 - ((temp_r0 + ((u32) temp_r0 >> 0x1FU)) * 7));
-    MIPS2C_ERROR(unknown instruction: addze $r3, $r3);
-    func_00400090(MIPS2C_ERROR(unknown instruction: subfc $r3, $r3, $r0));
+    func_00400090(sp8 % 8);
     func_00400090(sp8 % 9);
     func_00400090(sp8 % 10);
     func_00400090(sp8 % 11);
@@ -233,8 +228,7 @@ void test_s32_mod(s32 d) {
     func_00400090(sp8 - ((temp_r0_2 + ((u32) temp_r0_2 >> 0x1FU)) * 0xE));
     temp_r0_3 = (s32) (MULT_HI(0x88888889, sp8) + sp8) >> 3;
     func_00400090(sp8 - ((temp_r0_3 + ((u32) temp_r0_3 >> 0x1FU)) * 0xF));
-    MIPS2C_ERROR(unknown instruction: addze $r3, $r3);
-    func_00400090(MIPS2C_ERROR(unknown instruction: subfc $r3, $r3, $r0));
+    func_00400090(sp8 % 16);
     func_00400090(sp8 % 17);
     func_00400090(sp8 % 18);
     func_00400090(sp8 % 19);
@@ -255,8 +249,7 @@ void test_s32_mod(s32 d) {
     func_00400090(sp8 - ((temp_r0_7 + ((u32) temp_r0_7 >> 0x1FU)) * 0x1E));
     temp_r0_8 = (s32) (MULT_HI(0x84210843, sp8) + sp8) >> 4;
     func_00400090(sp8 - ((temp_r0_8 + ((u32) temp_r0_8 >> 0x1FU)) * 0x1F));
-    MIPS2C_ERROR(unknown instruction: addze $r3, $r3);
-    func_00400090(MIPS2C_ERROR(unknown instruction: subfc $r3, $r3, $r0));
+    func_00400090(sp8 - ((sp8 >> 5) << 5));
     func_00400090(sp8 % 33);
     func_00400090(sp8 % 100);
     temp_r0_9 = (s32) (MULT_HI(0x80808081, sp8) + sp8) >> 7;
@@ -273,8 +266,7 @@ void test_s32_mod(s32 d) {
     func_00400090(sp8 - ((temp_r0_11 + ((u32) temp_r0_11 >> 0x1FU)) * 0x3FFFFFFE));
     temp_r3 = (s32) (MULT_HI(0x80000003, sp8) + sp8) >> 0x1D;
     func_00400090(sp8 - ((temp_r3 + ((u32) temp_r3 >> 0x1FU)) * 0x3FFFFFFF));
-    MIPS2C_ERROR(unknown instruction: addze $r3, $r3);
-    func_00400090(MIPS2C_ERROR(unknown instruction: subfc $r3, $r3, $r0));
+    func_00400090(sp8 - ((sp8 >> 0x1E) << 0x1E));
     func_00400090(sp8 - ((sp8 / 1073741824) * 0x40000001));
     func_00400090(sp8 - ((sp8 / 2147483644) * 0x7FFFFFFD));
     temp_r3_2 = (s32) (MULT_HI(0x80000003, sp8) + sp8) >> 0x1E;

--- a/tests/end_to_end/modulo-by-power-of-two/mwcc-o4p-out.c
+++ b/tests/end_to_end/modulo-by-power-of-two/mwcc-o4p-out.c
@@ -1,5 +1,4 @@
 f32 test(s32 *arg0, f32 arg8) {
-    MIPS2C_ERROR(unknown instruction: addze $r0, $r0);
-    *arg0 = MIPS2C_ERROR(unknown instruction: subfc $r0, $r0, $r4);
+    *arg0 %= 2;
     return arg8;
 }

--- a/tests/end_to_end/multi-switch/mwcc-o4p-out.c
+++ b/tests/end_to_end/multi-switch/mwcc-o4p-out.c
@@ -3,9 +3,14 @@ extern s32 glob;
 s32 test(s32 arg0) {
     s32 phi_r3;
     s32 phi_r3_2;
+    s32 phi_r3_3;
+    s32 phi_r3_4;
+    s32 phi_r3_5;
 
     phi_r3_2 = arg0;
-    phi_r3 = arg0;
+    phi_r3_3 = arg0;
+    phi_r3_4 = arg0;
+    phi_r3_5 = arg0;
     if (arg0 != 0x32) {
         if (arg0 < 0x32) {
             switch (arg0) { // switch 1; irregular
@@ -19,7 +24,7 @@ s32 test(s32 arg0) {
                 glob = arg0 - 1;
                 return 2;
             default: // switch 1
-                phi_r3 = arg0 * 2;
+                phi_r3_3 = arg0 * 2;
                 goto block_28;
             }
         } else {
@@ -33,8 +38,11 @@ s32 test(s32 arg0) {
                 return 2;
             case 0x66:
 block_28:
+                phi_r3 = phi_r3_3;
+                phi_r3_5 = phi_r3_3;
                 if ((s32) glob == 0) {
-                    phi_r3 = MIPS2C_ERROR(unknown instruction: addze $r3, $r3);
+                    phi_r3_4 = phi_r3_5 - 1;
+                    phi_r3 = phi_r3_4 >> 1;
                 }
                 glob = phi_r3;
                 return 2;

--- a/tests/end_to_end/stack_reference/mwcc-o4p-out.c
+++ b/tests/end_to_end/stack_reference/mwcc-o4p-out.c
@@ -8,5 +8,5 @@ s32 test(s32 arg0, s32 arg1) {
     sp8 = arg0;
     temp_r0 = &spC - temp_r5;
     spC = arg1;
-    return MIPS2C_ERROR(unknown instruction: addze $r3, $r3);
+    return temp_r0 >> 2;
 }

--- a/tests/end_to_end/switch/mwcc-o4p-out.c
+++ b/tests/end_to_end/switch/mwcc-o4p-out.c
@@ -27,7 +27,7 @@ s32 test(s32 arg0) {
             return 2;
         }
 block_14:
-        glob = MIPS2C_ERROR(unknown instruction: addze $r3, $r3);
+        glob = arg0 >> 1;
         return 2;
     }
     glob = arg0 + 1;


### PR DESCRIPTION
This rounds out the most popular instructions. There's a histogram of remaining instructions in the projects I know about [in this gist](https://gist.github.com/zbanks/7e97b61b87b9e4f764f1a04f65f17ae3).  

Added instructions:
- `addc`
- `adde`
- `addze`
- `subfc`
- `subfe`
- `subfze`
- `andc`
- `eqv`
- `cntlzw`
- `fres`
- `frsqrte`
- `fsel`

The carry/extended behavior of the `-c`/`-e` instructions is not implemented. Usually these instructions are used to implement 64-bit integer arithmetic, but the codebase isn't currently equipped to easily handle this. (The instructions may be interleaved, and the value may be in an arbitrary pair of registers.)

Added a pattern to `fold_divmod` to rewrite `CLZ(x) >> 5` into `x == 0`.
This accounts for ~80% of `cntlzw` usage (and is why its implemented as a `UnaryOp` instead of a `fn_op`). This is tested by the `comparison` e2e test.

Also expanded the pattern for modulo-by-power-of-2 to match the MWCC version, which emits `(x - (x >> N) * M)` instead of `(x - (x / N) * N)`.

The other comparison patterns aren't detected yet (see the `comparison` e2e test).