### PR TITLE
Refactor `Instruction` to include arch information

### DIFF
--- a/src/arch_mips.py
+++ b/src/arch_mips.py
@@ -5,13 +5,16 @@ from typing import (
     Optional,
     Set,
     Tuple,
+    Union,
 )
 
 from .error import DecompFailure
 from .options import Target
 from .parse_instruction import (
+    Argument,
     AsmAddressMode,
     AsmGlobalSymbol,
+    AsmInstruction,
     AsmLiteral,
     Instruction,
     InstructionMeta,
@@ -23,6 +26,7 @@ from .asm_pattern import (
     AsmMatcher,
     AsmPattern,
     Replacement,
+    ReplacementPart,
     SimpleAsmPattern,
     make_pattern,
 )
@@ -198,9 +202,7 @@ class ModP2Pattern1(SimpleAsmPattern):
         val = (m.literals["N"] & 0xFFFF) + 1
         if val & (val - 1):
             return None  # not a power of two
-        mod = m.derived_instr(
-            "mod.fictive", [m.regs["o"], m.regs["i"], AsmLiteral(val)]
-        )
+        mod = AsmInstruction("mod.fictive", [m.regs["o"], m.regs["i"], AsmLiteral(val)])
         return Replacement([mod], len(m.body) - 1)
 
 
@@ -224,8 +226,9 @@ class ModP2Pattern2(SimpleAsmPattern):
             val += ((m.literals["LO"] + 0x8000) & 0xFFFF) - 0x8000
         if not val or val & (val - 1):
             return None  # not a power of two
-        mod = m.derived_instr(
-            "mod.fictive", [m.regs["o"], m.regs["i"], AsmLiteral(val)]
+        mod = AsmInstruction(
+            "mod.fictive",
+            [m.regs["o"], m.regs["i"], AsmLiteral(val)],
         )
         return Replacement([mod], len(m.body) - 1)
 
@@ -243,7 +246,7 @@ class DivP2Pattern1(SimpleAsmPattern):
 
     def replace(self, m: AsmMatch) -> Replacement:
         shift = m.literals["N"] & 0x1F
-        div = m.derived_instr(
+        div = AsmInstruction(
             "div.fictive", [m.regs["o"], m.regs["i"], AsmLiteral(2 ** shift)]
         )
         return Replacement([div], len(m.body) - 1)
@@ -262,7 +265,7 @@ class DivP2Pattern2(SimpleAsmPattern):
 
     def replace(self, m: AsmMatch) -> Replacement:
         shift = m.literals["N"] & 0x1F
-        div = m.derived_instr(
+        div = AsmInstruction(
             "div.fictive", [m.regs["x"], m.regs["x"], AsmLiteral(2 ** shift)]
         )
         return Replacement([div], len(m.body))
@@ -279,8 +282,8 @@ class Div2S16Pattern(SimpleAsmPattern):
 
     def replace(self, m: AsmMatch) -> Replacement:
         # Keep 32->16 conversion from $i to $o, just add a division
-        div = m.derived_instr("div.fictive", [m.regs["o"], m.regs["o"], AsmLiteral(2)])
-        return Replacement(m.body[:2] + [div], len(m.body))
+        div = AsmInstruction("div.fictive", [m.regs["o"], m.regs["o"], AsmLiteral(2)])
+        return Replacement([m.body[0], m.body[1], div], len(m.body))
 
 
 class Div2S32Pattern(SimpleAsmPattern):
@@ -291,7 +294,7 @@ class Div2S32Pattern(SimpleAsmPattern):
     )
 
     def replace(self, m: AsmMatch) -> Replacement:
-        div = m.derived_instr("div.fictive", [m.regs["o"], m.regs["i"], AsmLiteral(2)])
+        div = AsmInstruction("div.fictive", [m.regs["o"], m.regs["i"], AsmLiteral(2)])
         return Replacement([div], len(m.body))
 
 
@@ -307,7 +310,7 @@ class UtfPattern(SimpleAsmPattern):
     )
 
     def replace(self, m: AsmMatch) -> Replacement:
-        new_instr = m.derived_instr("cvt.s.u.fictive", [m.regs["o"], m.regs["i"]])
+        new_instr = AsmInstruction("cvt.s.u.fictive", [m.regs["o"], m.regs["i"]])
         return Replacement([new_instr], len(m.body) - 1)
 
 
@@ -356,9 +359,9 @@ class FtuPattern(SimpleAsmPattern):
         fmt = sub.mnemonic.split(".")[-1]
         args = [m.regs["o"], sub.args[1]]
         if fmt == "s":
-            new_instr = m.derived_instr("cvt.u.s.fictive", args)
+            new_instr = AsmInstruction("cvt.u.s.fictive", args)
         else:
-            new_instr = m.derived_instr("cvt.u.d.fictive", args)
+            new_instr = AsmInstruction("cvt.u.d.fictive", args)
         return Replacement([new_instr], len(m.body))
 
 
@@ -395,7 +398,7 @@ class Mips1DoubleLoadStorePattern(AsmPattern):
         # Store the even-numbered register (ra) into the low address (mb).
         new_args = [ra, mb]
         new_mn = "ldc1" if a.mnemonic == "lwc1" else "sdc1"
-        new_instr = m.derived_instr(new_mn, new_args)
+        new_instr = AsmInstruction(new_mn, new_args)
         return Replacement([new_instr], len(m.body))
 
 
@@ -429,7 +432,7 @@ class TrapuvPattern(SimpleAsmPattern):
     )
 
     def replace(self, m: AsmMatch) -> Replacement:
-        new_instr = m.derived_instr("trapuv.fictive", [])
+        new_instr = AsmInstruction("trapuv.fictive", [])
         return Replacement([m.body[2], new_instr], len(m.body))
 
 
@@ -527,31 +530,109 @@ class MipsArch(Arch):
         "r0": Register("zero"),
     }
 
-    uses_delay_slots = True
+    @classmethod
+    def missing_return(cls) -> List[Instruction]:
+        meta = InstructionMeta.missing()
+        return [
+            cls.parse("jr", [Register("ra")], meta),
+            cls.parse("nop", [], meta),
+        ]
 
-    @staticmethod
-    def is_branch_instruction(instr: Instruction) -> bool:
-        return (
-            instr.mnemonic
-            in [
-                "beq",
-                "bne",
-                "beqz",
-                "bnez",
-                "bgez",
-                "bgtz",
-                "blez",
-                "bltz",
-                "bc1t",
-                "bc1f",
-            ]
-            or MipsArch.is_branch_likely_instruction(instr)
-            or MipsArch.is_constant_branch_instruction(instr)
-        )
+    @classmethod
+    def normalize_instruction(cls, instr: AsmInstruction) -> AsmInstruction:
+        args = instr.args
+        if len(args) == 3:
+            if instr.mnemonic == "sll" and args[0] == args[1] == Register("zero"):
+                return AsmInstruction("nop", [])
+            if instr.mnemonic == "or" and args[2] == Register("zero"):
+                return AsmInstruction("move", args[:2])
+            if instr.mnemonic == "addu" and args[2] == Register("zero"):
+                return AsmInstruction("move", args[:2])
+            if instr.mnemonic == "daddu" and args[2] == Register("zero"):
+                return AsmInstruction("move", args[:2])
+            if instr.mnemonic == "nor" and args[1] == Register("zero"):
+                return AsmInstruction("not", [args[0], args[2]])
+            if instr.mnemonic == "nor" and args[2] == Register("zero"):
+                return AsmInstruction("not", [args[0], args[1]])
+            if instr.mnemonic == "addiu" and args[2] == AsmLiteral(0):
+                return AsmInstruction("move", args[:2])
+            if instr.mnemonic in DIV_MULT_INSTRUCTIONS:
+                if args[0] != Register("zero"):
+                    raise DecompFailure("first argument to div/mult must be $zero")
+                return AsmInstruction(instr.mnemonic, args[1:])
+            if (
+                instr.mnemonic == "ori"
+                and args[1] == Register("zero")
+                and isinstance(args[2], AsmLiteral)
+            ):
+                lit = AsmLiteral(args[2].value & 0xFFFF)
+                return AsmInstruction("li", [args[0], lit])
+            if (
+                instr.mnemonic == "addiu"
+                and args[1] == Register("zero")
+                and isinstance(args[2], AsmLiteral)
+            ):
+                lit = AsmLiteral(((args[2].value + 0x8000) & 0xFFFF) - 0x8000)
+                return AsmInstruction("li", [args[0], lit])
+            if instr.mnemonic == "beq" and args[0] == args[1] == Register("zero"):
+                return AsmInstruction("b", [args[2]])
+            if instr.mnemonic in ["bne", "beq", "beql", "bnel"] and args[1] == Register(
+                "zero"
+            ):
+                mn = instr.mnemonic[:3] + "z" + instr.mnemonic[3:]
+                return AsmInstruction(mn, [args[0], args[2]])
+        if len(args) == 2:
+            if instr.mnemonic == "beqz" and args[0] == Register("zero"):
+                return AsmInstruction("b", [args[1]])
+            if instr.mnemonic == "lui" and isinstance(args[1], AsmLiteral):
+                lit = AsmLiteral((args[1].value & 0xFFFF) << 16)
+                return AsmInstruction("li", [args[0], lit])
+            if instr.mnemonic in LENGTH_THREE:
+                return cls.normalize_instruction(
+                    AsmInstruction(instr.mnemonic, [args[0]] + args)
+                )
+        if len(args) == 1:
+            if instr.mnemonic in LENGTH_TWO:
+                return cls.normalize_instruction(
+                    AsmInstruction(instr.mnemonic, [args[0]] + args)
+                )
+        return instr
 
-    @staticmethod
-    def is_branch_likely_instruction(instr: Instruction) -> bool:
-        return instr.mnemonic in [
+    @classmethod
+    def parse(
+        cls, mnemonic: str, args: List[Argument], meta: InstructionMeta
+    ) -> Instruction:
+        jump_target: Optional[Union[JumpTarget, Register]] = None
+        function_target: Optional[Union[JumpTarget, Register]] = None
+        has_delay_slot = False
+        is_branch_likely = False
+        is_conditional = False
+        is_return = False
+
+        if mnemonic == "jr" and args[0] == Register("ra"):
+            # Return
+            is_return = True
+            has_delay_slot = True
+        elif mnemonic == "jr":
+            # Jump table (switch)
+            assert isinstance(args[0], Register)
+            jump_target = args[0]
+            is_conditional = True
+            has_delay_slot = True
+        elif mnemonic == "jal":
+            # Function call to label
+            function_target = cls.get_branch_target(args)
+            has_delay_slot = True
+        elif mnemonic == "jalr":
+            # Function call to pointer
+            assert isinstance(args[0], Register)
+            function_target = args[0]
+            has_delay_slot = True
+        elif mnemonic in ("b", "j"):
+            # Unconditional jump
+            jump_target = cls.get_branch_target(args)
+            has_delay_slot = True
+        elif mnemonic in (
             "beql",
             "bnel",
             "beqzl",
@@ -562,102 +643,40 @@ class MipsArch(Arch):
             "bltzl",
             "bc1tl",
             "bc1fl",
-        ]
+        ):
+            # Branch-likely
+            jump_target = cls.get_branch_target(args)
+            has_delay_slot = True
+            is_branch_likely = True
+            is_conditional = True
+        elif mnemonic in (
+            "beq",
+            "bne",
+            "beqz",
+            "bnez",
+            "bgez",
+            "bgtz",
+            "blez",
+            "bltz",
+            "bc1t",
+            "bc1f",
+        ):
+            # Normal branch
+            jump_target = cls.get_branch_target(args)
+            has_delay_slot = True
+            is_conditional = True
 
-    @staticmethod
-    def is_constant_branch_instruction(instr: Instruction) -> bool:
-        return instr.mnemonic in ("b", "j")
-
-    @staticmethod
-    def is_jump_instruction(instr: Instruction) -> bool:
-        # (we don't treat jal/jalr as jumps, since control flow will return
-        # after the call)
-        return MipsArch.is_branch_instruction(instr) or instr.mnemonic == "jr"
-
-    @staticmethod
-    def is_delay_slot_instruction(instr: Instruction) -> bool:
-        return MipsArch.is_branch_instruction(instr) or instr.mnemonic in [
-            "jr",
-            "jal",
-            "jalr",
-        ]
-
-    @staticmethod
-    def is_return_instruction(instr: Instruction) -> bool:
-        return instr.mnemonic == "jr" and instr.args[0] == Register("ra")
-
-    @staticmethod
-    def is_conditional_return_instruction(instr: Instruction) -> bool:
-        return False
-
-    @staticmethod
-    def is_jumptable_instruction(instr: Instruction) -> bool:
-        return instr.mnemonic == "jr" and instr.args[0] != Register("ra")
-
-    @staticmethod
-    def missing_return() -> List[Instruction]:
-        meta = InstructionMeta.missing()
-        return [Instruction("jr", [Register("ra")], meta), Instruction("nop", [], meta)]
-
-    @classmethod
-    def normalize_instruction(cls, instr: Instruction) -> Instruction:
-        args = instr.args
-        if len(args) == 3:
-            if instr.mnemonic == "sll" and args[0] == args[1] == Register("zero"):
-                return Instruction("nop", [], instr.meta)
-            if instr.mnemonic == "or" and args[2] == Register("zero"):
-                return Instruction("move", args[:2], instr.meta)
-            if instr.mnemonic == "addu" and args[2] == Register("zero"):
-                return Instruction("move", args[:2], instr.meta)
-            if instr.mnemonic == "daddu" and args[2] == Register("zero"):
-                return Instruction("move", args[:2], instr.meta)
-            if instr.mnemonic == "nor" and args[1] == Register("zero"):
-                return Instruction("not", [args[0], args[2]], instr.meta)
-            if instr.mnemonic == "nor" and args[2] == Register("zero"):
-                return Instruction("not", [args[0], args[1]], instr.meta)
-            if instr.mnemonic == "addiu" and args[2] == AsmLiteral(0):
-                return Instruction("move", args[:2], instr.meta)
-            if instr.mnemonic in DIV_MULT_INSTRUCTIONS:
-                if args[0] != Register("zero"):
-                    raise DecompFailure("first argument to div/mult must be $zero")
-                return Instruction(instr.mnemonic, args[1:], instr.meta)
-            if (
-                instr.mnemonic == "ori"
-                and args[1] == Register("zero")
-                and isinstance(args[2], AsmLiteral)
-            ):
-                lit = AsmLiteral(args[2].value & 0xFFFF)
-                return Instruction("li", [args[0], lit], instr.meta)
-            if (
-                instr.mnemonic == "addiu"
-                and args[1] == Register("zero")
-                and isinstance(args[2], AsmLiteral)
-            ):
-                lit = AsmLiteral(((args[2].value + 0x8000) & 0xFFFF) - 0x8000)
-                return Instruction("li", [args[0], lit], instr.meta)
-            if instr.mnemonic == "beq" and args[0] == args[1] == Register("zero"):
-                return Instruction("b", [args[2]], instr.meta)
-            if instr.mnemonic in ["bne", "beq", "beql", "bnel"] and args[1] == Register(
-                "zero"
-            ):
-                mn = instr.mnemonic[:3] + "z" + instr.mnemonic[3:]
-                return Instruction(mn, [args[0], args[2]], instr.meta)
-        if len(args) == 2:
-            if instr.mnemonic == "beqz" and args[0] == Register("zero"):
-                return Instruction("b", [args[1]], instr.meta)
-            if instr.mnemonic == "lui" and isinstance(args[1], AsmLiteral):
-                lit = AsmLiteral((args[1].value & 0xFFFF) << 16)
-                return Instruction("li", [args[0], lit], instr.meta)
-            if instr.mnemonic in LENGTH_THREE:
-                return cls.normalize_instruction(
-                    Instruction(instr.mnemonic, [args[0]] + args, instr.meta)
-                )
-        if len(args) == 1:
-            if instr.mnemonic in LENGTH_TWO:
-                return cls.normalize_instruction(
-                    Instruction(instr.mnemonic, [args[0]] + args, instr.meta)
-                )
-        return instr
+        return Instruction(
+            mnemonic=mnemonic,
+            args=args,
+            meta=meta,
+            jump_target=jump_target,
+            function_target=function_target,
+            has_delay_slot=has_delay_slot,
+            is_branch_likely=is_branch_likely,
+            is_conditional=is_conditional,
+            is_return=is_return,
+        )
 
     asm_patterns = [
         DivPattern(),

--- a/src/arch_mips.py
+++ b/src/arch_mips.py
@@ -27,7 +27,6 @@ from .asm_pattern import (
     AsmMatcher,
     AsmPattern,
     Replacement,
-    ReplacementPart,
     SimpleAsmPattern,
     make_pattern,
 )
@@ -588,11 +587,15 @@ class MipsArch(Arch):
             if instr.mnemonic == "lui" and isinstance(args[1], AsmLiteral):
                 lit = AsmLiteral((args[1].value & 0xFFFF) << 16)
                 return AsmInstruction("li", [args[0], lit])
+            if instr.mnemonic == "jalr" and args[0] != Register("ra"):
+                raise DecompFailure("Two-argument form of jalr is not supported.")
             if instr.mnemonic in LENGTH_THREE:
                 return cls.normalize_instruction(
                     AsmInstruction(instr.mnemonic, [args[0]] + args)
                 )
         if len(args) == 1:
+            if instr.mnemonic == "jalr":
+                return AsmInstruction("jalr", [Register("ra"), args[0]])
             if instr.mnemonic in LENGTH_TWO:
                 return cls.normalize_instruction(
                     AsmInstruction(instr.mnemonic, [args[0]] + args)

--- a/src/arch_ppc.py
+++ b/src/arch_ppc.py
@@ -5,6 +5,7 @@ from typing import (
     Optional,
     Set,
     Tuple,
+    Union,
 )
 from .error import DecompFailure
 from .options import Target
@@ -12,6 +13,7 @@ from .parse_instruction import (
     Argument,
     AsmAddressMode,
     AsmGlobalSymbol,
+    AsmInstruction,
     AsmLiteral,
     Instruction,
     InstructionMeta,
@@ -98,11 +100,11 @@ class FcmpoCrorPattern(SimpleAsmPattern):
         assert isinstance(fcmpo, Instruction)
         if m.literals["N"] == 0:
             return Replacement(
-                [m.derived_instr("fcmpo.lte.fictive", fcmpo.args)], len(m.body)
+                [AsmInstruction("fcmpo.lte.fictive", fcmpo.args)], len(m.body)
             )
         elif m.literals["N"] == 1:
             return Replacement(
-                [m.derived_instr("fcmpo.gte.fictive", fcmpo.args)], len(m.body)
+                [AsmInstruction("fcmpo.gte.fictive", fcmpo.args)], len(m.body)
             )
         return None
 
@@ -124,8 +126,8 @@ class TailCallPattern(AsmPattern):
         ):
             return Replacement(
                 [
-                    Instruction.derived("bl", instr.args, instr),
-                    Instruction.derived("blr", [], instr),
+                    AsmInstruction("bl", instr.args),
+                    AsmInstruction("blr", []),
                 ],
                 1,
             )
@@ -143,7 +145,7 @@ class BoolCastPattern(SimpleAsmPattern):
 
     def replace(self, m: AsmMatch) -> Optional[Replacement]:
         return Replacement(
-            [m.derived_instr("boolcast.fictive", [Register("r0"), m.regs["x"]])],
+            [AsmInstruction("boolcast.fictive", [Register("r0"), m.regs["x"]])],
             len(m.body),
         )
 
@@ -157,8 +159,8 @@ class BranchCtrPattern(AsmPattern):
             ctr = Register("ctr")
             return Replacement(
                 [
-                    Instruction.derived("addi", [ctr, ctr, AsmLiteral(-1)], instr),
-                    Instruction.derived(instr.mnemonic + ".fictive", instr.args, instr),
+                    AsmInstruction("addi", [ctr, ctr, AsmLiteral(-1)]),
+                    AsmInstruction(instr.mnemonic + ".fictive", instr.args),
                 ],
                 1,
             )
@@ -287,75 +289,9 @@ class PpcArch(Arch):
 
     aliased_regs: Dict[str, Register] = {}
 
-    uses_delay_slots = False
-
-    @staticmethod
-    def is_branch_instruction(instr: Instruction) -> bool:
-        return (
-            instr.mnemonic
-            in [
-                "ble",
-                "blt",
-                "beq",
-                "bge",
-                "bgt",
-                "bne",
-                "bdnz",
-                "bdz",
-                "bdnz.fictive",
-                "bdz.fictive",
-            ]
-            or PpcArch.is_constant_branch_instruction(instr)
-        )
-
-    @staticmethod
-    def is_branch_likely_instruction(instr: Instruction) -> bool:
-        return False
-
-    @staticmethod
-    def is_constant_branch_instruction(instr: Instruction) -> bool:
-        return instr.mnemonic == "b"
-
-    @staticmethod
-    def is_jump_instruction(instr: Instruction) -> bool:
-        # (we don't treat jal/jalr as jumps, since control flow will return
-        # after the call)
-        return (
-            PpcArch.is_conditional_return_instruction(instr)
-            or PpcArch.is_branch_instruction(instr)
-            or instr.mnemonic in ("blr", "bctr")
-        )
-
-    @staticmethod
-    def is_delay_slot_instruction(instr: Instruction) -> bool:
-        return False
-
-    @staticmethod
-    def is_return_instruction(instr: Instruction) -> bool:
-        return instr.mnemonic == "blr"
-
-    @staticmethod
-    def is_conditional_return_instruction(instr: Instruction) -> bool:
-        return instr.mnemonic in (
-            "beqlr",
-            "bgelr",
-            "bgtlr",
-            "blelr",
-            "bltlr",
-            "bnelr",
-            "bnglr",
-            "bnllr",
-            "bnslr",
-            "bsolr",
-        )
-
-    @staticmethod
-    def is_jumptable_instruction(instr: Instruction) -> bool:
-        return instr.mnemonic == "bctr"
-
-    @staticmethod
-    def missing_return() -> List[Instruction]:
-        return [Instruction("blr", [], InstructionMeta.missing())]
+    @classmethod
+    def missing_return(cls) -> List[Instruction]:
+        return [cls.parse("blr", [], InstructionMeta.missing())]
 
     # List of all instructions where `$r0` as certian args is interpreted as `0`
     # instead of the contents of `$r0`. The dict value represents the argument
@@ -413,13 +349,13 @@ class PpcArch(Arch):
     }
 
     @classmethod
-    def normalize_instruction(cls, instr: Instruction) -> Instruction:
+    def normalize_instruction(cls, instr: AsmInstruction) -> AsmInstruction:
         # Remove +/- suffix, which indicates branch-(un)likely and can be ignored
         if instr.mnemonic.startswith("b") and (
             instr.mnemonic.endswith("+") or instr.mnemonic.endswith("-")
         ):
             return PpcArch.normalize_instruction(
-                Instruction(instr.mnemonic[:-1], instr.args, instr.meta)
+                AsmInstruction(instr.mnemonic[:-1], instr.args)
             )
 
         args = instr.args
@@ -436,7 +372,7 @@ class PpcArch(Arch):
                 new_args = args[:]
                 new_args[r0_index] = r0_arg
                 return PpcArch.normalize_instruction(
-                    Instruction(instr.mnemonic, new_args, instr.meta)
+                    AsmInstruction(instr.mnemonic, new_args)
                 )
         if len(args) == 3:
             if (
@@ -445,11 +381,11 @@ class PpcArch(Arch):
                 and args[1] in (Register("r2"), Register("r13"))
                 and args[2].macro_name in ("sda2", "sda21")
             ):
-                return Instruction("li", [args[0], args[2].argument], instr.meta)
+                return AsmInstruction("li", [args[0], args[2].argument])
         if len(args) == 2:
             if instr.mnemonic == "lis" and isinstance(args[1], AsmLiteral):
                 lit = AsmLiteral((args[1].value & 0xFFFF) << 16)
-                return Instruction("li", [args[0], lit], instr.meta)
+                return AsmInstruction("li", [args[0], lit])
             if (
                 instr.mnemonic == "lis"
                 and isinstance(args[1], Macro)
@@ -461,12 +397,81 @@ class PpcArch(Arch):
                 if value & 0x8000:
                     value += 0x10000
                 lit = AsmLiteral(value & 0xFFFF0000)
-                return Instruction("li", [args[0], lit], instr.meta)
+                return AsmInstruction("li", [args[0], lit])
             if instr.mnemonic.startswith("cmp"):
                 # For the two-argument form of cmpw, the insert an implicit CR0 as the first arg
                 cr0: Argument = Register("cr0")
-                return Instruction(instr.mnemonic, [cr0] + instr.args, instr.meta)
+                return AsmInstruction(instr.mnemonic, [cr0] + instr.args)
         return instr
+
+    @classmethod
+    def parse(
+        cls, mnemonic: str, args: List[Argument], meta: InstructionMeta
+    ) -> Instruction:
+        jump_target: Optional[Union[JumpTarget, Register]] = None
+        function_target: Optional[Union[JumpTarget, Register]] = None
+        is_conditional = False
+        is_return = False
+
+        if mnemonic == "blr":
+            # Return
+            is_return = True
+        elif mnemonic in (
+            "beqlr",
+            "bgelr",
+            "bgtlr",
+            "blelr",
+            "bltlr",
+            "bnelr",
+            "bnglr",
+            "bnllr",
+            "bnslr",
+            "bsolr",
+        ):
+            # Conditional return
+            is_return = True
+            is_conditional = True
+        elif mnemonic == "bctr":
+            # Jump table (switch)
+            jump_target = Register("ctr")
+            is_conditional = True
+        elif mnemonic == "bl":
+            # Function call to label
+            function_target = cls.get_branch_target(args)
+        elif mnemonic == "bctrl":
+            # Function call to pointer in $ctr
+            function_target = Register("ctr")
+        elif mnemonic == "blrl":
+            # Function call to pointer in $lr
+            function_target = Register("lr")
+        elif mnemonic == "b":
+            # Unconditional jump
+            jump_target = cls.get_branch_target(args)
+        elif mnemonic in (
+            "ble",
+            "blt",
+            "beq",
+            "bge",
+            "bgt",
+            "bne",
+            "bdnz",
+            "bdz",
+            "bdnz.fictive",
+            "bdz.fictive",
+        ):
+            # Normal branch
+            jump_target = cls.get_branch_target(args)
+            is_conditional = True
+
+        return Instruction(
+            mnemonic=mnemonic,
+            args=args,
+            meta=meta,
+            jump_target=jump_target,
+            function_target=function_target,
+            is_conditional=is_conditional,
+            is_return=is_return,
+        )
 
     asm_patterns = [
         FcmpoCrorPattern(),

--- a/src/flow_graph.py
+++ b/src/flow_graph.py
@@ -114,12 +114,12 @@ class BlockBuilder:
         return self.blocks
 
 
-def verify_no_trailing_delay_slot(function: Function, arch: ArchFlowGraph) -> None:
+def verify_no_trailing_delay_slot(function: Function) -> None:
     last_ins: Optional[Instruction] = None
     for item in function.body:
         if isinstance(item, Instruction):
             last_ins = item
-    if last_ins and arch.is_delay_slot_instruction(last_ins):
+    if last_ins and last_ins.has_delay_slot:
         raise DecompFailure(f"Last instruction is missing a delay slot:\n{last_ins}")
 
 
@@ -192,9 +192,10 @@ def normalize_likely_branches(function: Function, arch: ArchFlowGraph) -> Functi
     for item in body_iter:
         orig_item = item
         if isinstance(item, Instruction) and (
-            arch.is_branch_likely_instruction(item) or item.mnemonic == "b"
+            item.is_branch_likely or item.mnemonic == "b"
         ):
-            old_label = arch.get_branch_target(item).target
+            assert isinstance(item.jump_target, JumpTarget)
+            old_label = item.jump_target.target
             if old_label not in label_prev_instr:
                 raise DecompFailure(
                     f"Unable to parse branch: label {old_label} does not exist in function {function.name}"
@@ -210,7 +211,7 @@ def normalize_likely_branches(function: Function, arch: ArchFlowGraph) -> Functi
             if (
                 item.mnemonic == "b"
                 and before_before_target is not None
-                and arch.is_delay_slot_instruction(before_before_target)
+                and before_before_target.has_delay_slot
             ):
                 # Don't treat 'b' instructions as branch likelies if doing so would
                 # introduce a label in a delay slot.
@@ -222,8 +223,8 @@ def normalize_likely_branches(function: Function, arch: ArchFlowGraph) -> Functi
                 and item.mnemonic != "b"
             ):
                 mn_inverted = invert_branch_mnemonic(item.mnemonic[:-1])
-                item = Instruction.derived(mn_inverted, item.args, item)
-                new_nop = Instruction.derived("nop", [], item)
+                item = arch.parse(mn_inverted, item.args, item.meta.derived())
+                new_nop = arch.parse("nop", [], item.meta.derived())
                 new_body.append((orig_item, item))
                 new_body.append((new_nop, new_nop))
                 new_body.append((orig_next_item, next_item))
@@ -240,10 +241,10 @@ def normalize_likely_branches(function: Function, arch: ArchFlowGraph) -> Functi
                     insert_label_before[id(before_target)] = new_label
                 new_target = JumpTarget(label_before_instr[id(before_target)])
                 mn_unlikely = item.mnemonic[:-1] or "b"
-                item = Instruction.derived(
-                    mn_unlikely, item.args[:-1] + [new_target], item
+                item = arch.parse(
+                    mn_unlikely, item.args[:-1] + [new_target], item.meta.derived()
                 )
-                next_item = Instruction.derived("nop", [], item)
+                next_item = arch.parse("nop", [], item.meta.derived())
                 new_body.append((orig_item, item))
                 new_body.append((orig_next_item, next_item))
             else:
@@ -261,17 +262,15 @@ def normalize_likely_branches(function: Function, arch: ArchFlowGraph) -> Functi
     return new_function
 
 
-def prune_unreferenced_labels(
-    function: Function, asm_data: AsmData, arch: ArchFlowGraph
-) -> Function:
+def prune_unreferenced_labels(function: Function, asm_data: AsmData) -> Function:
     labels_used: Set[str] = {
         label.name
         for label in function.body
         if isinstance(label, Label) and label.name in asm_data.mentioned_labels
     }
     for item in function.body:
-        if isinstance(item, Instruction) and arch.is_branch_instruction(item):
-            labels_used.add(arch.get_branch_target(item).target)
+        if isinstance(item, Instruction) and isinstance(item.jump_target, JumpTarget):
+            labels_used.add(item.jump_target.target)
 
     new_function = function.bodyless_copy()
     for item in function.body:
@@ -282,7 +281,7 @@ def prune_unreferenced_labels(
 
 
 def simplify_standard_patterns(function: Function, arch: ArchFlowGraph) -> Function:
-    new_body = simplify_patterns(function.body, arch.asm_patterns)
+    new_body = simplify_patterns(function.body, arch.asm_patterns, arch)
     new_function = function.bodyless_copy()
     new_function.body.extend(new_body)
     return new_function
@@ -292,12 +291,12 @@ def build_blocks(
     function: Function, asm_data: AsmData, arch: ArchFlowGraph
 ) -> List[Block]:
     if arch.arch == Target.ArchEnum.MIPS:
-        verify_no_trailing_delay_slot(function, arch)
+        verify_no_trailing_delay_slot(function)
         function = normalize_likely_branches(function, arch)
 
-    function = prune_unreferenced_labels(function, asm_data, arch)
+    function = prune_unreferenced_labels(function, asm_data)
     function = simplify_standard_patterns(function, arch)
-    function = prune_unreferenced_labels(function, asm_data, arch)
+    function = prune_unreferenced_labels(function, asm_data)
 
     block_builder = BlockBuilder()
 
@@ -312,10 +311,10 @@ def build_blocks(
             block_builder.set_label(item)
             return
 
-        if not arch.is_delay_slot_instruction(item):
+        if not item.has_delay_slot:
             block_builder.add_instruction(item)
             # Split blocks at jumps, at the next instruction.
-            if arch.is_jump_instruction(item):
+            if item.is_jump():
                 block_builder.new_block()
             return
 
@@ -354,32 +353,35 @@ def build_blocks(
                     ]
                 raise DecompFailure("\n".join(msg))
 
-        if arch.is_delay_slot_instruction(next_item):
+        if next_item.has_delay_slot:
             raise DecompFailure(
                 f"Two delay slot instructions in a row is not supported:\n{item}\n{next_item}"
             )
 
-        if arch.is_branch_likely_instruction(item):
-            target = arch.get_branch_target(item)
+        if item.is_branch_likely:
+            assert isinstance(item.jump_target, JumpTarget)
+            target = item.jump_target
             branch_likely_counts[target.target] += 1
             index = branch_likely_counts[target.target]
             mn_inverted = invert_branch_mnemonic(item.mnemonic[:-1])
             temp_label = JumpTarget(f"{target.target}_branchlikelyskip_{index}")
-            branch_not = Instruction.derived(
-                mn_inverted, item.args[:-1] + [temp_label], item
+            branch_not = arch.parse(
+                mn_inverted, item.args[:-1] + [temp_label], item.meta.derived()
             )
-            nop = Instruction.derived("nop", [], item)
+            nop = arch.parse("nop", [], item.meta.derived())
             block_builder.add_instruction(branch_not)
             block_builder.add_instruction(nop)
             block_builder.new_block()
             block_builder.add_instruction(next_item)
-            block_builder.add_instruction(Instruction.derived("b", [target], item))
+            block_builder.add_instruction(
+                arch.parse("b", [target], item.meta.derived())
+            )
             block_builder.add_instruction(nop)
             block_builder.new_block()
             block_builder.set_label(Label(temp_label.target))
             block_builder.add_instruction(nop)
 
-        elif item.mnemonic in ["jal", "jalr"]:
+        elif item.function_target is not None:
             # Move the delay slot instruction to before the call so it
             # passes correct arguments.
             if next_item.args and next_item.args[0] == item.args[0]:
@@ -394,7 +396,7 @@ def build_blocks(
             block_builder.add_instruction(item)
             block_builder.add_instruction(next_item)
 
-        if arch.is_jump_instruction(item):
+        if item.is_jump():
             # Split blocks at jumps, after the next instruction.
             block_builder.new_block()
 
@@ -410,13 +412,13 @@ def build_blocks(
             block_builder.set_label(item)
             return
 
-        if arch.is_conditional_return_instruction(item):
+        if item.is_conditional and item.is_return:
             if cond_return_target is None:
                 cond_return_target = JumpTarget(f"_conditionalreturn_")
             # Strip the "lr" off of the instruction
             assert item.mnemonic[-2:] == "lr"
-            branch_instr = Instruction.derived(
-                item.mnemonic[:-2], [cond_return_target], item
+            branch_instr = arch.parse(
+                item.mnemonic[:-2], [cond_return_target], item.meta.derived()
             )
             block_builder.add_instruction(branch_instr)
             block_builder.new_block()
@@ -425,11 +427,11 @@ def build_blocks(
         block_builder.add_instruction(item)
 
         # Split blocks at jumps, at the next instruction.
-        if arch.is_jump_instruction(item):
+        if item.is_jump():
             block_builder.new_block()
 
     for item in body_iter:
-        if arch.uses_delay_slots:
+        if arch.arch == Target.ArchEnum.MIPS:
             process_with_delay_slots(item)
         else:
             process_no_delay_slots(item)
@@ -647,9 +649,7 @@ def build_graph_from_block(
         return None
 
     # Extract branching instructions from this block.
-    jumps: List[Instruction] = [
-        inst for inst in block.instructions if arch.is_jump_instruction(inst)
-    ]
+    jumps: List[Instruction] = [inst for inst in block.instructions if inst.is_jump()]
     assert len(jumps) in [0, 1], "too many jump instructions in one block"
 
     if len(jumps) == 0:
@@ -670,12 +670,12 @@ def build_graph_from_block(
         # - a ConditionalNode.
         jump = jumps[0]
 
-        if arch.is_return_instruction(jump):
+        if jump.is_return:
             new_node = ReturnNode(block, False, index=0, terminal=terminal_node)
             nodes.append(new_node)
             return new_node
 
-        if arch.is_jumptable_instruction(jump):
+        if isinstance(jump.jump_target, Register):
             new_node = SwitchNode(block, False, [])
             nodes.append(new_node)
 
@@ -727,17 +727,17 @@ def build_graph_from_block(
                 new_node.cases.append(case_node)
             return new_node
 
-        assert arch.is_branch_instruction(jump)
-
         # Get the block associated with the jump target.
-        branch_label = arch.get_branch_target(jump)
+        branch_label = jump.jump_target
+        assert isinstance(branch_label, JumpTarget)
+
         branch_block = find_block_by_label(branch_label.target)
         if branch_block is None:
             target = branch_label.target
             raise DecompFailure(f"Cannot find branch target {target}")
 
         emit_goto = jump.meta.emit_goto
-        if arch.is_constant_branch_instruction(jump):
+        if not jump.is_conditional:
             # A constant branch becomes a basic edge to our branch target.
             new_node = BasicNode(block, emit_goto, dummy_node)
             nodes.append(new_node)

--- a/src/parse_instruction.py
+++ b/src/parse_instruction.py
@@ -143,14 +143,8 @@ class Instruction:
     args: List[Argument]
     meta: InstructionMeta
 
-    # TODO
-    # inputs: List[Argument]
-    # outputs: List[Argument]
-    # clobbers: List[Argument]
-    # evaluator: object
-
     jump_target: Optional[Union[JumpTarget, Register]] = None
-    function_target: Optional[Union[JumpTarget, Register]] = None
+    function_target: Optional[Union[AsmGlobalSymbol, Register]] = None
     is_conditional: bool = False
     is_return: bool = False
 
@@ -210,15 +204,6 @@ class ArchAsm(ArchAsmParsing):
     def missing_return(self) -> List[Instruction]:
         ...
 
-    @staticmethod
-    def get_branch_target(args: List[Argument]) -> JumpTarget:
-        label = args[-1]
-        if isinstance(label, AsmGlobalSymbol):
-            return JumpTarget(label.symbol_name)
-        if not isinstance(label, JumpTarget):
-            raise DecompFailure(f"Couldn't parse instruction: invalid branch target")
-        return label
-
     @abc.abstractmethod
     def parse(
         self, mnemonic: str, args: List[Argument], meta: InstructionMeta
@@ -275,6 +260,14 @@ def constant_fold(arg: Argument) -> Argument:
         if arg.op == "&":
             return AsmLiteral(lhs.value & rhs.value)
     return arg
+
+
+def get_jump_target(label: Argument) -> JumpTarget:
+    if isinstance(label, AsmGlobalSymbol):
+        return JumpTarget(label.symbol_name)
+    if not isinstance(label, JumpTarget):
+        raise DecompFailure(f"Couldn't parse instruction: invalid branch target")
+    return label
 
 
 # Main parser.

--- a/src/parse_instruction.py
+++ b/src/parse_instruction.py
@@ -198,8 +198,6 @@ class ArchAsm(ArchAsmParsing):
 
     aliased_regs: Dict[str, Register]
 
-    uses_delay_slots: bool
-
     @abc.abstractmethod
     def missing_return(self) -> List[Instruction]:
         ...
@@ -265,8 +263,7 @@ def constant_fold(arg: Argument) -> Argument:
 def get_jump_target(label: Argument) -> JumpTarget:
     if isinstance(label, AsmGlobalSymbol):
         return JumpTarget(label.symbol_name)
-    if not isinstance(label, JumpTarget):
-        raise DecompFailure(f"Couldn't parse instruction: invalid branch target")
+    assert isinstance(label, JumpTarget), "invalid branch target"
     return label
 
 

--- a/src/parse_instruction.py
+++ b/src/parse_instruction.py
@@ -111,6 +111,12 @@ Argument = Union[
 
 
 @dataclass(frozen=True)
+class AsmInstruction:
+    mnemonic: str
+    args: List[Argument]
+
+
+@dataclass(frozen=True)
 class InstructionMeta:
     emit_goto: bool
     filename: str
@@ -123,6 +129,9 @@ class InstructionMeta:
             emit_goto=False, filename="<unknown>", lineno=0, synthetic=True
         )
 
+    def derived(self) -> "InstructionMeta":
+        return replace(self, synthetic=True)
+
     def loc_str(self) -> str:
         adj = "near" if self.synthetic else "at"
         return f"{adj} {self.filename} line {self.lineno}"
@@ -134,11 +143,25 @@ class Instruction:
     args: List[Argument]
     meta: InstructionMeta
 
-    @staticmethod
-    def derived(
-        mnemonic: str, args: List[Argument], old: "Instruction"
-    ) -> "Instruction":
-        return Instruction(mnemonic, args, replace(old.meta, synthetic=True))
+    # TODO
+    # inputs: List[Argument]
+    # outputs: List[Argument]
+    # clobbers: List[Argument]
+    # evaluator: object
+
+    jump_target: Optional[Union[JumpTarget, Register]] = None
+    function_target: Optional[Union[JumpTarget, Register]] = None
+    is_conditional: bool = False
+    is_return: bool = False
+
+    # These are for MIPS. `is_branch_likely` refers to branch instructions which
+    # execute their delay slot only if the branch *is* taken. (Maybe these two
+    # bools should be merged into a 3-valued enum?)
+    has_delay_slot: bool = False
+    is_branch_likely: bool = False
+
+    def is_jump(self) -> bool:
+        return self.jump_target is not None or self.is_return
 
     def __str__(self) -> str:
         if not self.args:
@@ -158,7 +181,7 @@ class ArchAsmParsing(abc.ABC):
     aliased_regs: Dict[str, Register]
 
     @abc.abstractmethod
-    def normalize_instruction(self, instr: Instruction) -> Instruction:
+    def normalize_instruction(self, instr: AsmInstruction) -> AsmInstruction:
         ...
 
 
@@ -184,52 +207,23 @@ class ArchAsm(ArchAsmParsing):
     uses_delay_slots: bool
 
     @abc.abstractmethod
-    def is_branch_instruction(self, instr: Instruction) -> bool:
-        """Instructions with a label as a jump target (may be conditional)"""
-        ...
-
-    @abc.abstractmethod
-    def is_branch_likely_instruction(self, instr: Instruction) -> bool:
-        ...
-
-    @abc.abstractmethod
-    def is_constant_branch_instruction(self, instr: Instruction) -> bool:
-        ...
-
-    @abc.abstractmethod
-    def is_conditional_return_instruction(self, instr: Instruction) -> bool:
-        ...
-
-    @abc.abstractmethod
-    def is_jump_instruction(self, instr: Instruction) -> bool:
-        ...
-
-    @abc.abstractmethod
-    def is_delay_slot_instruction(self, instr: Instruction) -> bool:
-        ...
-
-    @abc.abstractmethod
-    def is_return_instruction(self, instr: Instruction) -> bool:
-        ...
-
-    @abc.abstractmethod
-    def is_jumptable_instruction(self, instr: Instruction) -> bool:
-        ...
-
-    @abc.abstractmethod
     def missing_return(self) -> List[Instruction]:
         ...
 
     @staticmethod
-    def get_branch_target(instr: Instruction) -> JumpTarget:
-        label = instr.args[-1]
+    def get_branch_target(args: List[Argument]) -> JumpTarget:
+        label = args[-1]
         if isinstance(label, AsmGlobalSymbol):
             return JumpTarget(label.symbol_name)
         if not isinstance(label, JumpTarget):
-            raise DecompFailure(
-                f'Couldn\'t parse instruction "{instr}": invalid branch target'
-            )
+            raise DecompFailure(f"Couldn't parse instruction: invalid branch target")
         return label
+
+    @abc.abstractmethod
+    def parse(
+        self, mnemonic: str, args: List[Argument], meta: InstructionMeta
+    ) -> Instruction:
+        ...
 
 
 class NaiveParsingArch(ArchAsmParsing):
@@ -239,7 +233,7 @@ class NaiveParsingArch(ArchAsmParsing):
     all_regs: List[Register] = []
     aliased_regs: Dict[str, Register] = {}
 
-    def normalize_instruction(self, instr: Instruction) -> Instruction:
+    def normalize_instruction(self, instr: AsmInstruction) -> AsmInstruction:
         return instr
 
 
@@ -442,16 +436,19 @@ def split_arg_list(args: str) -> List[str]:
     )
 
 
-def parse_instruction(
-    line: str, meta: InstructionMeta, arch: ArchAsmParsing
-) -> Instruction:
+def parse_asm_instruction(line: str, arch: ArchAsmParsing) -> AsmInstruction:
+    # First token is instruction name, rest is args.
+    line = line.strip()
+    mnemonic, _, args_str = line.partition(" ")
+    # Parse arguments.
+    args = [parse_arg(arg_str, arch) for arg_str in split_arg_list(args_str)]
+    instr = AsmInstruction(mnemonic, args)
+    return arch.normalize_instruction(instr)
+
+
+def parse_instruction(line: str, meta: InstructionMeta, arch: ArchAsm) -> Instruction:
     try:
-        # First token is instruction name, rest is args.
-        line = line.strip()
-        mnemonic, _, args_str = line.partition(" ")
-        # Parse arguments.
-        args = [parse_arg(arg_str, arch) for arg_str in split_arg_list(args_str)]
-        instr = Instruction(mnemonic, args, meta)
-        return arch.normalize_instruction(instr)
+        base = parse_asm_instruction(line, arch)
+        return arch.parse(base.mnemonic, base.args, meta)
     except Exception:
         raise DecompFailure(f"Failed to parse instruction {meta.loc_str()}: {line}")

--- a/src/translate.py
+++ b/src/translate.py
@@ -4191,16 +4191,7 @@ def translate_node_body(node: Node, regs: RegInfo, stack_info: StackInfo) -> Blo
             elif arch_mnemonic == "ppc:bctrl":
                 fn_target = args.regs[Register("ctr")]
             elif arch_mnemonic == "mips:jalr":
-                if args.count() == 1:
-                    fn_target = args.reg(0)
-                elif args.count() == 2:
-                    if args.reg_ref(0) != arch.return_address_reg:
-                        raise DecompFailure(
-                            "Two-argument form of jalr is not supported."
-                        )
-                    fn_target = args.reg(1)
-                else:
-                    raise DecompFailure(f"jalr takes 2 arguments, {args.count()} given")
+                fn_target = args.reg(1)
             else:
                 assert False, f"Unhandled fn call mnemonic {arch_mnemonic}"
 


### PR DESCRIPTION
Add arch-specific information to each `Instruction` that describes how it should be interpreted.

This replaces the existing `ArchAsm.is_*_instruction(...)` functions by including this information directly inside the `Instruction` object.
`AsmInstruction` is introduced to represent a "raw" instruction, with just a mnemonic + args.

This PR doesn't change any behavior (that I'm aware of); it's a refactor to help with more complex pattern matching that I'm working on. Project & end-to-end tests still pass: tested MIPS with MM, PM; tested PPC with Melee, SMS, and SMB1.

The first commit (`036e579`) is equivalent to [the changes I posted in Discord](https://github.com/matt-kempster/mips_to_c/compare/master...zbanks:8c9394e), to help make re-reviewing a bit easier.