### PR TITLE
Allow struct types on the stack

### DIFF
--- a/src/translate.py
+++ b/src/translate.py
@@ -408,7 +408,7 @@ class StackInfo:
 
                 if store:
                     # If there's already been a store to `location`, then return a fresh type
-                    field_type = Type.any_reg()
+                    field_type = Type.any_field()
                 else:
                     # Use the type of the last store instead of the one from `get_deref_field()`
                     field_type = previous_stored_type

--- a/src/types.py
+++ b/src/types.py
@@ -474,11 +474,7 @@ class Type:
                 return zero_offset_results[0]
             elif exact:
                 # Try to insert a new field into the struct at the given offset
-                # TODO Loosen this to Type.any_field(), even for stack structs
-                if data.struct.is_stack:
-                    field_type = Type.any_reg()
-                else:
-                    field_type = Type.any_field()
+                field_type = Type.any_field()
                 field_name = f"{data.struct.new_field_prefix}{offset:X}"
                 new_field = data.struct.try_add_field(
                     field_type, offset, field_name, size=target_size


### PR DESCRIPTION
I think after #178, this is viable now? 

[Diffs in OOT/MM/PM](https://gist.github.com/zbanks/cc88f4a0c348c465b0cf13b9247fbb7b)
- I carefully looked at the first 5% of MM, then skimmed the next ~15%, then very quickly skimmed the remainder.
- I skimmed OOT, it looked pretty similar to MM
- I skimmed PM, it's mostly less interesting because it uses structs less (mostly matrices/vectors)

There are some minor issues in the diffs, but I don't consider them regressions. (I'd also rather fix them in separate PRs to avoid changing too much at once?)

- [(example: MM lines 200-203)](https://gist.github.com/zbanks/cc88f4a0c348c465b0cf13b9247fbb7b#file-mm-diff-L200-L203) Arrays can show up as `u8 spN[]; char pad[0x10];` instead of `u8 spN[0x10];`. 
    - It should be straightforward to add a pass that expands all unsized arrays to fill the available empty space
- [(example: MM lines 3538-3570)](https://gist.github.com/zbanks/cc88f4a0c348c465b0cf13b9247fbb7b#file-mm-diff-L3538-L3570) Accessing the first member can result in ugly casts instead of field access: `Vec3f sp50; ... (bitwise f32) sp50` instead of `sp50.x`.
    - This should be fixable in `as_type`, similar to the existing fix for `ptr_target_type`. 
- In the final fn in PM, the use of `sp20` looks a bit weird. It *is* flagged as `compiler-managed`, but it really looks like it should have been a `Vec3f` not a `Camera`. The previous inferred type of `npc_test_move_taller_with_slipping` looks more correct.