### PR TITLE
Compute register usage as part of FlowGraph

### DIFF
--- a/src/arch_mips.py
+++ b/src/arch_mips.py
@@ -61,6 +61,7 @@ from .translate import (
     as_type,
     as_u32,
     as_u64,
+    error_stmt,
     fn_op,
     fold_divmod,
     fold_mul_chains,
@@ -980,7 +981,7 @@ class MipsArch(Arch):
             "MIPS2C_BREAK", [a.imm(0)] if a.count() >= 1 else []
         ),
         "sync": lambda a: void_fn_op("MIPS2C_SYNC", []),
-        "mtc0": lambda a: CommentStmt(f"mtc0 {a.raw_arg(0)}, {a.raw_arg(1)}"),
+        "mtc0": lambda a: error_stmt(f"mtc0 {a.raw_arg(0)}, {a.raw_arg(1)}"),
         "trapuv.fictive": lambda a: CommentStmt("code compiled with -trapuv"),
     }
     instrs_float_comp: CmpInstrMap = {

--- a/src/arch_ppc.py
+++ b/src/arch_ppc.py
@@ -7,6 +7,7 @@ from typing import (
     Tuple,
     Union,
 )
+
 from .error import DecompFailure
 from .options import Target
 from .parse_instruction import (
@@ -293,6 +294,7 @@ class PpcArch(Arch):
         ]
     )
 
+    constant_regs = [Register(r) for r in ["r2", "r13", "zero"]]
     aliased_regs: Dict[str, Register] = {}
 
     @classmethod

--- a/src/flow_graph.py
+++ b/src/flow_graph.py
@@ -1094,6 +1094,9 @@ class RefSet:
     def __iter__(self) -> Iterator[Reference]:
         return iter(self.refs)
 
+    def __len__(self) -> int:
+        return len(self.refs)
+
 
 @dataclass
 class AccessRefs:
@@ -1123,6 +1126,12 @@ class AccessRefs:
             self.refs[reg] = RefSet([ref])
         else:
             self.refs[reg].add(ref)
+
+    def extend(self, reg: Access, refs: RefSet) -> None:
+        if reg not in self:
+            self.refs[reg] = refs.copy()
+        else:
+            self.refs[reg].update(refs)
 
     def remove(self, reg: Access) -> None:
         self.refs.pop(reg)

--- a/src/main.py
+++ b/src/main.py
@@ -11,13 +11,13 @@ from .flow_graph import FlowGraph, build_flowgraph, visualize_flowgraph
 from .if_statements import get_function_text
 from .options import CodingStyle, Options, Target
 from .parse_file import AsmData, Function, parse_file
+from .parse_instruction import InstrProcessingFailure
 from .translate import (
     Arch,
     FunctionInfo,
     GlobalInfo,
-    InstrProcessingFailure,
     translate_to_ast,
-    narrow_func_call_outputs,
+    narrow_ir_with_context,
 )
 from .types import TypePool
 from .arch_mips import MipsArch
@@ -127,8 +127,9 @@ def run(options: Options) -> int:
     flow_graphs: List[Union[FlowGraph, Exception]] = []
     for function in functions:
         try:
-            narrow_func_call_outputs(function, global_info)
-            flow_graphs.append(build_flowgraph(function, global_info.asm_data, arch))
+            narrow_ir_with_context(function, global_info)
+            graph = build_flowgraph(function, global_info.asm_data, arch)
+            flow_graphs.append(graph)
         except Exception as e:
             # Store the exception for later, to preserve the order in the output
             flow_graphs.append(e)

--- a/src/parse_instruction.py
+++ b/src/parse_instruction.py
@@ -152,8 +152,12 @@ def access_may_overlap(left: Access, right: Access) -> bool:
     if isinstance(left, Register):
         return left == right
     elif isinstance(left, MemoryAccess):
-        # TODO: For now, this assumes that *any* two memory accesses can overlap
-        return isinstance(right, MemoryAccess)
+        if not isinstance(right, MemoryAccess):
+            return False
+        if left.base_reg == right.base_reg:
+            return access_must_overlap(left, right)
+        # TODO: For now, assume any two accesses via different base regs may overlap
+        return True
     else:
         static_assert_unreachable(left)
 

--- a/src/parse_instruction.py
+++ b/src/parse_instruction.py
@@ -117,6 +117,9 @@ class MemoryAccess:
         """Placeholder value used to mark that some arbitrary memory may be clobbered"""
         return MemoryAccess(Register("zero"), AsmLiteral(0), 0)
 
+    def __str__(self) -> str:
+        return f"{self.offset}({self.base_reg}):{self.size}"
+
 
 Argument = Union[
     Register, AsmGlobalSymbol, AsmAddressMode, Macro, AsmLiteral, BinOp, JumpTarget

--- a/src/translate.py
+++ b/src/translate.py
@@ -1892,6 +1892,10 @@ class CommentStmt(Statement):
         return f"// {self.contents}"
 
 
+def error_stmt(msg: str) -> ExprStmt:
+    return ExprStmt(ErrorExpr(msg))
+
+
 @dataclass(frozen=True)
 class AddressMode:
     offset: int

--- a/tests/end_to_end/error/manual-out.c
+++ b/tests/end_to_end/error/manual-out.c
@@ -1,3 +1,10 @@
+/*
+Warning: in test, regs were read before being written to:
+   $t0 at 0.15 (line 24): badinstr $t0, $t0
+   $t1 at 0.16 (line 25): badinstr2 $t1, $t1
+   $t2 at 0.17 (line 26): badinstr3 $v0, $t2
+   $v1 at 0.20 (line 29): addiu $v1, $v1, 0x2
+*/
 ? test(s32 arg0) {
     s32 temp_t1;
 

--- a/tests/end_to_end/return-detection/ppc-void.s
+++ b/tests/end_to_end/return-detection/ppc-void.s
@@ -5,10 +5,10 @@
 # to return a float value from $f1 (i.e. `f32 foo(s32, f32)`)
 
 glabel test
-mflr r0
+mflr r14
 cmpwi r3, 0
 bne .end
 bl foo
 .end:
-mtlr r0
+mtlr r14
 blr


### PR DESCRIPTION
This lays the groundwork for implementing "IR patterns", which need to (soundly) match reordered instructions.

If it's useful, my branch for doing IR pattern matching is [here](https://github.com/zbanks/mips_to_c/tree/ir-patterns). I'm not sure if we should just do one big PR off of that branch instead?

The changes here aren't intended to have any output diffs, but they do change:
- New `Warning: in ..., regs were read before being written to:` warnings.
    - I was unsure if these were worth adding at all: they usually aren't very useful to a decomper, but they are important to mips_to_c developers. 
    - Some were from unsound asm pattern replacements, like dropping the `"*"` instruction in `GccSqrtPattern`. (It's usually a `nop`, but sometimes it should be included)
- It's possible to get the state of argument/return registers incorrect by providing incorrect types in the context file. (e.g. marking a function `int foo(int);` as `void foo(void);`)
    - I had to change the `raise DecompError("Undeclared read...")` into a weaker `return ErrorExpr("Read from unset register...")` so that an incorrect context hint won't break an entire function.
- I added special error handling for `mtc0`. It now treats it as a no-dest instruction, instead of assuming that it writes to its first arg.
    - This changed the output of a few functions like `osUnmapTLBAll` 