### PR TITLE
Parse args like `%hi(fp)` where `fp` is a symbol

### DIFF
--- a/src/arch_mips.py
+++ b/src/arch_mips.py
@@ -528,8 +528,8 @@ class MipsArch(Arch):
     all_regs = saved_regs + temp_regs
 
     aliased_regs = {
-        "s8": Register("fp"),
-        "r0": Register("zero"),
+        Register("s8"): Register("fp"),
+        Register("r0"): Register("zero"),
     }
 
     @classmethod

--- a/src/arch_ppc.py
+++ b/src/arch_ppc.py
@@ -293,7 +293,7 @@ class PpcArch(Arch):
         ]
     )
 
-    aliased_regs: Dict[str, Register] = {}
+    aliased_regs: Dict[Register, Register] = {}
 
     @classmethod
     def missing_return(cls) -> List[Instruction]:


### PR DESCRIPTION
Previously, since `fp` is the name of a MIPS register, this would be incorrectly parsed as `Macro("hi", Register("fp"))`.

This change disables the sigil-less register coercion when parsing `Macro` or `BinOp` expressions.