### PR TITLE
Fix reg_vars behaviour for individual register names

### DIFF
--- a/src/parse_instruction.py
+++ b/src/parse_instruction.py
@@ -247,6 +247,10 @@ class RegFormatter:
 
     def parse(self, reg_name: str, arch: ArchAsmParsing) -> Register:
         internal_reg = arch.aliased_regs.get(reg_name, Register(reg_name))
+        return internal_reg
+
+    def parse_and_store(self, reg_name: str, arch: ArchAsmParsing) -> Register:
+        internal_reg = arch.aliased_regs.get(reg_name, Register(reg_name))
         existing_reg_name = self.used_names.get(internal_reg)
         if existing_reg_name is None:
             self.used_names[internal_reg] = reg_name
@@ -308,7 +312,7 @@ def replace_bare_reg(
     if isinstance(arg, AsmGlobalSymbol):
         reg_name = arg.symbol_name
         if Register(reg_name) in arch.all_regs or reg_name in arch.aliased_regs:
-            return reg_formatter.parse(reg_name, arch)
+            return reg_formatter.parse_and_store(reg_name, arch)
     return arg
 
 
@@ -349,7 +353,7 @@ def parse_arg_elems(
                 value = AsmGlobalSymbol(word)
             else:
                 value = Register(reg)
-                value = reg_formatter.parse(value.register_name, arch)
+                value = reg_formatter.parse_and_store(value.register_name, arch)
         elif tok == ".":
             # Either a jump target (i.e. a label), or a section reference.
             assert value is None

--- a/src/parse_instruction.py
+++ b/src/parse_instruction.py
@@ -246,8 +246,7 @@ class RegFormatter:
     used_names: Dict[Register, str] = field(default_factory=dict)
 
     def parse(self, reg_name: str, arch: ArchAsmParsing) -> Register:
-        internal_reg = arch.aliased_regs.get(reg_name, Register(reg_name))
-        return internal_reg
+        return arch.aliased_regs.get(reg_name, Register(reg_name))
 
     def parse_and_store(self, reg_name: str, arch: ArchAsmParsing) -> Register:
         internal_reg = arch.aliased_regs.get(reg_name, Register(reg_name))

--- a/src/translate.py
+++ b/src/translate.py
@@ -4891,12 +4891,9 @@ def translate_to_ast(
     elif options.reg_vars == ["all"]:
         reg_vars = arch.saved_regs + arch.simple_temp_regs + arch.argument_regs
     else:
-        reg_vars = list(
-            map(
-                lambda x: stack_info.function.reg_formatter.parse(x, arch),
-                options.reg_vars,
-            )
-        )
+        reg_vars = [
+            stack_info.function.reg_formatter.parse(x, arch) for x in options.reg_vars
+        ]
     for reg in reg_vars:
         reg_name = stack_info.function.reg_formatter.format(reg)
         stack_info.add_register_var(reg, reg_name)

--- a/src/translate.py
+++ b/src/translate.py
@@ -4891,11 +4891,15 @@ def translate_to_ast(
     elif options.reg_vars == ["all"]:
         reg_vars = arch.saved_regs + arch.simple_temp_regs + arch.argument_regs
     else:
-        reg_vars = list(map(Register, options.reg_vars))
+        reg_vars = list(
+            map(
+                lambda x: stack_info.function.reg_formatter.parse(x, arch),
+                options.reg_vars,
+            )
+        )
     for reg in reg_vars:
         reg_name = stack_info.function.reg_formatter.format(reg)
         stack_info.add_register_var(reg, reg_name)
-
 
     if options.debug:
         print(stack_info)


### PR DESCRIPTION
These were not being converted properly, so changed the function call to translate the name correctly. Behaviour is currently to silently use the names from the assembly rather than whatever the user specified. Possibly a note should be generated at output to explain this if it arises, but it would require modifying the parsing functions a fair amount, I imagine.