### PR TITLE
Improve asm file parsing; prune oversized structs

### DIFF
--- a/src/parse_file.py
+++ b/src/parse_file.py
@@ -371,6 +371,17 @@ def parse_file(f: typing.TextIO, arch: ArchAsm, options: Options) -> MIPSFile:
                     level = 1 - level
                 ifdef_level += level
                 ifdef_levels.append(level)
+            elif line.startswith(".if"):
+                macro_name = line.split()[1]
+                if macro_name == "0":
+                    level = 1
+                elif macro_name == "1":
+                    level = 0
+                else:
+                    level = 0
+                    add_warning(warnings, f"Note: ignoring .if {macro_name} directive")
+                ifdef_level += level
+                ifdef_levels.append(level)
             elif line.startswith(".else"):
                 level = ifdef_levels.pop()
                 ifdef_level -= level

--- a/src/parse_instruction.py
+++ b/src/parse_instruction.py
@@ -406,6 +406,8 @@ def parse_arg_elems(
             else:
                 # Address mode.
                 rhs = replace_bare_reg(rhs, arch, reg_formatter)
+                if rhs == AsmLiteral(0):
+                    rhs = Register("zero")
                 assert isinstance(rhs, Register)
                 value = AsmAddressMode(value or AsmLiteral(0), rhs)
         elif tok == '"':

--- a/src/parse_instruction.py
+++ b/src/parse_instruction.py
@@ -267,20 +267,23 @@ valid_number = "-xX" + string.hexdigits
 
 
 def parse_word(elems: List[str], valid: str = valid_word) -> str:
-    S: str = ""
+    ret: str = ""
     while elems and elems[0] in valid:
-        S += elems.pop(0)
-    return S
+        ret += elems.pop(0)
+    return ret
 
 
-def parse_quoted(elems: List[str], quote_chars: str) -> str:
-    S: str = ""
-    while elems and elems[0] not in quote_chars:
+def parse_quoted(elems: List[str], quote_char: str) -> str:
+    ret: str = ""
+    while elems and elems[0] != quote_char:
         # Handle backslash-escaped characters
+        # We only need to care about \\, \" and \' in this context.
         if elems[0] == "\\":
             elems.pop(0)
-        S += elems.pop(0)
-    return S
+            if not elems:
+                break
+        ret += elems.pop(0)
+    return ret
 
 
 def parse_number(elems: List[str]) -> int:


### PR DESCRIPTION
This PR is a combination of a few small fixes:

- Prune inferred fields in structs that exceed the (known) size of the struct itself.
    - [Diff for N64 projects](https://gist.github.com/zbanks/56826ed69047b6cd25fdbb9ca36b5c36) -- prevents issues like including a whole `Actor` or `GlobalContext` inside a smaller struct.
- Handle quoted symbols individually when parsing asm arguments, to parse terms like `"foo<bar>@baz"@ha`
- Still use `csv` to parse asm directives in `parse_file.py`, but consolidate the `.strip()` operations.
- Allow `0` to symbolize the zero register in AsmAddressMode, like in `lwz r4, 0xc0(0)`
- Handle `.if 0` and `.if 1` directives instead of skipping them