### PR TITLE
Expand % pattern to expressions

### DIFF
--- a/src/translate.py
+++ b/src/translate.py
@@ -3039,20 +3039,20 @@ def fold_divmod(original_expr: BinaryOp) -> BinaryOp:
                 right=Literal(new_denom),
             )
 
-    # Detect `%`: (x - ((x / N) * N)) --> x % N
+    # Detect `%`: (x - ((x / y) * y)) --> x % y
     if expr.op == "-" and isinstance(right_expr, BinaryOp) and right_expr.op == "*":
         div_expr = early_unwrap_ints(right_expr.left)
         mod_base = early_unwrap_ints(right_expr.right)
         if (
             isinstance(div_expr, BinaryOp)
             and early_unwrap_ints(div_expr.left) == left_expr
-            and isinstance(mod_base, Literal)
         ):
-            # Accept either `(x / N) * N` or `(x >> N) * M` (where `1 << N == M`)
+            # Accept either `(x / y) * y` or `(x >> N) * M` (where `1 << N == M`)
             divisor = early_unwrap_ints(div_expr.right)
             if (div_expr.op == "/" and divisor == mod_base) or (
                 div_expr.op == ">>"
                 and isinstance(divisor, Literal)
+                and isinstance(mod_base, Literal)
                 and (1 << divisor.value) == mod_base.value
             ):
                 return BinaryOp.int(left=left_expr, op="%", right=right_expr.right)


### PR DESCRIPTION
The previous pattern for detecting mod operations was limited to taking the mod of a `Literal` constant.

However, PPC has no mod instruction, so mod is implemented using the same series of instructions that GCC uses to mod by a constant in MIPS, `x % y` becomes `(x - ((x / y) * y))`.

This change produces no diff in any of the MIPS project corpuses, but makes several improvements to the PPC ones.
[Diff in the SMS project](https://gist.github.com/zbanks/5adcd36cabc76beebd382105446f4c71)

(Leaving this in draft until the big PR gets in; I just don't want to forget about this)